### PR TITLE
refactor(hydro_test): migrate paxos cross_singleton to by_ref() singleton mechanism [ci-bench]

### DIFF
--- a/hydro_test/src/cluster/compartmentalized_paxos.rs
+++ b/hydro_test/src/cluster/compartmentalized_paxos.rs
@@ -56,7 +56,7 @@ impl<'a> PaxosLike<'a> for CoreCompartmentalizedPaxos<'a> {
         ballot.map(q!(|ballot| ballot.proposer_id))
     }
 
-    fn build<P: PaxosPayload>(
+    fn build<P: PaxosPayload + 'a>(
         self,
         with_ballot: impl FnOnce(
             Stream<Ballot, Cluster<'a, Self::PaxosIn>, Unbounded>,
@@ -99,7 +99,7 @@ impl<'a> PaxosLike<'a> for CoreCompartmentalizedPaxos<'a> {
 /// non-deterministically dropped. The stream of ballots is also non-deterministic because
 /// leaders are elected in a non-deterministic process.
 #[expect(clippy::too_many_arguments, reason = "internal paxos code // TODO")]
-pub fn compartmentalized_paxos_core<'a, P: PaxosPayload>(
+pub fn compartmentalized_paxos_core<'a, P: PaxosPayload + 'a>(
     proposers: &Cluster<'a, Proposer>,
     proxy_leaders: &Cluster<'a, ProxyLeader>,
     acceptors: &Cluster<'a, Acceptor>,

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -245,7 +245,7 @@ pub fn paxos_core<'a, P: PaxosPayload + 'a>(
     clippy::too_many_arguments,
     reason = "internal paxos code // TODO"
 )]
-pub fn leader_election<'a, L: Clone + Debug + Serialize + DeserializeOwned>(
+pub fn leader_election<'a, L: Clone + Debug + Serialize + DeserializeOwned + 'a>(
     proposers: &Cluster<'a, Proposer>,
     acceptors: &Cluster<'a, Acceptor>,
     proposer_tick: &Tick<Cluster<'a, Proposer>>,
@@ -472,7 +472,7 @@ fn p_leader_heartbeat<'a>(
 }
 
 #[expect(clippy::type_complexity, reason = "internal paxos code // TODO")]
-fn acceptor_p1<'a, L: Serialize + DeserializeOwned + Clone>(
+fn acceptor_p1<'a, L: Serialize + DeserializeOwned + Clone + 'a>(
     acceptor_tick: &Tick<Cluster<'a, Acceptor>>,
     p_to_acceptors_p1a: Stream<Ballot, Tick<Cluster<'a, Acceptor>>, Bounded, NoOrder>,
     a_log: Singleton<(Option<usize>, L), Tick<Cluster<'a, Acceptor>>, Bounded>,
@@ -490,22 +490,26 @@ fn acceptor_p1<'a, L: Serialize + DeserializeOwned + Clone>(
             proposer_id: MemberId::from_raw_id(0)
         })));
 
+    let a_max_ballot_ref = a_max_ballot.by_ref();
+    let a_log_ref = a_log.by_ref();
     (
         a_max_ballot.clone(),
         p_to_acceptors_p1a
-            .cross_singleton(a_max_ballot)
-            .cross_singleton(a_log)
-            .map(q!(|((ballot, max_ballot), log)| (
-                ballot.proposer_id.clone(),
+            .map(q!(|ballot| {
+                let max_ballot = a_max_ballot_ref.clone();
+                let log = a_log_ref.clone();
                 (
-                    ballot.clone(),
-                    if ballot == max_ballot {
-                        Ok(log)
-                    } else {
-                        Err(max_ballot)
-                    }
+                    ballot.proposer_id.clone(),
+                    (
+                        ballot.clone(),
+                        if ballot == max_ballot {
+                            Ok(log)
+                        } else {
+                            Err(max_ballot)
+                        },
+                    ),
                 )
-            )))
+            }))
             .all_ticks()
             .demux(proposers, TCP.fail_stop().bincode())
             .values(),

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -94,7 +94,7 @@ impl<'a> PaxosLike<'a> for CorePaxos<'a> {
         ballot.map(q!(|ballot| ballot.proposer_id))
     }
 
-    fn build<P: PaxosPayload>(
+    fn build<P: PaxosPayload + 'a>(
         self,
         with_ballot: impl FnOnce(
             Stream<Ballot, Cluster<'a, Self::PaxosIn>, Unbounded>,
@@ -132,7 +132,7 @@ impl<'a> PaxosLike<'a> for CorePaxos<'a> {
 /// in deterministic order. However, when the leader is changing, payloads may be
 /// non-deterministically dropped. The stream of ballots is also non-deterministic because
 /// leaders are elected in a non-deterministic process.
-pub fn paxos_core<'a, P: PaxosPayload>(
+pub fn paxos_core<'a, P: PaxosPayload + 'a>(
     proposers: &Cluster<'a, Proposer>,
     acceptors: &Cluster<'a, Acceptor>,
     a_checkpoint: Optional<usize, Cluster<'a, Acceptor>, Unbounded>,
@@ -626,20 +626,20 @@ pub fn recommit_after_leader_election<'a, P: PaxosPayload>(
             }
         }, commutative = manual_proof!(/** TODO */)))
         .map(q!(|(count, entry)| (count, entry.unwrap())));
+    let p_ballot_ref = p_ballot.by_ref();
+    let p_p1b_max_checkpoint_ref = p_p1b_max_checkpoint.by_ref();
     let p_log_to_try_commit = p_p1b_highest_entries_and_count
         .clone()
         .entries()
-        .cross_singleton(p_ballot.clone())
-        .cross_singleton(p_p1b_max_checkpoint.clone())
-        .filter_map(q!(move |(((slot, (count, entry)), ballot), checkpoint)| {
+        .filter_map(q!(move |(slot, (count, entry))| {
             if count > f {
                 return None;
-            } else if let Some(checkpoint) = checkpoint
+            } else if let Some(checkpoint) = *p_p1b_max_checkpoint_ref
                 && slot <= checkpoint
             {
                 return None;
             }
-            Some(((slot, ballot), entry.value))
+            Some(((slot, p_ballot_ref.clone()), entry.value))
         }));
     let p_max_slot = p_p1b_highest_entries_and_count.clone().keys().max();
     let p_proposed_slots = p_p1b_highest_entries_and_count.clone().keys();
@@ -654,8 +654,7 @@ pub fn recommit_after_leader_election<'a, P: PaxosPayload>(
             }
         }))
         .filter_not_in(p_proposed_slots)
-        .cross_singleton(p_ballot.clone())
-        .map(q!(move |(slot, ballot)| ((slot, ballot), None)));
+        .map(q!(move |slot| ((slot, p_ballot_ref.clone()), None)));
 
     (p_log_to_try_commit.chain(p_log_holes), p_max_slot)
 }
@@ -716,10 +715,10 @@ fn sequence_payload<'a, P: PaxosPayload>(
             .filter_if(p_is_leader.clone()),
     );
 
+    let p_ballot_ref = p_ballot.by_ref();
     let payloads_to_send = indexed_payloads
-        .cross_singleton(p_ballot.clone())
-        .map(q!(|((slot, payload), ballot)| (
-            (slot, ballot),
+        .map(q!(|(slot, payload)| (
+            (slot, p_ballot_ref.clone()),
             Some(payload)
         )))
         .chain(p_log_to_recommit)
@@ -767,7 +766,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
 }
 
 // Proposer logic to send p2as, outputting the next slot and the p2as to send to acceptors.
-pub fn index_payloads<'a, L: Location<'a>, P: PaxosPayload>(
+pub fn index_payloads<'a, L: Location<'a> + 'a, P: PaxosPayload>(
     p_max_slot: Optional<usize, Tick<L>, Bounded>,
     c_to_proposers: Stream<P, Tick<L>, Bounded>,
 ) -> Stream<(usize, P), Tick<L::DropConsistency>, Bounded> {
@@ -780,11 +779,11 @@ pub fn index_payloads<'a, L: Location<'a>, P: PaxosPayload>(
         let next_slot_after_reconciling_p1bs = updated_max_slot.map(q!(|s| s + 1));
         let base_slot = next_slot_after_reconciling_p1bs.unwrap_or(next_slot);
 
+        let base_slot_ref = base_slot.by_ref();
         let indexed_payloads = payload_batch
             .enumerate()
-            .cross_singleton(base_slot.clone())
-            .map(q!(|((index, payload), base_slot)| (
-                base_slot + index,
+            .map(q!(|(index, payload)| (
+                *base_slot_ref + index,
                 payload
             )));
 
@@ -832,19 +831,21 @@ pub fn acceptor_p2<'a, P: PaxosPayload, S: Clone>(
     );
     // .inspect(q!(|min_seq| println!("Acceptor new checkpoint: {:?}", min_seq)));
 
-    let a_p2as_to_place_in_log = p_to_acceptors_p2a_batch
-        .clone()
-        .cross_singleton(a_max_ballot.clone()) // Don't consider p2as if the current ballot is higher
-        .filter_map(q!(|(p2a, max_ballot)|
-            if p2a.ballot >= max_ballot {
-                Some((p2a.slot, LogValue {
-                    ballot: p2a.ballot,
-                    value: p2a.value,
-                }))
+    let a_max_ballot_ref = a_max_ballot.by_ref();
+    let a_p2as_to_place_in_log =
+        p_to_acceptors_p2a_batch
+            .clone()
+            .filter_map(q!(|p2a| if p2a.ballot >= *a_max_ballot_ref {
+                Some((
+                    p2a.slot,
+                    LogValue {
+                        ballot: p2a.ballot,
+                        value: p2a.value,
+                    },
+                ))
             } else {
                 None
-            }
-        ));
+            }));
     let a_log = a_p2as_to_place_in_log.across_ticks(|s| {
         s.into_keyed().reduce_watermark(
             a_checkpoint.clone(),
@@ -870,18 +871,20 @@ pub fn acceptor_p2<'a, P: PaxosPayload, S: Clone>(
     );
 
     let a_to_proposers_p2b = p_to_acceptors_p2a_batch
-        .cross_singleton(a_max_ballot)
-        .map(q!(|(p2a, max_ballot)| (
-            p2a.sender,
+        .map(q!(|p2a| {
+            let max_ballot = a_max_ballot_ref.clone();
             (
-                (p2a.slot, p2a.ballot.clone()),
-                if p2a.ballot == max_ballot {
-                    Ok(())
-                } else {
-                    Err(max_ballot)
-                }
+                p2a.sender,
+                (
+                    (p2a.slot, p2a.ballot.clone()),
+                    if p2a.ballot == max_ballot {
+                        Ok(())
+                    } else {
+                        Err(max_ballot)
+                    },
+                ),
             )
-        )))
+        }))
         .all_ticks()
         .demux(proposers, TCP.fail_stop().bincode())
         .values();

--- a/hydro_test/src/cluster/paxos_with_client.rs
+++ b/hydro_test/src/cluster/paxos_with_client.rs
@@ -29,7 +29,7 @@ pub trait PaxosLike<'a>: Sized {
     /// # Non-Determinism
     /// During leader-reelection, the latest known leader may be stale, which may
     /// result in non-deterministic dropping of payloads.
-    fn build<P: PaxosPayload>(
+    fn build<P: PaxosPayload + 'a>(
         self,
         payload_generator: impl FnOnce(
             Stream<Self::Ballot, Cluster<'a, Self::PaxosIn>, Unbounded>,
@@ -43,7 +43,7 @@ pub trait PaxosLike<'a>: Sized {
     /// During leader-reelection, the latest known leader may be stale, which may
     /// result in non-deterministic dropping of payloads. Also, payloads across
     /// clients will be arbitrarily interleaved as they arrive at the leader.
-    fn with_client<C: 'a, P: PaxosPayload>(
+    fn with_client<C: 'a, P: PaxosPayload + 'a>(
         self,
         clients: &Cluster<'a, C>,
         payloads: Stream<P, Cluster<'a, C>, Unbounded>,

--- a/hydro_test/src/cluster/snapshots-nightly/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots-nightly/paxos_ir.snap
@@ -1112,13 +1112,813 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: Reference {
+            inner: <shared 7>: Tee {
+                inner: <shared 8>: Cast {
+                    inner: ChainFirst {
+                        first: Batch {
+                            inner: Reduce {
+                                f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
+                                input: ObserveNonDet {
+                                    inner: YieldConcat {
+                                        inner: Inspect {
+                                            f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_486_20 ! ([] [| p1a | println ! ("Acceptor received P1a: {:?}" , p1a)]) }),
+                                            input: Tee {
+                                                inner: <shared 9>: Batch {
+                                                    inner: Map {
+                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
+                                                        input: Cast {
+                                                            inner: Network {
+                                                                name: None,
+                                                                networking_info: Tcp {
+                                                                    fault: FailStop,
+                                                                },
+                                                                serialize_fn: Some(
+                                                                    hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                                ),
+                                                                instantiate_fn: <network instantiate>,
+                                                                deserialize_fn: Some(
+                                                                    | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: Ballot > (& b) . unwrap ()) },
+                                                                ),
+                                                                input: YieldConcat {
+                                                                    inner: Cast {
+                                                                        inner: CrossProduct {
+                                                                            left: ObserveNonDet {
+                                                                                inner: Map {
+                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
+                                                                                    input: Cast {
+                                                                                        inner: Cast {
+                                                                                            inner: Filter {
+                                                                                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_1187_61 ! ([] [| b | * b]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
+                                                                                                input: Batch {
+                                                                                                    inner: FoldKeyed {
+                                                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_36_11 ! ([] [| | false]) }),
+                                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_37_11 ! ([] [| present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } }]) }),
+                                                                                                        input: Cast {
+                                                                                                            inner: Map {
+                                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; hydro_lang :: __stageleft_quote_src_location_mod_rs_545_16 ! ([] [| (k , v) | (MemberId :: from_tagless (k) , v)]) }),
+                                                                                                                input: Source {
+                                                                                                                    source: ClusterMembers(
+                                                                                                                        Cluster(loc2v1),
+                                                                                                                        Uninit,
+                                                                                                                    ),
+                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                        location_id: Cluster(loc1v1),
+                                                                                                                        collection_kind: Stream {
+                                                                                                                            bound: Unbounded,
+                                                                                                                            order: TotalOrder,
+                                                                                                                            retry: ExactlyOnce,
+                                                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                    location_id: Cluster(loc1v1),
+                                                                                                                    collection_kind: Stream {
+                                                                                                                        bound: Unbounded,
+                                                                                                                        order: TotalOrder,
+                                                                                                                        retry: ExactlyOnce,
+                                                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                                                    },
+                                                                                                                },
+                                                                                                            },
+                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                location_id: Cluster(loc1v1),
+                                                                                                                collection_kind: KeyedStream {
+                                                                                                                    bound: Unbounded,
+                                                                                                                    value_order: TotalOrder,
+                                                                                                                    value_retry: ExactlyOnce,
+                                                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                                    value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
+                                                                                                                },
+                                                                                                            },
+                                                                                                        },
+                                                                                                        metadata: HydroIrMetadata {
+                                                                                                            location_id: Cluster(loc1v1),
+                                                                                                            collection_kind: KeyedSingleton {
+                                                                                                                bound: MonotonicKeys,
+                                                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                                value_type: bool,
+                                                                                                            },
+                                                                                                        },
+                                                                                                    },
+                                                                                                    metadata: HydroIrMetadata {
+                                                                                                        location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                        collection_kind: KeyedSingleton {
+                                                                                                            bound: Bounded,
+                                                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                            value_type: bool,
+                                                                                                        },
+                                                                                                    },
+                                                                                                },
+                                                                                                metadata: HydroIrMetadata {
+                                                                                                    location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                    collection_kind: KeyedSingleton {
+                                                                                                        bound: Bounded,
+                                                                                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                        value_type: bool,
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                            metadata: HydroIrMetadata {
+                                                                                                location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                collection_kind: KeyedStream {
+                                                                                                    bound: Bounded,
+                                                                                                    value_order: TotalOrder,
+                                                                                                    value_retry: ExactlyOnce,
+                                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                    value_type: bool,
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_id: Tick(8, Cluster(loc1v1)),
+                                                                                            collection_kind: Stream {
+                                                                                                bound: Bounded,
+                                                                                                order: NoOrder,
+                                                                                                retry: ExactlyOnce,
+                                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                    metadata: HydroIrMetadata {
+                                                                                        location_id: Tick(8, Cluster(loc1v1)),
+                                                                                        collection_kind: Stream {
+                                                                                            bound: Bounded,
+                                                                                            order: NoOrder,
+                                                                                            retry: ExactlyOnce,
+                                                                                            element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                                trusted: true,
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_id: Tick(8, Cluster(loc1v1)),
+                                                                                    collection_kind: Stream {
+                                                                                        bound: Bounded,
+                                                                                        order: TotalOrder,
+                                                                                        retry: ExactlyOnce,
+                                                                                        element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                    },
+                                                                                },
+                                                                            },
+                                                                            right: Batch {
+                                                                                inner: Inspect {
+                                                                                    f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_317_20 ! ([] [| _ | println ! ("Proposer leader expired, sending P1a")]) }),
+                                                                                    input: YieldConcat {
+                                                                                        inner: Cast {
+                                                                                            inner: Map {
+                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
+                                                                                                input: CrossSingleton {
+                                                                                                    left: Tee {
+                                                                                                        inner: <shared 4>,
+                                                                                                        metadata: HydroIrMetadata {
+                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                            collection_kind: Singleton {
+                                                                                                                bound: Bounded,
+                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                            },
+                                                                                                        },
+                                                                                                    },
+                                                                                                    right: Filter {
+                                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_34 ! ([] [| b | * b]) }),
+                                                                                                        input: Map {
+                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_1144_31 ! ([] [| (a , b) | a && b]) }),
+                                                                                                            input: Cast {
+                                                                                                                inner: CrossSingleton {
+                                                                                                                    left: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_908_20 ! ([] [| o | o . is_some ()]) }),
+                                                                                                                        input: Cast {
+                                                                                                                            inner: ChainFirst {
+                                                                                                                                first: Map {
+                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
+                                                                                                                                    input: Map {
+                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
+                                                                                                                                        input: Map {
+                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (() , bool) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_1105_51 ! ([] [| (d , _) | d]) }),
+                                                                                                                                            input: CrossSingleton {
+                                                                                                                                                left: Batch {
+                                                                                                                                                    inner: YieldConcat {
+                                                                                                                                                        inner: FilterMap {
+                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2027_27 ! ([duration__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_438_15 ! ([i_am_leader_check_timeout__free = 10u64 ,] [Duration :: from_secs (i_am_leader_check_timeout__free)]) } ,] [move | latest_received | { if let Some (latest_received) = latest_received { if Instant :: now () . duration_since (latest_received) > duration__free { Some (()) } else { None } } else { Some (()) } }]) }),
+                                                                                                                                                            input: Batch {
+                                                                                                                                                                inner: Fold {
+                                                                                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2016_15 ! ([] [| | None]) }),
+                                                                                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2018_16 ! ([] [| latest , _ | { * latest = Some (Instant :: now ()) ; }]) }),
+                                                                                                                                                                    input: ObserveNonDet {
+                                                                                                                                                                        inner: Tee {
+                                                                                                                                                                            inner: <shared 3>,
+                                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                                location_id: Cluster(loc1v1),
+                                                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                                                    bound: Unbounded,
+                                                                                                                                                                                    order: NoOrder,
+                                                                                                                                                                                    retry: AtLeastOnce,
+                                                                                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                                                                                },
+                                                                                                                                                                            },
+                                                                                                                                                                        },
+                                                                                                                                                                        trusted: false,
+                                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                                            location_id: Cluster(loc1v1),
+                                                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                                                bound: Unbounded,
+                                                                                                                                                                                order: NoOrder,
+                                                                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                                                                            },
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                                        location_id: Cluster(loc1v1),
+                                                                                                                                                                        collection_kind: Singleton {
+                                                                                                                                                                            bound: Unbounded,
+                                                                                                                                                                            element_type: core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >,
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                    location_id: Tick(7, Cluster(loc1v1)),
+                                                                                                                                                                    collection_kind: Singleton {
+                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                        element_type: core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >,
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                location_id: Tick(7, Cluster(loc1v1)),
+                                                                                                                                                                collection_kind: Optional {
+                                                                                                                                                                    bound: Bounded,
+                                                                                                                                                                    element_type: (),
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                            location_id: Cluster(loc1v1),
+                                                                                                                                                            collection_kind: Optional {
+                                                                                                                                                                bound: Unbounded,
+                                                                                                                                                                element_type: (),
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                        collection_kind: Optional {
+                                                                                                                                                            bound: Bounded,
+                                                                                                                                                            element_type: (),
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                                right: Filter {
+                                                                                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_1105_34 ! ([] [| b | * b]) }),
+                                                                                                                                                    input: Map {
+                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_1078_20 ! ([] [| b | ! b]) }),
+                                                                                                                                                        input: Tee {
+                                                                                                                                                            inner: <shared 6>,
+                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                collection_kind: Singleton {
+                                                                                                                                                                    bound: Bounded,
+                                                                                                                                                                    element_type: bool,
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            collection_kind: Singleton {
+                                                                                                                                                                bound: Bounded,
+                                                                                                                                                                element_type: bool,
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                        collection_kind: Optional {
+                                                                                                                                                            bound: Bounded,
+                                                                                                                                                            element_type: bool,
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    collection_kind: Optional {
+                                                                                                                                                        bound: Bounded,
+                                                                                                                                                        element_type: (() , bool),
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                collection_kind: Optional {
+                                                                                                                                                    bound: Bounded,
+                                                                                                                                                    element_type: (),
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            collection_kind: Optional {
+                                                                                                                                                bound: Bounded,
+                                                                                                                                                element_type: (),
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        collection_kind: Optional {
+                                                                                                                                            bound: Bounded,
+                                                                                                                                            element_type: core :: option :: Option < () >,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                second: Cast {
+                                                                                                                                    inner: SingletonSource {
+                                                                                                                                        value: :: std :: option :: Option :: None,
+                                                                                                                                        first_tick_only: false,
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            collection_kind: Singleton {
+                                                                                                                                                bound: Bounded,
+                                                                                                                                                element_type: core :: option :: Option < () >,
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        collection_kind: Optional {
+                                                                                                                                            bound: Bounded,
+                                                                                                                                            element_type: core :: option :: Option < () >,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                    collection_kind: Optional {
+                                                                                                                                        bound: Bounded,
+                                                                                                                                        element_type: core :: option :: Option < () >,
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                collection_kind: Singleton {
+                                                                                                                                    bound: Bounded,
+                                                                                                                                    element_type: core :: option :: Option < () >,
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                            collection_kind: Singleton {
+                                                                                                                                bound: Bounded,
+                                                                                                                                element_type: bool,
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    right: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_908_20 ! ([] [| o | o . is_some ()]) }),
+                                                                                                                        input: Cast {
+                                                                                                                            inner: ChainFirst {
+                                                                                                                                first: Map {
+                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
+                                                                                                                                    input: Map {
+                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
+                                                                                                                                        input: Reduce {
+                                                                                                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1589_23 ! ([] [| _ , _ | { }]) }),
+                                                                                                                                            input: FlatMap {
+                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1955_27 ! ([] [| d | d]) }),
+                                                                                                                                                input: Scan {
+                                                                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < core :: option :: Option < () > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1915_27 ! ([] [| | None]) }),
+                                                                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < core :: option :: Option < () > > , () , core :: option :: Option < core :: option :: Option < () > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1918_24 ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , hydro_test :: __staged :: __deps :: hydro_lang :: live_collections :: keyed_stream :: Generate < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1588_37 ! ([] [| _ , item | Generate :: Return (item)]) }) , init__free = stageleft :: runtime_support :: fn0_type_hint :: < () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1588_26 ! ([] [| | ()]) }) ,] [move | state : & mut Option < Option < _ > > , v | { if state . is_none () { * state = Some (Some (init__free ())) ; } match state { Some (Some (state_value)) => match f__free (state_value , v) { Generate :: Yield (out) => Some (Some (out)) , Generate :: Return (out) => { * state = Some (None) ; Some (Some (out)) } Generate :: Break => None , Generate :: Continue => Some (None) , } , _ => None , } }]) }),
+                                                                                                                                                    input: Batch {
+                                                                                                                                                        inner: Source {
+                                                                                                                                                            source: Stream(
+                                                                                                                                                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; hydro_lang :: __stageleft_quote_src_location_mod_rs_1439_30 ! ([delay__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_453_19 ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) , i_am_leader_check_timeout_delay_multiplier__free = 15usize ,] [Duration :: from_secs ((CLUSTER_SELF_ID__free . get_raw_id () * i_am_leader_check_timeout_delay_multiplier__free as u32) . into ())]) } , interval__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_458_19 ! ([i_am_leader_check_timeout__free = 10u64 ,] [Duration :: from_secs (i_am_leader_check_timeout__free)]) } ,] [tokio_stream :: StreamExt :: map (tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval_at (tokio :: time :: Instant :: now () + delay__free , interval__free ,)) , | _ | ())]) },
+                                                                                                                                                            ),
+                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                location_id: Cluster(loc1v1),
+                                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                                    bound: Unbounded,
+                                                                                                                                                                    order: TotalOrder,
+                                                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                                                    element_type: (),
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                                bound: Bounded,
+                                                                                                                                                                order: TotalOrder,
+                                                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                                                element_type: (),
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                        collection_kind: Stream {
+                                                                                                                                                            bound: Bounded,
+                                                                                                                                                            order: TotalOrder,
+                                                                                                                                                            retry: ExactlyOnce,
+                                                                                                                                                            element_type: core :: option :: Option < () >,
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    collection_kind: Stream {
+                                                                                                                                                        bound: Bounded,
+                                                                                                                                                        order: TotalOrder,
+                                                                                                                                                        retry: ExactlyOnce,
+                                                                                                                                                        element_type: (),
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                collection_kind: Optional {
+                                                                                                                                                    bound: Bounded,
+                                                                                                                                                    element_type: (),
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            collection_kind: Optional {
+                                                                                                                                                bound: Bounded,
+                                                                                                                                                element_type: (),
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        collection_kind: Optional {
+                                                                                                                                            bound: Bounded,
+                                                                                                                                            element_type: core :: option :: Option < () >,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                second: Cast {
+                                                                                                                                    inner: SingletonSource {
+                                                                                                                                        value: :: std :: option :: Option :: None,
+                                                                                                                                        first_tick_only: false,
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            collection_kind: Singleton {
+                                                                                                                                                bound: Bounded,
+                                                                                                                                                element_type: core :: option :: Option < () >,
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        collection_kind: Optional {
+                                                                                                                                            bound: Bounded,
+                                                                                                                                            element_type: core :: option :: Option < () >,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                    collection_kind: Optional {
+                                                                                                                                        bound: Bounded,
+                                                                                                                                        element_type: core :: option :: Option < () >,
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                collection_kind: Singleton {
+                                                                                                                                    bound: Bounded,
+                                                                                                                                    element_type: core :: option :: Option < () >,
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                            collection_kind: Singleton {
+                                                                                                                                bound: Bounded,
+                                                                                                                                element_type: bool,
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                        collection_kind: Optional {
+                                                                                                                            bound: Bounded,
+                                                                                                                            element_type: (bool , bool),
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                    collection_kind: Singleton {
+                                                                                                                        bound: Bounded,
+                                                                                                                        element_type: (bool , bool),
+                                                                                                                    },
+                                                                                                                },
+                                                                                                            },
+                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                collection_kind: Singleton {
+                                                                                                                    bound: Bounded,
+                                                                                                                    element_type: bool,
+                                                                                                                },
+                                                                                                            },
+                                                                                                        },
+                                                                                                        metadata: HydroIrMetadata {
+                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                            collection_kind: Optional {
+                                                                                                                bound: Bounded,
+                                                                                                                element_type: bool,
+                                                                                                            },
+                                                                                                        },
+                                                                                                    },
+                                                                                                    metadata: HydroIrMetadata {
+                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                        collection_kind: Optional {
+                                                                                                            bound: Bounded,
+                                                                                                            element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool),
+                                                                                                        },
+                                                                                                    },
+                                                                                                },
+                                                                                                metadata: HydroIrMetadata {
+                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                    collection_kind: Optional {
+                                                                                                        bound: Bounded,
+                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                            metadata: HydroIrMetadata {
+                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                collection_kind: Stream {
+                                                                                                    bound: Bounded,
+                                                                                                    order: TotalOrder,
+                                                                                                    retry: ExactlyOnce,
+                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_id: Cluster(loc1v1),
+                                                                                            collection_kind: Stream {
+                                                                                                bound: Unbounded,
+                                                                                                order: TotalOrder,
+                                                                                                retry: ExactlyOnce,
+                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                    metadata: HydroIrMetadata {
+                                                                                        location_id: Cluster(loc1v1),
+                                                                                        collection_kind: Stream {
+                                                                                            bound: Unbounded,
+                                                                                            order: TotalOrder,
+                                                                                            retry: ExactlyOnce,
+                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_id: Tick(8, Cluster(loc1v1)),
+                                                                                    collection_kind: Stream {
+                                                                                        bound: Bounded,
+                                                                                        order: TotalOrder,
+                                                                                        retry: ExactlyOnce,
+                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                    },
+                                                                                },
+                                                                            },
+                                                                            metadata: HydroIrMetadata {
+                                                                                location_id: Tick(8, Cluster(loc1v1)),
+                                                                                collection_kind: Stream {
+                                                                                    bound: Bounded,
+                                                                                    order: TotalOrder,
+                                                                                    retry: ExactlyOnce,
+                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        metadata: HydroIrMetadata {
+                                                                            location_id: Tick(8, Cluster(loc1v1)),
+                                                                            collection_kind: KeyedStream {
+                                                                                bound: Bounded,
+                                                                                value_order: TotalOrder,
+                                                                                value_retry: ExactlyOnce,
+                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                value_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                    metadata: HydroIrMetadata {
+                                                                        location_id: Cluster(loc1v1),
+                                                                        collection_kind: KeyedStream {
+                                                                            bound: Unbounded,
+                                                                            value_order: TotalOrder,
+                                                                            value_retry: ExactlyOnce,
+                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                            value_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                        },
+                                                                    },
+                                                                },
+                                                                metadata: HydroIrMetadata {
+                                                                    location_id: Cluster(loc2v1),
+                                                                    collection_kind: KeyedStream {
+                                                                        bound: Unbounded,
+                                                                        value_order: TotalOrder,
+                                                                        value_retry: ExactlyOnce,
+                                                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                        value_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                    },
+                                                                },
+                                                            },
+                                                            metadata: HydroIrMetadata {
+                                                                location_id: Cluster(loc2v1),
+                                                                collection_kind: Stream {
+                                                                    bound: Unbounded,
+                                                                    order: NoOrder,
+                                                                    retry: ExactlyOnce,
+                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                },
+                                                            },
+                                                        },
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Cluster(loc2v1),
+                                                            collection_kind: Stream {
+                                                                bound: Unbounded,
+                                                                order: NoOrder,
+                                                                retry: ExactlyOnce,
+                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                            },
+                                                        },
+                                                    },
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(2, Cluster(loc2v1)),
+                                                        collection_kind: Stream {
+                                                            bound: Bounded,
+                                                            order: NoOrder,
+                                                            retry: ExactlyOnce,
+                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(2, Cluster(loc2v1)),
+                                                    collection_kind: Stream {
+                                                        bound: Bounded,
+                                                        order: NoOrder,
+                                                        retry: ExactlyOnce,
+                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Tick(2, Cluster(loc2v1)),
+                                                collection_kind: Stream {
+                                                    bound: Bounded,
+                                                    order: NoOrder,
+                                                    retry: ExactlyOnce,
+                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_id: Atomic(Tick(2, Cluster(loc2v1))),
+                                            collection_kind: Stream {
+                                                bound: Unbounded,
+                                                order: NoOrder,
+                                                retry: ExactlyOnce,
+                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                            },
+                                        },
+                                    },
+                                    trusted: false,
+                                    metadata: HydroIrMetadata {
+                                        location_id: Atomic(Tick(2, Cluster(loc2v1))),
+                                        collection_kind: Stream {
+                                            bound: Unbounded,
+                                            order: TotalOrder,
+                                            retry: ExactlyOnce,
+                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_id: Atomic(Tick(2, Cluster(loc2v1))),
+                                    collection_kind: Optional {
+                                        bound: Unbounded,
+                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_id: Tick(2, Cluster(loc2v1)),
+                                collection_kind: Optional {
+                                    bound: Bounded,
+                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                },
+                            },
+                        },
+                        second: Cast {
+                            inner: SingletonSource {
+                                value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_488_46 ! ([] [Ballot { num : 0 , proposer_id : MemberId :: from_raw_id (0) }]) },
+                                first_tick_only: false,
+                                metadata: HydroIrMetadata {
+                                    location_id: Tick(2, Cluster(loc2v1)),
+                                    collection_kind: Singleton {
+                                        bound: Bounded,
+                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_id: Tick(2, Cluster(loc2v1)),
+                                collection_kind: Optional {
+                                    bound: Bounded,
+                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                },
+                            },
+                        },
+                        metadata: HydroIrMetadata {
+                            location_id: Tick(2, Cluster(loc2v1)),
+                            collection_kind: Optional {
+                                bound: Bounded,
+                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                            },
+                        },
+                    },
+                    metadata: HydroIrMetadata {
+                        location_id: Tick(2, Cluster(loc2v1)),
+                        collection_kind: Singleton {
+                            bound: Bounded,
+                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                        },
+                    },
+                },
+                metadata: HydroIrMetadata {
+                    location_id: Tick(2, Cluster(loc2v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                    },
+                },
+            },
+            kind: Singleton,
+            access_counter: Counting(
+                Cell {
+                    value: 0,
+                },
+            ),
+            metadata: HydroIrMetadata {
+                location_id: Tick(2, Cluster(loc2v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
+    Null {
+        input: Reference {
+            inner: <shared 10>: CycleSource {
+                cycle_id: CycleId(
+                    4,
+                ),
+                metadata: HydroIrMetadata {
+                    location_id: Tick(2, Cluster(loc2v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                    },
+                },
+            },
+            kind: Singleton,
+            access_counter: Counting(
+                Cell {
+                    value: 0,
+                },
+            ),
+            metadata: HydroIrMetadata {
+                location_id: Tick(2, Cluster(loc2v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             9,
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 7>: Chain {
+                inner: <shared 11>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -1146,7 +1946,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <shared 8>: Inspect {
+                            inner: <shared 12>: Inspect {
                                 f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_338_38 ! ([] [| p1b | println ! ("Proposer received P1b: {:?}" , p1b)]) }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
@@ -1166,820 +1966,16 @@ expression: built.ir()
                                             input: Cast {
                                                 inner: YieldConcat {
                                                     inner: Map {
-                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_498_20 ! ([] [| ((ballot , max_ballot) , log) | (ballot . proposer_id . clone () , (ballot . clone () , if ballot == max_ballot { Ok (log) } else { Err (max_ballot) }))]) }),
-                                                        input: CrossSingleton {
-                                                            left: CrossSingleton {
-                                                                left: Tee {
-                                                                    inner: <shared 9>: Batch {
-                                                                        inner: Map {
-                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
-                                                                            input: Cast {
-                                                                                inner: Network {
-                                                                                    name: None,
-                                                                                    networking_info: Tcp {
-                                                                                        fault: FailStop,
-                                                                                    },
-                                                                                    serialize_fn: Some(
-                                                                                        hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                                                    ),
-                                                                                    instantiate_fn: <network instantiate>,
-                                                                                    deserialize_fn: Some(
-                                                                                        | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: Ballot > (& b) . unwrap ()) },
-                                                                                    ),
-                                                                                    input: YieldConcat {
-                                                                                        inner: Cast {
-                                                                                            inner: CrossProduct {
-                                                                                                left: ObserveNonDet {
-                                                                                                    inner: Map {
-                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
-                                                                                                        input: Cast {
-                                                                                                            inner: Cast {
-                                                                                                                inner: Filter {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_1187_61 ! ([] [| b | * b]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
-                                                                                                                    input: Batch {
-                                                                                                                        inner: FoldKeyed {
-                                                                                                                            init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_36_11 ! ([] [| | false]) }),
-                                                                                                                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_37_11 ! ([] [| present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } }]) }),
-                                                                                                                            input: Cast {
-                                                                                                                                inner: Map {
-                                                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; hydro_lang :: __stageleft_quote_src_location_mod_rs_545_16 ! ([] [| (k , v) | (MemberId :: from_tagless (k) , v)]) }),
-                                                                                                                                    input: Source {
-                                                                                                                                        source: ClusterMembers(
-                                                                                                                                            Cluster(loc2v1),
-                                                                                                                                            Uninit,
-                                                                                                                                        ),
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Cluster(loc1v1),
-                                                                                                                                            collection_kind: Stream {
-                                                                                                                                                bound: Unbounded,
-                                                                                                                                                order: TotalOrder,
-                                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Cluster(loc1v1),
-                                                                                                                                        collection_kind: Stream {
-                                                                                                                                            bound: Unbounded,
-                                                                                                                                            order: TotalOrder,
-                                                                                                                                            retry: ExactlyOnce,
-                                                                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                },
-                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Cluster(loc1v1),
-                                                                                                                                    collection_kind: KeyedStream {
-                                                                                                                                        bound: Unbounded,
-                                                                                                                                        value_order: TotalOrder,
-                                                                                                                                        value_retry: ExactlyOnce,
-                                                                                                                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                                        value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
-                                                                                                                                    },
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_id: Cluster(loc1v1),
-                                                                                                                                collection_kind: KeyedSingleton {
-                                                                                                                                    bound: MonotonicKeys,
-                                                                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                                    value_type: bool,
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                                            collection_kind: KeyedSingleton {
-                                                                                                                                bound: Bounded,
-                                                                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                                value_type: bool,
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                                        collection_kind: KeyedSingleton {
-                                                                                                                            bound: Bounded,
-                                                                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                            value_type: bool,
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                                    collection_kind: KeyedStream {
-                                                                                                                        bound: Bounded,
-                                                                                                                        value_order: TotalOrder,
-                                                                                                                        value_retry: ExactlyOnce,
-                                                                                                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                        value_type: bool,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                            },
-                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                                collection_kind: Stream {
-                                                                                                                    bound: Bounded,
-                                                                                                                    order: NoOrder,
-                                                                                                                    retry: ExactlyOnce,
-                                                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
-                                                                                                                },
-                                                                                                            },
-                                                                                                        },
-                                                                                                        metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                            collection_kind: Stream {
-                                                                                                                bound: Bounded,
-                                                                                                                order: NoOrder,
-                                                                                                                retry: ExactlyOnce,
-                                                                                                                element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                            },
-                                                                                                        },
-                                                                                                    },
-                                                                                                    trusted: true,
-                                                                                                    metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                        collection_kind: Stream {
-                                                                                                            bound: Bounded,
-                                                                                                            order: TotalOrder,
-                                                                                                            retry: ExactlyOnce,
-                                                                                                            element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                        },
-                                                                                                    },
-                                                                                                },
-                                                                                                right: Batch {
-                                                                                                    inner: Inspect {
-                                                                                                        f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_317_20 ! ([] [| _ | println ! ("Proposer leader expired, sending P1a")]) }),
-                                                                                                        input: YieldConcat {
-                                                                                                            inner: Cast {
-                                                                                                                inner: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
-                                                                                                                    input: CrossSingleton {
-                                                                                                                        left: Tee {
-                                                                                                                            inner: <shared 4>,
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                collection_kind: Singleton {
-                                                                                                                                    bound: Bounded,
-                                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                        right: Filter {
-                                                                                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_34 ! ([] [| b | * b]) }),
-                                                                                                                            input: Map {
-                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_1144_31 ! ([] [| (a , b) | a && b]) }),
-                                                                                                                                input: Cast {
-                                                                                                                                    inner: CrossSingleton {
-                                                                                                                                        left: Map {
-                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_908_20 ! ([] [| o | o . is_some ()]) }),
-                                                                                                                                            input: Cast {
-                                                                                                                                                inner: ChainFirst {
-                                                                                                                                                    first: Map {
-                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
-                                                                                                                                                        input: Map {
-                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
-                                                                                                                                                            input: Map {
-                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (() , bool) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_1105_51 ! ([] [| (d , _) | d]) }),
-                                                                                                                                                                input: CrossSingleton {
-                                                                                                                                                                    left: Batch {
-                                                                                                                                                                        inner: YieldConcat {
-                                                                                                                                                                            inner: FilterMap {
-                                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2027_27 ! ([duration__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_438_15 ! ([i_am_leader_check_timeout__free = 10u64 ,] [Duration :: from_secs (i_am_leader_check_timeout__free)]) } ,] [move | latest_received | { if let Some (latest_received) = latest_received { if Instant :: now () . duration_since (latest_received) > duration__free { Some (()) } else { None } } else { Some (()) } }]) }),
-                                                                                                                                                                                input: Batch {
-                                                                                                                                                                                    inner: Fold {
-                                                                                                                                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2016_15 ! ([] [| | None]) }),
-                                                                                                                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2018_16 ! ([] [| latest , _ | { * latest = Some (Instant :: now ()) ; }]) }),
-                                                                                                                                                                                        input: ObserveNonDet {
-                                                                                                                                                                                            inner: Tee {
-                                                                                                                                                                                                inner: <shared 3>,
-                                                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                                                    location_id: Cluster(loc1v1),
-                                                                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                                                                        bound: Unbounded,
-                                                                                                                                                                                                        order: NoOrder,
-                                                                                                                                                                                                        retry: AtLeastOnce,
-                                                                                                                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                                                                    },
-                                                                                                                                                                                                },
-                                                                                                                                                                                            },
-                                                                                                                                                                                            trusted: false,
-                                                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                                                location_id: Cluster(loc1v1),
-                                                                                                                                                                                                collection_kind: Stream {
-                                                                                                                                                                                                    bound: Unbounded,
-                                                                                                                                                                                                    order: NoOrder,
-                                                                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                                                                },
-                                                                                                                                                                                            },
-                                                                                                                                                                                        },
-                                                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                                                            location_id: Cluster(loc1v1),
-                                                                                                                                                                                            collection_kind: Singleton {
-                                                                                                                                                                                                bound: Unbounded,
-                                                                                                                                                                                                element_type: core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >,
-                                                                                                                                                                                            },
-                                                                                                                                                                                        },
-                                                                                                                                                                                    },
-                                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                                        location_id: Tick(7, Cluster(loc1v1)),
-                                                                                                                                                                                        collection_kind: Singleton {
-                                                                                                                                                                                            bound: Bounded,
-                                                                                                                                                                                            element_type: core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >,
-                                                                                                                                                                                        },
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                                    location_id: Tick(7, Cluster(loc1v1)),
-                                                                                                                                                                                    collection_kind: Optional {
-                                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                                        element_type: (),
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                                location_id: Cluster(loc1v1),
-                                                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                                                    bound: Unbounded,
-                                                                                                                                                                                    element_type: (),
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                                element_type: (),
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                    right: Filter {
-                                                                                                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_1105_34 ! ([] [| b | * b]) }),
-                                                                                                                                                                        input: Map {
-                                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_1078_20 ! ([] [| b | ! b]) }),
-                                                                                                                                                                            input: Tee {
-                                                                                                                                                                                inner: <shared 6>,
-                                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                                    collection_kind: Singleton {
-                                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                                        element_type: bool,
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                                    element_type: bool,
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                                element_type: bool,
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                        collection_kind: Optional {
-                                                                                                                                                                            bound: Bounded,
-                                                                                                                                                                            element_type: (() , bool),
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                    collection_kind: Optional {
-                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                        element_type: (),
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: (),
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: core :: option :: Option < () >,
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    second: Cast {
-                                                                                                                                                        inner: SingletonSource {
-                                                                                                                                                            value: :: std :: option :: Option :: None,
-                                                                                                                                                            first_tick_only: false,
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: core :: option :: Option < () >,
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: core :: option :: Option < () >,
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: Optional {
-                                                                                                                                                            bound: Bounded,
-                                                                                                                                                            element_type: core :: option :: Option < () >,
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Singleton {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        element_type: core :: option :: Option < () >,
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    element_type: bool,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        right: Map {
-                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_908_20 ! ([] [| o | o . is_some ()]) }),
-                                                                                                                                            input: Cast {
-                                                                                                                                                inner: ChainFirst {
-                                                                                                                                                    first: Map {
-                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
-                                                                                                                                                        input: Map {
-                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
-                                                                                                                                                            input: Reduce {
-                                                                                                                                                                f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1589_23 ! ([] [| _ , _ | { }]) }),
-                                                                                                                                                                input: FlatMap {
-                                                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1955_27 ! ([] [| d | d]) }),
-                                                                                                                                                                    input: Scan {
-                                                                                                                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < core :: option :: Option < () > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1915_27 ! ([] [| | None]) }),
-                                                                                                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < core :: option :: Option < () > > , () , core :: option :: Option < core :: option :: Option < () > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1918_24 ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , hydro_test :: __staged :: __deps :: hydro_lang :: live_collections :: keyed_stream :: Generate < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1588_37 ! ([] [| _ , item | Generate :: Return (item)]) }) , init__free = stageleft :: runtime_support :: fn0_type_hint :: < () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1588_26 ! ([] [| | ()]) }) ,] [move | state : & mut Option < Option < _ > > , v | { if state . is_none () { * state = Some (Some (init__free ())) ; } match state { Some (Some (state_value)) => match f__free (state_value , v) { Generate :: Yield (out) => Some (Some (out)) , Generate :: Return (out) => { * state = Some (None) ; Some (Some (out)) } Generate :: Break => None , Generate :: Continue => Some (None) , } , _ => None , } }]) }),
-                                                                                                                                                                        input: Batch {
-                                                                                                                                                                            inner: Source {
-                                                                                                                                                                                source: Stream(
-                                                                                                                                                                                    { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; hydro_lang :: __stageleft_quote_src_location_mod_rs_1439_30 ! ([delay__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_453_19 ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) , i_am_leader_check_timeout_delay_multiplier__free = 15usize ,] [Duration :: from_secs ((CLUSTER_SELF_ID__free . get_raw_id () * i_am_leader_check_timeout_delay_multiplier__free as u32) . into ())]) } , interval__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_458_19 ! ([i_am_leader_check_timeout__free = 10u64 ,] [Duration :: from_secs (i_am_leader_check_timeout__free)]) } ,] [tokio_stream :: StreamExt :: map (tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval_at (tokio :: time :: Instant :: now () + delay__free , interval__free ,)) , | _ | ())]) },
-                                                                                                                                                                                ),
-                                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                                    location_id: Cluster(loc1v1),
-                                                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                                                        bound: Unbounded,
-                                                                                                                                                                                        order: TotalOrder,
-                                                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                                                        element_type: (),
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                                collection_kind: Stream {
-                                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                                    order: TotalOrder,
-                                                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                                                    element_type: (),
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                            collection_kind: Stream {
-                                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                                order: TotalOrder,
-                                                                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                                                                element_type: core :: option :: Option < () >,
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                        collection_kind: Stream {
-                                                                                                                                                                            bound: Bounded,
-                                                                                                                                                                            order: TotalOrder,
-                                                                                                                                                                            retry: ExactlyOnce,
-                                                                                                                                                                            element_type: (),
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                    collection_kind: Optional {
-                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                        element_type: (),
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: (),
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: core :: option :: Option < () >,
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    second: Cast {
-                                                                                                                                                        inner: SingletonSource {
-                                                                                                                                                            value: :: std :: option :: Option :: None,
-                                                                                                                                                            first_tick_only: false,
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: core :: option :: Option < () >,
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: core :: option :: Option < () >,
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: Optional {
-                                                                                                                                                            bound: Bounded,
-                                                                                                                                                            element_type: core :: option :: Option < () >,
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Singleton {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        element_type: core :: option :: Option < () >,
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    element_type: bool,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                bound: Bounded,
-                                                                                                                                                element_type: (bool , bool),
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                        collection_kind: Singleton {
-                                                                                                                                            bound: Bounded,
-                                                                                                                                            element_type: (bool , bool),
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                },
-                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                    collection_kind: Singleton {
-                                                                                                                                        bound: Bounded,
-                                                                                                                                        element_type: bool,
-                                                                                                                                    },
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                collection_kind: Optional {
-                                                                                                                                    bound: Bounded,
-                                                                                                                                    element_type: bool,
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                            collection_kind: Optional {
-                                                                                                                                bound: Bounded,
-                                                                                                                                element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool),
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                        collection_kind: Optional {
-                                                                                                                            bound: Bounded,
-                                                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                    collection_kind: Stream {
-                                                                                                                        bound: Bounded,
-                                                                                                                        order: TotalOrder,
-                                                                                                                        retry: ExactlyOnce,
-                                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                            },
-                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                location_id: Cluster(loc1v1),
-                                                                                                                collection_kind: Stream {
-                                                                                                                    bound: Unbounded,
-                                                                                                                    order: TotalOrder,
-                                                                                                                    retry: ExactlyOnce,
-                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                },
-                                                                                                            },
-                                                                                                        },
-                                                                                                        metadata: HydroIrMetadata {
-                                                                                                            location_id: Cluster(loc1v1),
-                                                                                                            collection_kind: Stream {
-                                                                                                                bound: Unbounded,
-                                                                                                                order: TotalOrder,
-                                                                                                                retry: ExactlyOnce,
-                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                            },
-                                                                                                        },
-                                                                                                    },
-                                                                                                    metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                        collection_kind: Stream {
-                                                                                                            bound: Bounded,
-                                                                                                            order: TotalOrder,
-                                                                                                            retry: ExactlyOnce,
-                                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                        },
-                                                                                                    },
-                                                                                                },
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                    collection_kind: Stream {
-                                                                                                        bound: Bounded,
-                                                                                                        order: TotalOrder,
-                                                                                                        retry: ExactlyOnce,
-                                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
-                                                                                                    },
-                                                                                                },
-                                                                                            },
-                                                                                            metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                collection_kind: KeyedStream {
-                                                                                                    bound: Bounded,
-                                                                                                    value_order: TotalOrder,
-                                                                                                    value_retry: ExactlyOnce,
-                                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                    value_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                },
-                                                                                            },
-                                                                                        },
-                                                                                        metadata: HydroIrMetadata {
-                                                                                            location_id: Cluster(loc1v1),
-                                                                                            collection_kind: KeyedStream {
-                                                                                                bound: Unbounded,
-                                                                                                value_order: TotalOrder,
-                                                                                                value_retry: ExactlyOnce,
-                                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                value_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                            },
-                                                                                        },
-                                                                                    },
-                                                                                    metadata: HydroIrMetadata {
-                                                                                        location_id: Cluster(loc2v1),
-                                                                                        collection_kind: KeyedStream {
-                                                                                            bound: Unbounded,
-                                                                                            value_order: TotalOrder,
-                                                                                            value_retry: ExactlyOnce,
-                                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                                            value_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                        },
-                                                                                    },
-                                                                                },
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_id: Cluster(loc2v1),
-                                                                                    collection_kind: Stream {
-                                                                                        bound: Unbounded,
-                                                                                        order: NoOrder,
-                                                                                        retry: ExactlyOnce,
-                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
-                                                                                    },
-                                                                                },
-                                                                            },
-                                                                            metadata: HydroIrMetadata {
-                                                                                location_id: Cluster(loc2v1),
-                                                                                collection_kind: Stream {
-                                                                                    bound: Unbounded,
-                                                                                    order: NoOrder,
-                                                                                    retry: ExactlyOnce,
-                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                },
-                                                                            },
-                                                                        },
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Cluster(loc2v1)),
-                                                                            collection_kind: Stream {
-                                                                                bound: Bounded,
-                                                                                order: NoOrder,
-                                                                                retry: ExactlyOnce,
-                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                        collection_kind: Stream {
-                                                                            bound: Bounded,
-                                                                            order: NoOrder,
-                                                                            retry: ExactlyOnce,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                right: Cast {
-                                                                    inner: Tee {
-                                                                        inner: <shared 10>: Cast {
-                                                                            inner: ChainFirst {
-                                                                                first: Batch {
-                                                                                    inner: Reduce {
-                                                                                        f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
-                                                                                        input: ObserveNonDet {
-                                                                                            inner: YieldConcat {
-                                                                                                inner: Inspect {
-                                                                                                    f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_486_20 ! ([] [| p1a | println ! ("Acceptor received P1a: {:?}" , p1a)]) }),
-                                                                                                    input: Tee {
-                                                                                                        inner: <shared 9>,
-                                                                                                        metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(2, Cluster(loc2v1)),
-                                                                                                            collection_kind: Stream {
-                                                                                                                bound: Bounded,
-                                                                                                                order: NoOrder,
-                                                                                                                retry: ExactlyOnce,
-                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                            },
-                                                                                                        },
-                                                                                                    },
-                                                                                                    metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                                                        collection_kind: Stream {
-                                                                                                            bound: Bounded,
-                                                                                                            order: NoOrder,
-                                                                                                            retry: ExactlyOnce,
-                                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                        },
-                                                                                                    },
-                                                                                                },
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_id: Atomic(Tick(2, Cluster(loc2v1))),
-                                                                                                    collection_kind: Stream {
-                                                                                                        bound: Unbounded,
-                                                                                                        order: NoOrder,
-                                                                                                        retry: ExactlyOnce,
-                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                    },
-                                                                                                },
-                                                                                            },
-                                                                                            trusted: false,
-                                                                                            metadata: HydroIrMetadata {
-                                                                                                location_id: Atomic(Tick(2, Cluster(loc2v1))),
-                                                                                                collection_kind: Stream {
-                                                                                                    bound: Unbounded,
-                                                                                                    order: TotalOrder,
-                                                                                                    retry: ExactlyOnce,
-                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                },
-                                                                                            },
-                                                                                        },
-                                                                                        metadata: HydroIrMetadata {
-                                                                                            location_id: Atomic(Tick(2, Cluster(loc2v1))),
-                                                                                            collection_kind: Optional {
-                                                                                                bound: Unbounded,
-                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                            },
-                                                                                        },
-                                                                                    },
-                                                                                    metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                                        collection_kind: Optional {
-                                                                                            bound: Bounded,
-                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                        },
-                                                                                    },
-                                                                                },
-                                                                                second: Cast {
-                                                                                    inner: SingletonSource {
-                                                                                        value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_488_46 ! ([] [Ballot { num : 0 , proposer_id : MemberId :: from_raw_id (0) }]) },
-                                                                                        first_tick_only: false,
-                                                                                        metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(2, Cluster(loc2v1)),
-                                                                                            collection_kind: Singleton {
-                                                                                                bound: Bounded,
-                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                            },
-                                                                                        },
-                                                                                    },
-                                                                                    metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                                        collection_kind: Optional {
-                                                                                            bound: Bounded,
-                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                        },
-                                                                                    },
-                                                                                },
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(2, Cluster(loc2v1)),
-                                                                                    collection_kind: Optional {
-                                                                                        bound: Bounded,
-                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                    },
-                                                                                },
-                                                                            },
-                                                                            metadata: HydroIrMetadata {
-                                                                                location_id: Tick(2, Cluster(loc2v1)),
-                                                                                collection_kind: Singleton {
-                                                                                    bound: Bounded,
-                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                },
-                                                                            },
-                                                                        },
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Cluster(loc2v1)),
-                                                                            collection_kind: Singleton {
-                                                                                bound: Bounded,
-                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                        collection_kind: Optional {
-                                                                            bound: Bounded,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
-                                                                    collection_kind: Stream {
-                                                                        bound: Bounded,
-                                                                        order: NoOrder,
-                                                                        retry: ExactlyOnce,
-                                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot),
-                                                                    },
-                                                                },
-                                                            },
-                                                            right: Cast {
-                                                                inner: CycleSource {
-                                                                    cycle_id: CycleId(
-                                                                        4,
-                                                                    ),
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                        collection_kind: Singleton {
-                                                                            bound: Bounded,
-                                                                            element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                        },
-                                                                    },
-                                                                },
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
-                                                                    collection_kind: Optional {
-                                                                        bound: Bounded,
-                                                                        element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                    },
-                                                                },
-                                                            },
+                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_498_20 ! ([a_log_ref__free = __hydro_singleton_ref_0 , a_max_ballot_ref__free = __hydro_singleton_ref_1 ,] [| ballot | { let max_ballot = a_max_ballot_ref__free . clone () ; let log = a_log_ref__free . clone () ; (ballot . proposer_id . clone () , (ballot . clone () , if ballot == max_ballot { Ok (log) } else { Err (max_ballot) } ,) ,) }]) }),
+                                                        input: Tee {
+                                                            inner: <shared 9>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(2, Cluster(loc2v1)),
                                                                 collection_kind: Stream {
                                                                     bound: Bounded,
                                                                     order: NoOrder,
                                                                     retry: ExactlyOnce,
-                                                                    element_type: ((hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)),
+                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                 },
                                                             },
                                                         },
@@ -2096,19 +2092,19 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 11>: Map {
+                inner: <shared 13>: Map {
                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_60_27 ! ([max__free = 3usize ,] [move | (success , error) | (success + error) >= max__free]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
                                 input: Tee {
-                                    inner: <shared 12>: FoldKeyed {
+                                    inner: <shared 14>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_34_15 ! ([] [move | | (0 , 0)]) }),
                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_35_15 ! ([] [move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } }]) }),
                                         input: Cast {
                                             inner: Tee {
-                                                inner: <shared 7>,
+                                                inner: <shared 11>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(9, Cluster(loc1v1)),
                                                     collection_kind: Stream {
@@ -2222,7 +2218,7 @@ expression: built.ir()
                         inner: Filter {
                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_51_23 ! ([min__free = 2usize ,] [move | (success , _error) | success >= & min__free]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
                             input: Tee {
-                                inner: <shared 12>,
+                                inner: <shared 14>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(9, Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
@@ -2273,7 +2269,7 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 11>,
+                inner: <shared 13>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(9, Cluster(loc1v1)),
                     collection_kind: Stream {
@@ -2301,7 +2297,7 @@ expression: built.ir()
             7,
         ),
         input: Tee {
-            inner: <shared 13>: Map {
+            inner: <shared 15>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_1144_31 ! ([] [| (a , b) | a && b]) }),
                 input: Cast {
                     inner: CrossSingleton {
@@ -2314,8 +2310,8 @@ expression: built.ir()
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                             input: Tee {
-                                                inner: <shared 14>: FilterMap {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_564_12 ! ([] [move | ((quorum_ballot , quorum_accepted) , my_ballot) | if quorum_ballot == my_ballot { Some (quorum_accepted) } else { None }]) }),
+                                                inner: <shared 16>: FilterMap {
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_568_12 ! ([] [move | ((quorum_ballot , quorum_accepted) , my_ballot) | if quorum_ballot == my_ballot { Some (quorum_accepted) } else { None }]) }),
                                                     input: CrossSingleton {
                                                         left: Batch {
                                                             inner: Reduce {
@@ -2328,7 +2324,7 @@ expression: built.ir()
                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) > , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1667_27 ! ([] [| d | d]) }),
                                                                                     input: Scan {
                                                                                         init: stageleft :: runtime_support :: fn0_type_hint :: < std :: collections :: hash_map :: HashMap < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1629_27 ! ([] [| | HashMap :: new ()]) }),
-                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , core :: option :: Option < core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1632_24 ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: __deps :: hydro_lang :: live_collections :: keyed_stream :: Generate < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1737_15 ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_544_15 ! ([quorum_size__free = 2usize ,] [move | logs , log | { logs . push (log) ; logs . len () >= quorum_size__free }]) }) ,] [move | key_state , v | { if let Some (key_state_value) = key_state . as_mut () { if f__free (key_state_value , v) { Generate :: Return (key_state . take () . unwrap ()) } else { Generate :: Continue } } else { unreachable ! () } }]) }) , init__free = stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1736_15 ! ([init__free = stageleft :: runtime_support :: fn0_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_543_15 ! ([] [| | vec ! []]) }) ,] [move | | Some (init__free ())]) }) ,] [move | acc : & mut HashMap < _ , _ > , (k , v) | { let existing_state = acc . entry (Clone :: clone (& k)) . or_insert_with (| | Some (init__free ())) ; if let Some (existing_state_value) = existing_state { match f__free (existing_state_value , v) { Generate :: Yield (out) => Some (Some ((k , out))) , Generate :: Return (out) => { let _ = existing_state . take () ; Some (Some ((k , out))) } Generate :: Break => { let _ = existing_state . take () ; Some (None) } Generate :: Continue => Some (None) , } } else { Some (None) } }]) }),
+                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , core :: option :: Option < core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1632_24 ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: __deps :: hydro_lang :: live_collections :: keyed_stream :: Generate < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1737_15 ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_548_15 ! ([quorum_size__free = 2usize ,] [move | logs , log | { logs . push (log) ; logs . len () >= quorum_size__free }]) }) ,] [move | key_state , v | { if let Some (key_state_value) = key_state . as_mut () { if f__free (key_state_value , v) { Generate :: Return (key_state . take () . unwrap ()) } else { Generate :: Continue } } else { unreachable ! () } }]) }) , init__free = stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1736_15 ! ([init__free = stageleft :: runtime_support :: fn0_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_547_15 ! ([] [| | vec ! []]) }) ,] [move | | Some (init__free ())]) }) ,] [move | acc : & mut HashMap < _ , _ > , (k , v) | { let existing_state = acc . entry (Clone :: clone (& k)) . or_insert_with (| | Some (init__free ())) ; if let Some (existing_state_value) = existing_state { match f__free (existing_state_value , v) { Generate :: Yield (out) => Some (Some ((k , out))) , Generate :: Return (out) => { let _ = existing_state . take () ; Some (Some ((k , out))) } Generate :: Break => { let _ = existing_state . take () ; Some (None) } Generate :: Continue => Some (None) , } } else { Some (None) } }]) }),
                                                                                         input: ObserveNonDet {
                                                                                             inner: Cast {
                                                                                                 inner: YieldConcat {
@@ -2337,7 +2333,7 @@ expression: built.ir()
                                                                                                         input: AntiJoin {
                                                                                                             pos: AntiJoin {
                                                                                                                 pos: Tee {
-                                                                                                                    inner: <shared 7>,
+                                                                                                                    inner: <shared 11>,
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_id: Tick(9, Cluster(loc1v1)),
                                                                                                                         collection_kind: Stream {
@@ -2355,7 +2351,7 @@ expression: built.ir()
                                                                                                                             inner: Filter {
                                                                                                                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_46_23 ! ([min__free = 2usize ,] [move | (success , _error) | success < & min__free]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
                                                                                                                                 input: Tee {
-                                                                                                                                    inner: <shared 12>,
+                                                                                                                                    inner: <shared 14>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(9, Cluster(loc1v1)),
                                                                                                                                         collection_kind: KeyedSingleton {
@@ -2779,11 +2775,11 @@ expression: built.ir()
             5,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_580_21 ! ([] [| (_ , ballot) | ballot]) }),
+            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_584_21 ! ([] [| (_ , ballot) | ballot]) }),
             input: FilterMap {
                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_82_32 ! ([] [move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , }]) }),
                 input: Tee {
-                    inner: <shared 8>,
+                    inner: <shared 12>,
                     metadata: HydroIrMetadata {
                         location_id: Cluster(loc1v1),
                         collection_kind: Stream {
@@ -2824,7 +2820,7 @@ expression: built.ir()
             f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1054_20 ! ([] [| (d , _) | d]) }),
             input: CrossSingleton {
                 left: Tee {
-                    inner: <shared 15>: Chain {
+                    inner: <shared 17>: Chain {
                         first: DeferTick {
                             input: CycleSource {
                                 cycle_id: CycleId(
@@ -2856,7 +2852,7 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < (u32 , i32) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_bench_rs_42_28 ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_tagless ((__hydro_lang_cluster_self_id_loc3v1) . clone ()) ,] [move | (virtual_id , payload) | { (virtual_id , (CLUSTER_SELF_ID__free . clone () , payload)) }]) }),
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <shared 16>: Map {
+                                            inner: <shared 18>: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < i32 >) , (u32 , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_813_23 ! ([f__free = stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < i32 > , i32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_bench_rs_136_33 ! ([] [move | payload | { if let Some (counter) = payload { counter + 1 } else { 0 } }]) }) ,] [{ let orig = f__free ; move | (k , v) | (k , orig (v)) }]) }),
                                                 input: Chain {
                                                     first: YieldConcat {
@@ -3037,7 +3033,7 @@ expression: built.ir()
                                     input: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_935_20 ! ([] [| _ | ()]) }),
                                         input: Tee {
-                                            inner: <shared 17>: Batch {
+                                            inner: <shared 19>: Batch {
                                                 inner: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_94_22 ! ([] [| ballot | ballot . proposer_id]) }),
                                                     input: Reduce {
@@ -3201,12 +3197,12 @@ expression: built.ir()
                                                                                                             right: Filter {
                                                                                                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_34 ! ([] [| b | * b]) }),
                                                                                                                 input: Tee {
-                                                                                                                    inner: <shared 18>: Map {
+                                                                                                                    inner: <shared 20>: Map {
                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_1144_31 ! ([] [| (a , b) | a && b]) }),
                                                                                                                         input: Cast {
                                                                                                                             inner: CrossSingleton {
                                                                                                                                 left: Tee {
-                                                                                                                                    inner: <shared 13>,
+                                                                                                                                    inner: <shared 15>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Singleton {
@@ -3229,7 +3225,7 @@ expression: built.ir()
                                                                                                                                                             input: Map {
                                                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_192_16 ! ([] [| is_leader | is_leader . then_some (())]) }),
                                                                                                                                                                 input: Tee {
-                                                                                                                                                                    inner: <shared 13>,
+                                                                                                                                                                    inner: <shared 15>,
                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                                                         collection_kind: Singleton {
@@ -3616,7 +3612,7 @@ expression: built.ir()
     },
     Null {
         input: Reference {
-            inner: <shared 19>: Tee {
+            inner: <shared 21>: Tee {
                 inner: <shared 4>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(15, Cluster(loc1v1)),
@@ -3647,15 +3643,15 @@ expression: built.ir()
             12,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_793_20 ! ([] [| (num_payloads , base_slot) | base_slot + num_payloads]) }),
+            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_797_20 ! ([] [| (num_payloads , base_slot) | base_slot + num_payloads]) }),
             input: Cast {
                 inner: CrossSingleton {
                     left: Fold {
                         init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2427_15 ! ([] [| | 0usize]) }),
                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2429_16 ! ([] [| count , _ | * count += 1]) }),
                         input: Tee {
-                            inner: <shared 20>: Map {
-                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_785_20 ! ([base_slot_ref__free = __hydro_singleton_ref_0 ,] [| (index , payload) | (* base_slot_ref__free + index , payload)]) }),
+                            inner: <shared 22>: Map {
+                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_789_20 ! ([base_slot_ref__free = __hydro_singleton_ref_0 ,] [| (index , payload) | (* base_slot_ref__free + index , payload)]) }),
                                 input: Enumerate {
                                     input: Batch {
                                         inner: YieldConcat {
@@ -3685,7 +3681,7 @@ expression: built.ir()
                                                                                 input: YieldConcat {
                                                                                     inner: CrossSingleton {
                                                                                         left: Tee {
-                                                                                            inner: <shared 15>,
+                                                                                            inner: <shared 17>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(11, Cluster(loc3v1)),
                                                                                                 collection_kind: Stream {
@@ -3697,7 +3693,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         right: Tee {
-                                                                                            inner: <shared 17>,
+                                                                                            inner: <shared 19>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(11, Cluster(loc3v1)),
                                                                                                 collection_kind: Optional {
@@ -3802,7 +3798,7 @@ expression: built.ir()
                                                     right: Filter {
                                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1053_46 ! ([] [| b | * b]) }),
                                                         input: Tee {
-                                                            inner: <shared 13>,
+                                                            inner: <shared 15>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                 collection_kind: Singleton {
@@ -3898,14 +3894,14 @@ expression: built.ir()
                         },
                     },
                     right: Reference {
-                        inner: <shared 21>: Cast {
+                        inner: <shared 23>: Cast {
                             inner: ChainFirst {
                                 first: Map {
-                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_779_71 ! ([] [| s | s + 1]) }),
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_783_71 ! ([] [| s | s + 1]) }),
                                     input: Batch {
                                         inner: YieldConcat {
                                             inner: Tee {
-                                                inner: <shared 22>: Reduce {
+                                                inner: <shared 24>: Reduce {
                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
                                                     input: ObserveNonDet {
                                                         inner: Map {
@@ -3913,22 +3909,22 @@ expression: built.ir()
                                                             input: Cast {
                                                                 inner: Cast {
                                                                     inner: Tee {
-                                                                        inner: <shared 23>: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_484_23 ! ([f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_628_16 ! ([] [| (count , entry) | (count , entry . unwrap ())]) }) ,] [{ let orig = f__free ; move | (k , v) | (k , orig (v)) }]) }),
+                                                                        inner: <shared 25>: Map {
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_484_23 ! ([f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_632_16 ! ([] [| (count , entry) | (count , entry . unwrap ())]) }) ,] [{ let orig = f__free ; move | (k , v) | (k , orig (v)) }]) }),
                                                                             input: FoldKeyed {
-                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_607_67 ! ([] [| | (0 , None)]) }),
-                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_607_85 ! ([] [| curr_entry , new_entry | { if let Some (curr_entry_payload) = & mut curr_entry . 1 { let same_values = new_entry . value == curr_entry_payload . value ; let higher_ballot = new_entry . ballot > curr_entry_payload . ballot ; if same_values { curr_entry . 0 += 1 ; } if higher_ballot { curr_entry_payload . ballot = new_entry . ballot ; if ! same_values { curr_entry . 0 = 1 ; curr_entry_payload . value = new_entry . value ; } } } else { * curr_entry = (1 , Some (new_entry)) ; } }]) }),
+                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_611_67 ! ([] [| | (0 , None)]) }),
+                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_611_85 ! ([] [| curr_entry , new_entry | { if let Some (curr_entry_payload) = & mut curr_entry . 1 { let same_values = new_entry . value == curr_entry_payload . value ; let higher_ballot = new_entry . ballot > curr_entry_payload . ballot ; if same_values { curr_entry . 0 += 1 ; } if higher_ballot { curr_entry_payload . ballot = new_entry . ballot ; if ! same_values { curr_entry . 0 = 1 ; curr_entry_payload . value = new_entry . value ; } } } else { * curr_entry = (1 , Some (new_entry)) ; } }]) }),
                                                                                 input: Cast {
                                                                                     inner: FlatMap {
                                                                                         f: stageleft :: runtime_support :: fnmut1_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_764_35 ! ([] [| d | d]) }),
                                                                                         input: Map {
-                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_604_16 ! ([] [| (_checkpoint , log) | log]) }),
+                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_608_16 ! ([] [| (_checkpoint , log) | log]) }),
                                                                                             input: Tee {
-                                                                                                inner: <shared 24>: FlatMap {
+                                                                                                inner: <shared 26>: FlatMap {
                                                                                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_571_35 ! ([] [| v | v]) }),
                                                                                                     input: Cast {
                                                                                                         inner: Tee {
-                                                                                                            inner: <shared 14>,
+                                                                                                            inner: <shared 16>,
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                 collection_kind: Optional {
@@ -4133,7 +4129,7 @@ expression: built.ir()
                                             },
                                             second: Cast {
                                                 inner: SingletonSource {
-                                                    value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_775_58 ! ([] [0]) },
+                                                    value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_779_58 ! ([] [0]) },
                                                     first_tick_only: false,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(15, Cluster(loc1v1)),
@@ -4233,8 +4229,8 @@ expression: built.ir()
     },
     Null {
         input: Reference {
-            inner: <shared 25>: Tee {
-                inner: <shared 10>,
+            inner: <shared 27>: Tee {
+                inner: <shared 8>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(2, Cluster(loc2v1)),
                     collection_kind: Singleton {
@@ -4265,7 +4261,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 26>: Chain {
+                inner: <shared 28>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -4293,7 +4289,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <shared 27>: Map {
+                            inner: <shared 29>: Map {
                                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
                                 input: Cast {
                                     inner: Network {
@@ -4311,9 +4307,9 @@ expression: built.ir()
                                         input: Cast {
                                             inner: YieldConcat {
                                                 inner: Map {
-                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_872_16 ! ([a_max_ballot_ref__free = __hydro_singleton_ref_0 ,] [| p2a | { let max_ballot = a_max_ballot_ref__free . clone () ; (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) } ,) ,) }]) }),
+                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_878_16 ! ([a_max_ballot_ref__free = __hydro_singleton_ref_0 ,] [| p2a | { let max_ballot = a_max_ballot_ref__free . clone () ; (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) } ,) ,) }]) }),
                                                     input: Tee {
-                                                        inner: <shared 28>: Batch {
+                                                        inner: <shared 30>: Batch {
                                                             inner: Map {
                                                                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
                                                                 input: Cast {
@@ -4453,20 +4449,20 @@ expression: built.ir()
                                                                                     },
                                                                                     right: Batch {
                                                                                         inner: Map {
-                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_734_20 ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ,] [move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free . clone () , ballot , slot , value }]) }),
+                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_738_20 ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ,] [move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free . clone () , ballot , slot , value }]) }),
                                                                                             input: EndAtomic {
                                                                                                 inner: Tee {
-                                                                                                    inner: <shared 29>: YieldConcat {
+                                                                                                    inner: <shared 31>: YieldConcat {
                                                                                                         inner: Map {
                                                                                                             f: stageleft :: runtime_support :: fnmut1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1054_20 ! ([] [| (d , _) | d]) }),
                                                                                                             input: CrossSingleton {
                                                                                                                 left: Chain {
                                                                                                                     first: Map {
-                                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_720_16 ! ([p_ballot_ref__free = __hydro_singleton_ref_0 ,] [| (slot , payload) | ((slot , p_ballot_ref__free . clone ()) , Some (payload))]) }),
+                                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_724_16 ! ([p_ballot_ref__free = __hydro_singleton_ref_0 ,] [| (slot , payload) | ((slot , p_ballot_ref__free . clone ()) , Some (payload))]) }),
                                                                                                                         input: Batch {
                                                                                                                             inner: YieldConcat {
                                                                                                                                 inner: Tee {
-                                                                                                                                    inner: <shared 20>,
+                                                                                                                                    inner: <shared 22>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Stream {
@@ -4509,11 +4505,11 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                     second: Chain {
                                                                                                                         first: FilterMap {
-                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_634_23 ! ([f__free = 1usize , p_ballot_ref__free = __hydro_singleton_ref_0 , p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1 ,] [move | (slot , (count , entry)) | { if count > f__free { return None ; } else if let Some (checkpoint) = * p_p1b_max_checkpoint_ref__free && slot <= checkpoint { return None ; } Some (((slot , p_ballot_ref__free . clone ()) , entry . value)) }]) }),
+                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_638_23 ! ([f__free = 1usize , p_ballot_ref__free = __hydro_singleton_ref_0 , p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1 ,] [move | (slot , (count , entry)) | { if count > f__free { return None ; } else if let Some (checkpoint) = * p_p1b_max_checkpoint_ref__free && slot <= checkpoint { return None ; } Some (((slot , p_ballot_ref__free . clone ()) , entry . value)) }]) }),
                                                                                                                             input: Cast {
                                                                                                                                 inner: Cast {
                                                                                                                                     inner: Tee {
-                                                                                                                                        inner: <shared 23>,
+                                                                                                                                        inner: <shared 25>,
                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                             collection_kind: KeyedSingleton {
@@ -4555,14 +4551,14 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         second: Map {
-                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < usize , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_657_16 ! ([p_ballot_ref__free = __hydro_singleton_ref_0 ,] [move | slot | ((slot , p_ballot_ref__free . clone ()) , None)]) }),
+                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < usize , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_661_16 ! ([p_ballot_ref__free = __hydro_singleton_ref_0 ,] [move | slot | ((slot , p_ballot_ref__free . clone ()) , None)]) }),
                                                                                                                             input: Difference {
                                                                                                                                 pos: FlatMap {
-                                                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_649_29 ! ([] [| (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } }]) }),
+                                                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_653_29 ! ([] [| (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } }]) }),
                                                                                                                                     input: Cast {
                                                                                                                                         inner: CrossSingleton {
                                                                                                                                             left: Tee {
-                                                                                                                                                inner: <shared 22>,
+                                                                                                                                                inner: <shared 24>,
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Optional {
@@ -4573,7 +4569,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                             right: Cast {
                                                                                                                                                 inner: Reference {
-                                                                                                                                                    inner: <shared 30>: Cast {
+                                                                                                                                                    inner: <shared 32>: Cast {
                                                                                                                                                         inner: ChainFirst {
                                                                                                                                                             first: Map {
                                                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
@@ -4581,9 +4577,9 @@ expression: built.ir()
                                                                                                                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
                                                                                                                                                                     input: ObserveNonDet {
                                                                                                                                                                         inner: FilterMap {
-                                                                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_600_23 ! ([] [| (checkpoint , _log) | checkpoint]) }),
+                                                                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_604_23 ! ([] [| (checkpoint , _log) | checkpoint]) }),
                                                                                                                                                                             input: Tee {
-                                                                                                                                                                                inner: <shared 24>,
+                                                                                                                                                                                inner: <shared 26>,
                                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                                     location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                                                                     collection_kind: Stream {
@@ -4722,7 +4718,7 @@ expression: built.ir()
                                                                                                                                     input: Cast {
                                                                                                                                         inner: Cast {
                                                                                                                                             inner: Tee {
-                                                                                                                                                inner: <shared 23>,
+                                                                                                                                                inner: <shared 25>,
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                                     collection_kind: KeyedSingleton {
@@ -4806,7 +4802,7 @@ expression: built.ir()
                                                                                                                 right: Filter {
                                                                                                                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1053_46 ! ([] [| b | * b]) }),
                                                                                                                     input: Tee {
-                                                                                                                        inner: <shared 13>,
+                                                                                                                        inner: <shared 15>,
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                             collection_kind: Singleton {
@@ -5079,19 +5075,19 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 31>: Map {
+                inner: <shared 33>: Map {
                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_134_27 ! ([max__free = 3usize ,] [move | (success , error) | (success + error) >= max__free]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
                                 input: Tee {
-                                    inner: <shared 32>: FoldKeyed {
+                                    inner: <shared 34>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_109_15 ! ([] [move | | (0 , 0)]) }),
                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_110_15 ! ([] [move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } }]) }),
                                         input: Cast {
                                             inner: Tee {
-                                                inner: <shared 26>,
+                                                inner: <shared 28>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(14, Cluster(loc1v1)),
                                                     collection_kind: Stream {
@@ -5199,12 +5195,12 @@ expression: built.ir()
         ),
         input: Difference {
             pos: Tee {
-                inner: <shared 33>: FilterMap {
+                inner: <shared 35>: FilterMap {
                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_122_27 ! ([min__free = 2usize ,] [move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None }]) }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <shared 32>,
+                                inner: <shared 34>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(14, Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
@@ -5256,7 +5252,7 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 31>,
+                inner: <shared 33>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(14, Cluster(loc1v1)),
                     collection_kind: Stream {
@@ -5285,7 +5281,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 34>: Chain {
+                inner: <shared 36>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -5315,7 +5311,7 @@ expression: built.ir()
                         inner: YieldConcat {
                             inner: Batch {
                                 inner: Tee {
-                                    inner: <shared 29>,
+                                    inner: <shared 31>,
                                     metadata: HydroIrMetadata {
                                         location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                         collection_kind: Stream {
@@ -5379,13 +5375,13 @@ expression: built.ir()
             neg: Map {
                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; hydro_std :: __stageleft_quote_src_request_response_rs_39_78 ! ([] [| (key , _) | key]) }),
                 input: Tee {
-                    inner: <shared 35>: Batch {
+                    inner: <shared 37>: Batch {
                         inner: Map {
-                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_750_23 ! ([] [| k | (k , ())]) }),
+                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_754_23 ! ([] [| k | (k , ())]) }),
                             input: YieldConcat {
                                 inner: Difference {
                                     pos: Tee {
-                                        inner: <shared 33>,
+                                        inner: <shared 35>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(14, Cluster(loc1v1)),
                                             collection_kind: Stream {
@@ -5495,7 +5491,7 @@ expression: built.ir()
     },
     Null {
         input: Reference {
-            inner: <shared 36>: Tee {
+            inner: <shared 38>: Tee {
                 inner: <shared 4>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(15, Cluster(loc1v1)),
@@ -5534,7 +5530,7 @@ expression: built.ir()
                                 first: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
                                     input: Tee {
-                                        inner: <shared 37>: Batch {
+                                        inner: <shared 39>: Batch {
                                             inner: CycleSource {
                                                 cycle_id: CycleId(
                                                     2,
@@ -5608,20 +5604,20 @@ expression: built.ir()
                             },
                         },
                         right: Fold {
-                            init: stageleft :: runtime_support :: fn0_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_862_11 ! ([] [| | HashMap :: new ()]) }),
-                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_864_12 ! ([] [| map , (slot , entry) | { map . insert (slot , entry) ; }]) }),
+                            init: stageleft :: runtime_support :: fn0_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_868_11 ! ([] [| | HashMap :: new ()]) }),
+                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_870_12 ! ([] [| map , (slot , entry) | { map . insert (slot , entry) ; }]) }),
                             input: Cast {
                                 inner: Cast {
                                     inner: Batch {
                                         inner: ReduceKeyedWatermark {
-                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_850_15 ! ([] [| prev_entry , entry | { if entry . ballot > prev_entry . ballot { * prev_entry = LogValue { ballot : entry . ballot , value : entry . value , } ; } }]) }),
+                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_856_15 ! ([] [| prev_entry , entry | { if entry . ballot > prev_entry . ballot { * prev_entry = LogValue { ballot : entry . ballot , value : entry . value , } ; } }]) }),
                                             input: ObserveNonDet {
                                                 inner: Cast {
                                                     inner: YieldConcat {
                                                         inner: FilterMap {
-                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_837_23 ! ([a_max_ballot_ref__free = __hydro_singleton_ref_0 ,] [| p2a | if p2a . ballot >= * a_max_ballot_ref__free { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , })) } else { None }]) }),
+                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_842_27 ! ([a_max_ballot_ref__free = __hydro_singleton_ref_0 ,] [| p2a | if p2a . ballot >= * a_max_ballot_ref__free { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , } ,)) } else { None }]) }),
                                                             input: Tee {
-                                                                inner: <shared 28>,
+                                                                inner: <shared 30>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(2, Cluster(loc2v1)),
                                                                     collection_kind: Stream {
@@ -5676,7 +5672,7 @@ expression: built.ir()
                                                 },
                                             },
                                             watermark: Tee {
-                                                inner: <shared 37>,
+                                                inner: <shared 39>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(2, Cluster(loc2v1)),
                                                     collection_kind: Optional {
@@ -5771,11 +5767,11 @@ expression: built.ir()
             3,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_764_21 ! ([] [| (_ , ballot) | ballot]) }),
+            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_768_21 ! ([] [| (_ , ballot) | ballot]) }),
             input: FilterMap {
                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_151_32 ! ([] [move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , }]) }),
                 input: Tee {
-                    inner: <shared 27>,
+                    inner: <shared 29>,
                     metadata: HydroIrMetadata {
                         location_id: Cluster(loc1v1),
                         collection_kind: Stream {
@@ -5827,7 +5823,7 @@ expression: built.ir()
                         right: Filter {
                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_34 ! ([] [| b | * b]) }),
                             input: Tee {
-                                inner: <shared 18>,
+                                inner: <shared 20>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(15, Cluster(loc1v1)),
                                     collection_kind: Singleton {
@@ -5892,7 +5888,7 @@ expression: built.ir()
                 f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_49_12 ! ([] [| (sorted_payload , highest_seq) | sorted_payload . seq > * highest_seq]) }),
                 input: CrossSingleton {
                     left: Tee {
-                        inner: <shared 38>: Sort {
+                        inner: <shared 40>: Sort {
                             input: Chain {
                                 first: Batch {
                                     inner: Map {
@@ -6038,13 +6034,13 @@ expression: built.ir()
                                                                     },
                                                                     right: Batch {
                                                                         inner: Map {
-                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_762_29 ! ([] [| ((slot , _ballot) , (value , _)) | (slot , value)]) }),
+                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_766_29 ! ([] [| ((slot , _ballot) , (value , _)) | (slot , value)]) }),
                                                                             input: YieldConcat {
                                                                                 inner: Map {
                                                                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; hydro_std :: __stageleft_quote_src_request_response_rs_37_20 ! ([] [| (key , (meta , resp)) | (key , (meta , resp))]) }),
                                                                                     input: JoinHalf {
                                                                                         left: Tee {
-                                                                                            inner: <shared 34>,
+                                                                                            inner: <shared 36>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
@@ -6056,7 +6052,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         right: Tee {
-                                                                                            inner: <shared 35>,
+                                                                                            inner: <shared 37>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
@@ -6267,12 +6263,12 @@ expression: built.ir()
                     },
                     right: Cast {
                         inner: Tee {
-                            inner: <shared 39>: Fold {
+                            inner: <shared 41>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_31_15 ! ([] [| | 0]) }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_32_15 ! ([] [| new_next_slot , (sorted_payload , next_slot) | { if sorted_payload . seq == std :: cmp :: max (* new_next_slot , next_slot) { * new_next_slot = sorted_payload . seq + 1 ; } }]) }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 38>,
+                                        inner: <shared 40>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(17, Cluster(loc5v1)),
                                             collection_kind: Stream {
@@ -6422,7 +6418,7 @@ expression: built.ir()
             17,
         ),
         input: Tee {
-            inner: <shared 40>: Map {
+            inner: <shared 42>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_78_40 ! ([] [| (_kv_store , next_slot) | next_slot]) }),
                 input: Batch {
                     inner: Fold {
@@ -6430,13 +6426,13 @@ expression: built.ir()
                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_69_15 ! ([] [| (kv_store , next_slot) , payload | { if let Some (kv) = payload . kv { kv_store . insert (kv . key , kv . value) ; } * next_slot = payload . seq + 1 ; }]) }),
                         input: YieldConcat {
                             inner: Tee {
-                                inner: <shared 41>: Map {
+                                inner: <shared 43>: Map {
                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_45_16 ! ([] [| (sorted_payload , _) | { sorted_payload }]) }),
                                     input: Filter {
                                         f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_43_12 ! ([] [| (sorted_payload , highest_seq) | sorted_payload . seq < * highest_seq]) }),
                                         input: CrossSingleton {
                                             left: Tee {
-                                                inner: <shared 38>,
+                                                inner: <shared 40>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(17, Cluster(loc5v1)),
                                                     collection_kind: Stream {
@@ -6449,7 +6445,7 @@ expression: built.ir()
                                             },
                                             right: Cast {
                                                 inner: Tee {
-                                                    inner: <shared 39>,
+                                                    inner: <shared 41>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(17, Cluster(loc5v1)),
                                                         collection_kind: Singleton {
@@ -6555,7 +6551,7 @@ expression: built.ir()
             18,
         ),
         input: Tee {
-            inner: <shared 42>: FilterMap {
+            inner: <shared 44>: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , usize) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_95_12 ! ([checkpoint_frequency__free = 1000usize ,] [move | (max_checkpointed_seq , next_slot) | if max_checkpointed_seq . map (| m | next_slot - m >= checkpoint_frequency__free) . unwrap_or (true) { Some (next_slot) } else { None }]) }),
                 input: Cast {
                     inner: CrossSingleton {
@@ -6674,7 +6670,7 @@ expression: built.ir()
                                 first: DeferTick {
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <shared 40>,
+                                            inner: <shared 42>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(17, Cluster(loc5v1)),
                                                 collection_kind: Singleton {
@@ -6785,7 +6781,7 @@ expression: built.ir()
                                 left: Cast {
                                     inner: Cast {
                                         inner: Tee {
-                                            inner: <shared 43>: Batch {
+                                            inner: <shared 45>: Batch {
                                                 inner: ReduceKeyed {
                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_bench_rs_73_24 ! ([] [| curr_seq , seq | { if seq > * curr_seq { * curr_seq = seq ; } }]) }),
                                                     input: Network {
@@ -6926,7 +6922,7 @@ expression: built.ir()
                                                                         inner: YieldConcat {
                                                                             inner: Cast {
                                                                                 inner: Tee {
-                                                                                    inner: <shared 42>,
+                                                                                    inner: <shared 44>,
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Tick(17, Cluster(loc5v1)),
                                                                                         collection_kind: Optional {
@@ -7067,7 +7063,7 @@ expression: built.ir()
                                                 inner: Cast {
                                                     inner: Cast {
                                                         inner: Tee {
-                                                            inner: <shared 43>,
+                                                            inner: <shared 45>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(19, Cluster(loc2v1)),
                                                                 collection_kind: KeyedSingleton {
@@ -7198,7 +7194,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 44>: Chain {
+                inner: <shared 46>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -7226,7 +7222,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <shared 45>: Map {
+                            inner: <shared 47>: Map {
                                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , i32) , core :: result :: Result < () , () >)) , ((u32 , i32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
                                 input: Cast {
                                     inner: Network {
@@ -7248,7 +7244,7 @@ expression: built.ir()
                                                     inner: FilterMap {
                                                         f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_108_23 ! ([] [| payload | payload . kv]) }),
                                                         input: Tee {
-                                                            inner: <shared 41>,
+                                                            inner: <shared 43>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(17, Cluster(loc5v1)),
                                                                 collection_kind: Stream {
@@ -7372,17 +7368,17 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 46>: FilterMap {
+                inner: <shared 48>: FilterMap {
                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , i32) , (usize , usize)) , core :: option :: Option < (u32 , i32) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_122_27 ! ([min__free = 2usize ,] [move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None }]) }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <shared 47>: FoldKeyed {
+                                inner: <shared 49>: FoldKeyed {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_109_15 ! ([] [move | | (0 , 0)]) }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_110_15 ! ([] [move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } }]) }),
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <shared 44>,
+                                            inner: <shared 46>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(20, Cluster(loc3v1)),
                                                 collection_kind: Stream {
@@ -7510,7 +7506,7 @@ expression: built.ir()
         input: FilterMap {
             f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , i32) , core :: result :: Result < () , () >) , core :: option :: Option < ((u32 , i32) , ()) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_151_32 ! ([] [move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , }]) }),
             input: Tee {
-                inner: <shared 45>,
+                inner: <shared 47>,
                 metadata: HydroIrMetadata {
                     location_id: Cluster(loc3v1),
                     collection_kind: Stream {
@@ -7538,10 +7534,10 @@ expression: built.ir()
             1,
         ),
         input: Tee {
-            inner: <shared 48>: Cast {
+            inner: <shared 50>: Cast {
                 inner: YieldConcat {
                     inner: Tee {
-                        inner: <shared 46>,
+                        inner: <shared 48>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(20, Cluster(loc3v1)),
                             collection_kind: Stream {
@@ -7596,11 +7592,11 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_183_20 ! ([] [| (new , old) | { old . borrow_mut () . add (new) . expect ("Error adding value to histogram") ; old }]) }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 49>: Fold {
+                            inner: <shared 51>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_153_15 ! ([] [move | | Histogram :: < u64 > :: new (3) . unwrap ()]) }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , core :: time :: Duration , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_154_15 ! ([] [move | latencies , latency | { latencies . record (latency . as_nanos () as u64) . unwrap () ; }]) }),
                                 input: Tee {
-                                    inner: <shared 50>: Batch {
+                                    inner: <shared 52>: Batch {
                                         inner: Map {
                                             f: stageleft :: runtime_support :: fnmut1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_bench_rs_118_12 ! ([] [| (_virtual_client_id , (_output , latency)) | latency]) }),
                                             input: Cast {
@@ -7620,7 +7616,7 @@ expression: built.ir()
                                                                                                 init: stageleft :: runtime_support :: fn0_type_hint :: < std :: time :: Instant > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_101_11 ! ([] [| | Instant :: now ()]) }),
                                                                                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: time :: Instant , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_103_12 ! ([] [| curr , _new | { * curr = Instant :: now () ; }]) }),
                                                                                                 input: Tee {
-                                                                                                    inner: <shared 16>,
+                                                                                                    inner: <shared 18>,
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Cluster(loc3v1),
                                                                                                         collection_kind: KeyedStream {
@@ -7689,7 +7685,7 @@ expression: built.ir()
                                                                                             input: ObserveNonDet {
                                                                                                 inner: Batch {
                                                                                                     inner: Tee {
-                                                                                                        inner: <shared 48>,
+                                                                                                        inner: <shared 50>,
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_id: Cluster(loc3v1),
                                                                                                             collection_kind: KeyedStream {
@@ -7892,11 +7888,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <shared 51>: Map {
+                            inner: <shared 53>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 52>: Cast {
+                                        inner: <shared 54>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -7974,7 +7970,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_935_20 ! ([] [| _ | ()]) }),
                                                             input: Tee {
-                                                                inner: <shared 53>: Reduce {
+                                                                inner: <shared 55>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1589_23 ! ([] [| _ , _ | { }]) }),
                                                                     input: FlatMap {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1955_27 ! ([] [| d | d]) }),
@@ -8154,7 +8150,7 @@ expression: built.ir()
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_187_56 ! ([] [| histogram | Rc :: new (RefCell :: new (histogram))]) }),
                         input: Tee {
-                            inner: <shared 49>,
+                            inner: <shared 51>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(22, Cluster(loc3v1)),
                                 collection_kind: Singleton {
@@ -8207,12 +8203,12 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_174_20 ! ([] [| (new , old) | new + old]) }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 54>: Fold {
+                            inner: <shared 56>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2427_15 ! ([] [| | 0usize]) }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , core :: time :: Duration , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2429_16 ! ([] [| count , _ | * count += 1]) }),
                                 input: ObserveNonDet {
                                     inner: Tee {
-                                        inner: <shared 50>,
+                                        inner: <shared 52>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(22, Cluster(loc3v1)),
                                             collection_kind: Stream {
@@ -8251,11 +8247,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <shared 55>: Map {
+                            inner: <shared 57>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 56>: Cast {
+                                        inner: <shared 58>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -8333,7 +8329,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_935_20 ! ([] [| _ | ()]) }),
                                                             input: Tee {
-                                                                inner: <shared 53>,
+                                                                inner: <shared 55>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                     collection_kind: Optional {
@@ -8452,7 +8448,7 @@ expression: built.ir()
                 },
                 second: Cast {
                     inner: Tee {
-                        inner: <shared 54>,
+                        inner: <shared 56>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(22, Cluster(loc3v1)),
                             collection_kind: Singleton {
@@ -8498,7 +8494,7 @@ expression: built.ir()
                     left: Cast {
                         inner: CrossSingleton {
                             left: Tee {
-                                inner: <shared 57>: Cast {
+                                inner: <shared 59>: Cast {
                                     inner: ChainFirst {
                                         first: DeferTick {
                                             input: CycleSource {
@@ -8599,7 +8595,7 @@ expression: built.ir()
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                                                                         input: CrossSingleton {
                                                                                             left: Tee {
-                                                                                                inner: <shared 52>,
+                                                                                                inner: <shared 54>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                                                     collection_kind: Singleton {
@@ -8619,7 +8615,7 @@ expression: built.ir()
                                                                                                                 input: Map {
                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                                                                                     input: Tee {
-                                                                                                                        inner: <shared 53>,
+                                                                                                                        inner: <shared 55>,
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Tick(22, Cluster(loc3v1)),
                                                                                                                             collection_kind: Optional {
@@ -8888,7 +8884,7 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
                                 input: DeferTick {
                                     input: Tee {
-                                        inner: <shared 58>: Reduce {
+                                        inner: <shared 60>: Reduce {
                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1589_23 ! ([] [| _ , _ | { }]) }),
                                             input: FlatMap {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1955_27 ! ([] [| d | d]) }),
@@ -9065,7 +9061,7 @@ expression: built.ir()
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                                 input: CrossSingleton {
                                                     left: Tee {
-                                                        inner: <shared 56>,
+                                                        inner: <shared 58>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(22, Cluster(loc3v1)),
                                                             collection_kind: Singleton {
@@ -9085,7 +9081,7 @@ expression: built.ir()
                                                                         input: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                                             input: Tee {
-                                                                                inner: <shared 53>,
+                                                                                inner: <shared 55>,
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                                     collection_kind: Optional {
@@ -9254,7 +9250,7 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <shared 59>: Cast {
+                                inner: <shared 61>: Cast {
                                     inner: ChainFirst {
                                         first: DeferTick {
                                             input: CycleSource {
@@ -9332,7 +9328,7 @@ expression: built.ir()
                                                 input: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_935_20 ! ([] [| _ | ()]) }),
                                                     input: Tee {
-                                                        inner: <shared 58>,
+                                                        inner: <shared 60>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(23, Process(loc4v1)),
                                                             collection_kind: Optional {
@@ -9463,7 +9459,7 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 59>,
+                            inner: <shared 61>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(23, Process(loc4v1)),
                                 collection_kind: Singleton {
@@ -9483,7 +9479,7 @@ expression: built.ir()
                                             input: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                 input: Tee {
-                                                    inner: <shared 58>,
+                                                    inner: <shared 60>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(23, Process(loc4v1)),
                                                         collection_kind: Optional {
@@ -9608,7 +9604,7 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <shared 57>,
+                                inner: <shared 59>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(23, Process(loc4v1)),
                                     collection_kind: Singleton {
@@ -9628,7 +9624,7 @@ expression: built.ir()
                                                 input: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                     input: Tee {
-                                                        inner: <shared 58>,
+                                                        inner: <shared 60>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(23, Process(loc4v1)),
                                                             collection_kind: Optional {

--- a/hydro_test/src/cluster/snapshots-nightly/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots-nightly/paxos_ir.snap
@@ -3614,85 +3614,102 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: Reference {
+            inner: <shared 19>: Tee {
+                inner: <shared 4>,
+                metadata: HydroIrMetadata {
+                    location_id: Tick(15, Cluster(loc1v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                    },
+                },
+            },
+            kind: Singleton,
+            access_counter: Counting(
+                Cell {
+                    value: 0,
+                },
+            ),
+            metadata: HydroIrMetadata {
+                location_id: Tick(15, Cluster(loc1v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             12,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_794_20 ! ([] [| (num_payloads , base_slot) | base_slot + num_payloads]) }),
+            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_793_20 ! ([] [| (num_payloads , base_slot) | base_slot + num_payloads]) }),
             input: Cast {
                 inner: CrossSingleton {
                     left: Fold {
                         init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2427_15 ! ([] [| | 0usize]) }),
                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2429_16 ! ([] [| count , _ | * count += 1]) }),
                         input: Tee {
-                            inner: <shared 19>: Map {
-                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , usize) , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_786_20 ! ([] [| ((index , payload) , base_slot) | (base_slot + index , payload)]) }),
-                                input: CrossSingleton {
-                                    left: Enumerate {
-                                        input: Batch {
-                                            inner: YieldConcat {
-                                                inner: Map {
-                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1054_20 ! ([] [| (d , _) | d]) }),
-                                                    input: CrossSingleton {
-                                                        left: Batch {
-                                                            inner: ObserveNonDet {
-                                                                inner: Map {
-                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
-                                                                    input: Cast {
-                                                                        inner: Network {
-                                                                            name: None,
-                                                                            networking_info: Tcp {
-                                                                                fault: FailStop,
-                                                                            },
-                                                                            serialize_fn: Some(
-                                                                                hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                                            ),
-                                                                            instantiate_fn: <network instantiate>,
-                                                                            deserialize_fn: Some(
-                                                                                | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > (& b) . unwrap ()) },
-                                                                            ),
-                                                                            input: Cast {
-                                                                                inner: Map {
-                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_with_client_rs_88_24 ! ([] [move | (payload , leader_id) | (leader_id , payload)]) }),
-                                                                                    input: YieldConcat {
-                                                                                        inner: CrossSingleton {
-                                                                                            left: Tee {
-                                                                                                inner: <shared 15>,
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(11, Cluster(loc3v1)),
-                                                                                                    collection_kind: Stream {
-                                                                                                        bound: Bounded,
-                                                                                                        order: TotalOrder,
-                                                                                                        retry: ExactlyOnce,
-                                                                                                        element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
-                                                                                                    },
-                                                                                                },
-                                                                                            },
-                                                                                            right: Tee {
-                                                                                                inner: <shared 17>,
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(11, Cluster(loc3v1)),
-                                                                                                    collection_kind: Optional {
-                                                                                                        bound: Bounded,
-                                                                                                        element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                                                    },
-                                                                                                },
-                                                                                            },
+                            inner: <shared 20>: Map {
+                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_785_20 ! ([base_slot_ref__free = __hydro_singleton_ref_0 ,] [| (index , payload) | (* base_slot_ref__free + index , payload)]) }),
+                                input: Enumerate {
+                                    input: Batch {
+                                        inner: YieldConcat {
+                                            inner: Map {
+                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1054_20 ! ([] [| (d , _) | d]) }),
+                                                input: CrossSingleton {
+                                                    left: Batch {
+                                                        inner: ObserveNonDet {
+                                                            inner: Map {
+                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
+                                                                input: Cast {
+                                                                    inner: Network {
+                                                                        name: None,
+                                                                        networking_info: Tcp {
+                                                                            fault: FailStop,
+                                                                        },
+                                                                        serialize_fn: Some(
+                                                                            hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                                        ),
+                                                                        instantiate_fn: <network instantiate>,
+                                                                        deserialize_fn: Some(
+                                                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > (& b) . unwrap ()) },
+                                                                        ),
+                                                                        input: Cast {
+                                                                            inner: Map {
+                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_with_client_rs_88_24 ! ([] [move | (payload , leader_id) | (leader_id , payload)]) }),
+                                                                                input: YieldConcat {
+                                                                                    inner: CrossSingleton {
+                                                                                        left: Tee {
+                                                                                            inner: <shared 15>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(11, Cluster(loc3v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
                                                                                                     order: TotalOrder,
                                                                                                     retry: ExactlyOnce,
-                                                                                                    element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >),
+                                                                                                    element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                        right: Tee {
+                                                                                            inner: <shared 17>,
+                                                                                            metadata: HydroIrMetadata {
+                                                                                                location_id: Tick(11, Cluster(loc3v1)),
+                                                                                                collection_kind: Optional {
+                                                                                                    bound: Bounded,
+                                                                                                    element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                                 },
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Cluster(loc3v1),
+                                                                                            location_id: Tick(11, Cluster(loc3v1)),
                                                                                             collection_kind: Stream {
-                                                                                                bound: Unbounded,
+                                                                                                bound: Bounded,
                                                                                                 order: TotalOrder,
                                                                                                 retry: ExactlyOnce,
                                                                                                 element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >),
@@ -3705,39 +3722,39 @@ expression: built.ir()
                                                                                             bound: Unbounded,
                                                                                             order: TotalOrder,
                                                                                             retry: ExactlyOnce,
-                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
+                                                                                            element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >),
                                                                                         },
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Cluster(loc3v1),
-                                                                                    collection_kind: KeyedStream {
+                                                                                    collection_kind: Stream {
                                                                                         bound: Unbounded,
-                                                                                        value_order: TotalOrder,
-                                                                                        value_retry: ExactlyOnce,
-                                                                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                                        value_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                                                        order: TotalOrder,
+                                                                                        retry: ExactlyOnce,
+                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                                                                     },
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Cluster(loc1v1),
+                                                                                location_id: Cluster(loc3v1),
                                                                                 collection_kind: KeyedStream {
                                                                                     bound: Unbounded,
                                                                                     value_order: TotalOrder,
                                                                                     value_retry: ExactlyOnce,
-                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
+                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                     value_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                                                                 },
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Cluster(loc1v1),
-                                                                            collection_kind: Stream {
+                                                                            collection_kind: KeyedStream {
                                                                                 bound: Unbounded,
-                                                                                order: NoOrder,
-                                                                                retry: ExactlyOnce,
-                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
+                                                                                value_order: TotalOrder,
+                                                                                value_retry: ExactlyOnce,
+                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
+                                                                                value_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                                                             },
                                                                         },
                                                                     },
@@ -3747,48 +3764,28 @@ expression: built.ir()
                                                                             bound: Unbounded,
                                                                             order: NoOrder,
                                                                             retry: ExactlyOnce,
-                                                                            element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                                                         },
                                                                     },
                                                                 },
-                                                                trusted: false,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Cluster(loc1v1),
                                                                     collection_kind: Stream {
                                                                         bound: Unbounded,
-                                                                        order: TotalOrder,
+                                                                        order: NoOrder,
                                                                         retry: ExactlyOnce,
                                                                         element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                                                     },
                                                                 },
                                                             },
+                                                            trusted: false,
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                location_id: Cluster(loc1v1),
                                                                 collection_kind: Stream {
-                                                                    bound: Bounded,
+                                                                    bound: Unbounded,
                                                                     order: TotalOrder,
                                                                     retry: ExactlyOnce,
                                                                     element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
-                                                                },
-                                                            },
-                                                        },
-                                                        right: Filter {
-                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1053_46 ! ([] [| b | * b]) }),
-                                                            input: Tee {
-                                                                inner: <shared 13>,
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                    collection_kind: Singleton {
-                                                                        bound: Bounded,
-                                                                        element_type: bool,
-                                                                    },
-                                                                },
-                                                            },
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                collection_kind: Optional {
-                                                                    bound: Bounded,
-                                                                    element_type: bool,
                                                                 },
                                                             },
                                                         },
@@ -3798,7 +3795,27 @@ expression: built.ir()
                                                                 bound: Bounded,
                                                                 order: TotalOrder,
                                                                 retry: ExactlyOnce,
-                                                                element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool),
+                                                                element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                            },
+                                                        },
+                                                    },
+                                                    right: Filter {
+                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1053_46 ! ([] [| b | * b]) }),
+                                                        input: Tee {
+                                                            inner: <shared 13>,
+                                                            metadata: HydroIrMetadata {
+                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                collection_kind: Singleton {
+                                                                    bound: Bounded,
+                                                                    element_type: bool,
+                                                                },
+                                                            },
+                                                        },
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                            collection_kind: Optional {
+                                                                bound: Bounded,
+                                                                element_type: bool,
                                                             },
                                                         },
                                                     },
@@ -3808,14 +3825,14 @@ expression: built.ir()
                                                             bound: Bounded,
                                                             order: TotalOrder,
                                                             retry: ExactlyOnce,
-                                                            element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                            element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool),
                                                         },
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                    location_id: Tick(15, Cluster(loc1v1)),
                                                     collection_kind: Stream {
-                                                        bound: Unbounded,
+                                                        bound: Bounded,
                                                         order: TotalOrder,
                                                         retry: ExactlyOnce,
                                                         element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
@@ -3823,9 +3840,9 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                                 collection_kind: Stream {
-                                                    bound: Bounded,
+                                                    bound: Unbounded,
                                                     order: TotalOrder,
                                                     retry: ExactlyOnce,
                                                     element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
@@ -3838,318 +3855,7 @@ expression: built.ir()
                                                 bound: Bounded,
                                                 order: TotalOrder,
                                                 retry: ExactlyOnce,
-                                                element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
-                                            },
-                                        },
-                                    },
-                                    right: Cast {
-                                        inner: Tee {
-                                            inner: <shared 20>: Cast {
-                                                inner: ChainFirst {
-                                                    first: Map {
-                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_780_71 ! ([] [| s | s + 1]) }),
-                                                        input: Batch {
-                                                            inner: YieldConcat {
-                                                                inner: Tee {
-                                                                    inner: <shared 21>: Reduce {
-                                                                        f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
-                                                                        input: ObserveNonDet {
-                                                                            inner: Map {
-                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
-                                                                                input: Cast {
-                                                                                    inner: Cast {
-                                                                                        inner: Tee {
-                                                                                            inner: <shared 22>: Map {
-                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_484_23 ! ([f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_628_16 ! ([] [| (count , entry) | (count , entry . unwrap ())]) }) ,] [{ let orig = f__free ; move | (k , v) | (k , orig (v)) }]) }),
-                                                                                                input: FoldKeyed {
-                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_607_67 ! ([] [| | (0 , None)]) }),
-                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_607_85 ! ([] [| curr_entry , new_entry | { if let Some (curr_entry_payload) = & mut curr_entry . 1 { let same_values = new_entry . value == curr_entry_payload . value ; let higher_ballot = new_entry . ballot > curr_entry_payload . ballot ; if same_values { curr_entry . 0 += 1 ; } if higher_ballot { curr_entry_payload . ballot = new_entry . ballot ; if ! same_values { curr_entry . 0 = 1 ; curr_entry_payload . value = new_entry . value ; } } } else { * curr_entry = (1 , Some (new_entry)) ; } }]) }),
-                                                                                                    input: Cast {
-                                                                                                        inner: FlatMap {
-                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_764_35 ! ([] [| d | d]) }),
-                                                                                                            input: Map {
-                                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_604_16 ! ([] [| (_checkpoint , log) | log]) }),
-                                                                                                                input: Tee {
-                                                                                                                    inner: <shared 23>: FlatMap {
-                                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_571_35 ! ([] [| v | v]) }),
-                                                                                                                        input: Cast {
-                                                                                                                            inner: Tee {
-                                                                                                                                inner: <shared 14>,
-                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                    collection_kind: Optional {
-                                                                                                                                        bound: Bounded,
-                                                                                                                                        element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
-                                                                                                                                    },
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                collection_kind: Stream {
-                                                                                                                                    bound: Bounded,
-                                                                                                                                    order: TotalOrder,
-                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                    element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                            collection_kind: Stream {
-                                                                                                                                bound: Bounded,
-                                                                                                                                order: NoOrder,
-                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                        collection_kind: Stream {
-                                                                                                                            bound: Bounded,
-                                                                                                                            order: NoOrder,
-                                                                                                                            retry: ExactlyOnce,
-                                                                                                                            element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                    collection_kind: Stream {
-                                                                                                                        bound: Bounded,
-                                                                                                                        order: NoOrder,
-                                                                                                                        retry: ExactlyOnce,
-                                                                                                                        element_type: std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                            },
-                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                collection_kind: Stream {
-                                                                                                                    bound: Bounded,
-                                                                                                                    order: NoOrder,
-                                                                                                                    retry: ExactlyOnce,
-                                                                                                                    element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                                },
-                                                                                                            },
-                                                                                                        },
-                                                                                                        metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                            collection_kind: KeyedStream {
-                                                                                                                bound: Bounded,
-                                                                                                                value_order: NoOrder,
-                                                                                                                value_retry: ExactlyOnce,
-                                                                                                                key_type: usize,
-                                                                                                                value_type: hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >,
-                                                                                                            },
-                                                                                                        },
-                                                                                                    },
-                                                                                                    metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                        collection_kind: KeyedSingleton {
-                                                                                                            bound: Bounded,
-                                                                                                            key_type: usize,
-                                                                                                            value_type: (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                                                        },
-                                                                                                    },
-                                                                                                },
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                    collection_kind: KeyedSingleton {
-                                                                                                        bound: Bounded,
-                                                                                                        key_type: usize,
-                                                                                                        value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                    },
-                                                                                                },
-                                                                                            },
-                                                                                            metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                collection_kind: KeyedSingleton {
-                                                                                                    bound: Bounded,
-                                                                                                    key_type: usize,
-                                                                                                    value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                },
-                                                                                            },
-                                                                                        },
-                                                                                        metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                            collection_kind: KeyedStream {
-                                                                                                bound: Bounded,
-                                                                                                value_order: TotalOrder,
-                                                                                                value_retry: ExactlyOnce,
-                                                                                                key_type: usize,
-                                                                                                value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                            },
-                                                                                        },
-                                                                                    },
-                                                                                    metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                        collection_kind: Stream {
-                                                                                            bound: Bounded,
-                                                                                            order: NoOrder,
-                                                                                            retry: ExactlyOnce,
-                                                                                            element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
-                                                                                        },
-                                                                                    },
-                                                                                },
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                    collection_kind: Stream {
-                                                                                        bound: Bounded,
-                                                                                        order: NoOrder,
-                                                                                        retry: ExactlyOnce,
-                                                                                        element_type: usize,
-                                                                                    },
-                                                                                },
-                                                                            },
-                                                                            trusted: true,
-                                                                            metadata: HydroIrMetadata {
-                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                collection_kind: Stream {
-                                                                                    bound: Bounded,
-                                                                                    order: TotalOrder,
-                                                                                    retry: ExactlyOnce,
-                                                                                    element_type: usize,
-                                                                                },
-                                                                            },
-                                                                        },
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                            collection_kind: Optional {
-                                                                                bound: Bounded,
-                                                                                element_type: usize,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                        collection_kind: Optional {
-                                                                            bound: Bounded,
-                                                                            element_type: usize,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Atomic(Tick(15, Cluster(loc1v1))),
-                                                                    collection_kind: Optional {
-                                                                        bound: Unbounded,
-                                                                        element_type: usize,
-                                                                    },
-                                                                },
-                                                            },
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                collection_kind: Optional {
-                                                                    bound: Bounded,
-                                                                    element_type: usize,
-                                                                },
-                                                            },
-                                                        },
-                                                        metadata: HydroIrMetadata {
-                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                            collection_kind: Optional {
-                                                                bound: Bounded,
-                                                                element_type: usize,
-                                                            },
-                                                        },
-                                                    },
-                                                    second: Cast {
-                                                        inner: Cast {
-                                                            inner: ChainFirst {
-                                                                first: DeferTick {
-                                                                    input: CycleSource {
-                                                                        cycle_id: CycleId(
-                                                                            12,
-                                                                        ),
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                            collection_kind: Singleton {
-                                                                                bound: Bounded,
-                                                                                element_type: usize,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                        collection_kind: Optional {
-                                                                            bound: Bounded,
-                                                                            element_type: usize,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                second: Cast {
-                                                                    inner: SingletonSource {
-                                                                        value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_776_58 ! ([] [0]) },
-                                                                        first_tick_only: false,
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                            collection_kind: Singleton {
-                                                                                bound: Bounded,
-                                                                                element_type: usize,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                        collection_kind: Optional {
-                                                                            bound: Bounded,
-                                                                            element_type: usize,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                    collection_kind: Optional {
-                                                                        bound: Bounded,
-                                                                        element_type: usize,
-                                                                    },
-                                                                },
-                                                            },
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                collection_kind: Singleton {
-                                                                    bound: Bounded,
-                                                                    element_type: usize,
-                                                                },
-                                                            },
-                                                        },
-                                                        metadata: HydroIrMetadata {
-                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                            collection_kind: Optional {
-                                                                bound: Bounded,
-                                                                element_type: usize,
-                                                            },
-                                                        },
-                                                    },
-                                                    metadata: HydroIrMetadata {
-                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                        collection_kind: Optional {
-                                                            bound: Bounded,
-                                                            element_type: usize,
-                                                        },
-                                                    },
-                                                },
-                                                metadata: HydroIrMetadata {
-                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                    collection_kind: Singleton {
-                                                        bound: Bounded,
-                                                        element_type: usize,
-                                                    },
-                                                },
-                                            },
-                                            metadata: HydroIrMetadata {
-                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                collection_kind: Singleton {
-                                                    bound: Bounded,
-                                                    element_type: usize,
-                                                },
-                                            },
-                                        },
-                                        metadata: HydroIrMetadata {
-                                            location_id: Tick(15, Cluster(loc1v1)),
-                                            collection_kind: Optional {
-                                                bound: Bounded,
-                                                element_type: usize,
+                                                element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                             },
                                         },
                                     },
@@ -4159,7 +3865,7 @@ expression: built.ir()
                                             bound: Bounded,
                                             order: TotalOrder,
                                             retry: ExactlyOnce,
-                                            element_type: ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , usize),
+                                            element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                         },
                                     },
                                 },
@@ -4191,8 +3897,306 @@ expression: built.ir()
                             },
                         },
                     },
-                    right: Tee {
-                        inner: <shared 20>,
+                    right: Reference {
+                        inner: <shared 21>: Cast {
+                            inner: ChainFirst {
+                                first: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_779_71 ! ([] [| s | s + 1]) }),
+                                    input: Batch {
+                                        inner: YieldConcat {
+                                            inner: Tee {
+                                                inner: <shared 22>: Reduce {
+                                                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
+                                                    input: ObserveNonDet {
+                                                        inner: Map {
+                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
+                                                            input: Cast {
+                                                                inner: Cast {
+                                                                    inner: Tee {
+                                                                        inner: <shared 23>: Map {
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_484_23 ! ([f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_628_16 ! ([] [| (count , entry) | (count , entry . unwrap ())]) }) ,] [{ let orig = f__free ; move | (k , v) | (k , orig (v)) }]) }),
+                                                                            input: FoldKeyed {
+                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_607_67 ! ([] [| | (0 , None)]) }),
+                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_607_85 ! ([] [| curr_entry , new_entry | { if let Some (curr_entry_payload) = & mut curr_entry . 1 { let same_values = new_entry . value == curr_entry_payload . value ; let higher_ballot = new_entry . ballot > curr_entry_payload . ballot ; if same_values { curr_entry . 0 += 1 ; } if higher_ballot { curr_entry_payload . ballot = new_entry . ballot ; if ! same_values { curr_entry . 0 = 1 ; curr_entry_payload . value = new_entry . value ; } } } else { * curr_entry = (1 , Some (new_entry)) ; } }]) }),
+                                                                                input: Cast {
+                                                                                    inner: FlatMap {
+                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_764_35 ! ([] [| d | d]) }),
+                                                                                        input: Map {
+                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_604_16 ! ([] [| (_checkpoint , log) | log]) }),
+                                                                                            input: Tee {
+                                                                                                inner: <shared 24>: FlatMap {
+                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_571_35 ! ([] [| v | v]) }),
+                                                                                                    input: Cast {
+                                                                                                        inner: Tee {
+                                                                                                            inner: <shared 14>,
+                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                collection_kind: Optional {
+                                                                                                                    bound: Bounded,
+                                                                                                                    element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
+                                                                                                                },
+                                                                                                            },
+                                                                                                        },
+                                                                                                        metadata: HydroIrMetadata {
+                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                            collection_kind: Stream {
+                                                                                                                bound: Bounded,
+                                                                                                                order: TotalOrder,
+                                                                                                                retry: ExactlyOnce,
+                                                                                                                element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
+                                                                                                            },
+                                                                                                        },
+                                                                                                    },
+                                                                                                    metadata: HydroIrMetadata {
+                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                        collection_kind: Stream {
+                                                                                                            bound: Bounded,
+                                                                                                            order: NoOrder,
+                                                                                                            retry: ExactlyOnce,
+                                                                                                            element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                                        },
+                                                                                                    },
+                                                                                                },
+                                                                                                metadata: HydroIrMetadata {
+                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                    collection_kind: Stream {
+                                                                                                        bound: Bounded,
+                                                                                                        order: NoOrder,
+                                                                                                        retry: ExactlyOnce,
+                                                                                                        element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                            metadata: HydroIrMetadata {
+                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                collection_kind: Stream {
+                                                                                                    bound: Bounded,
+                                                                                                    order: NoOrder,
+                                                                                                    retry: ExactlyOnce,
+                                                                                                    element_type: std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >,
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                            collection_kind: Stream {
+                                                                                                bound: Bounded,
+                                                                                                order: NoOrder,
+                                                                                                retry: ExactlyOnce,
+                                                                                                element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                    metadata: HydroIrMetadata {
+                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                        collection_kind: KeyedStream {
+                                                                                            bound: Bounded,
+                                                                                            value_order: NoOrder,
+                                                                                            value_retry: ExactlyOnce,
+                                                                                            key_type: usize,
+                                                                                            value_type: hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                    collection_kind: KeyedSingleton {
+                                                                                        bound: Bounded,
+                                                                                        key_type: usize,
+                                                                                        value_type: (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                    },
+                                                                                },
+                                                                            },
+                                                                            metadata: HydroIrMetadata {
+                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                collection_kind: KeyedSingleton {
+                                                                                    bound: Bounded,
+                                                                                    key_type: usize,
+                                                                                    value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        metadata: HydroIrMetadata {
+                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                            collection_kind: KeyedSingleton {
+                                                                                bound: Bounded,
+                                                                                key_type: usize,
+                                                                                value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                    metadata: HydroIrMetadata {
+                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                        collection_kind: KeyedStream {
+                                                                            bound: Bounded,
+                                                                            value_order: TotalOrder,
+                                                                            value_retry: ExactlyOnce,
+                                                                            key_type: usize,
+                                                                            value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                        },
+                                                                    },
+                                                                },
+                                                                metadata: HydroIrMetadata {
+                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                    collection_kind: Stream {
+                                                                        bound: Bounded,
+                                                                        order: NoOrder,
+                                                                        retry: ExactlyOnce,
+                                                                        element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
+                                                                    },
+                                                                },
+                                                            },
+                                                            metadata: HydroIrMetadata {
+                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                collection_kind: Stream {
+                                                                    bound: Bounded,
+                                                                    order: NoOrder,
+                                                                    retry: ExactlyOnce,
+                                                                    element_type: usize,
+                                                                },
+                                                            },
+                                                        },
+                                                        trusted: true,
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                            collection_kind: Stream {
+                                                                bound: Bounded,
+                                                                order: TotalOrder,
+                                                                retry: ExactlyOnce,
+                                                                element_type: usize,
+                                                            },
+                                                        },
+                                                    },
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                        collection_kind: Optional {
+                                                            bound: Bounded,
+                                                            element_type: usize,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                collection_kind: Optional {
+                                                    bound: Unbounded,
+                                                    element_type: usize,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_id: Tick(15, Cluster(loc1v1)),
+                                            collection_kind: Optional {
+                                                bound: Bounded,
+                                                element_type: usize,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_id: Tick(15, Cluster(loc1v1)),
+                                        collection_kind: Optional {
+                                            bound: Bounded,
+                                            element_type: usize,
+                                        },
+                                    },
+                                },
+                                second: Cast {
+                                    inner: Cast {
+                                        inner: ChainFirst {
+                                            first: DeferTick {
+                                                input: CycleSource {
+                                                    cycle_id: CycleId(
+                                                        12,
+                                                    ),
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                        collection_kind: Singleton {
+                                                            bound: Bounded,
+                                                            element_type: usize,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            second: Cast {
+                                                inner: SingletonSource {
+                                                    value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_775_58 ! ([] [0]) },
+                                                    first_tick_only: false,
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                        collection_kind: Singleton {
+                                                            bound: Bounded,
+                                                            element_type: usize,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                collection_kind: Optional {
+                                                    bound: Bounded,
+                                                    element_type: usize,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_id: Tick(15, Cluster(loc1v1)),
+                                            collection_kind: Singleton {
+                                                bound: Bounded,
+                                                element_type: usize,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_id: Tick(15, Cluster(loc1v1)),
+                                        collection_kind: Optional {
+                                            bound: Bounded,
+                                            element_type: usize,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_id: Tick(15, Cluster(loc1v1)),
+                                    collection_kind: Optional {
+                                        bound: Bounded,
+                                        element_type: usize,
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_id: Tick(15, Cluster(loc1v1)),
+                                collection_kind: Singleton {
+                                    bound: Bounded,
+                                    element_type: usize,
+                                },
+                            },
+                        },
+                        kind: Singleton,
+                        access_counter: Counting(
+                            Cell {
+                                value: 0,
+                            },
+                        ),
                         metadata: HydroIrMetadata {
                             location_id: Tick(15, Cluster(loc1v1)),
                             collection_kind: Singleton {
@@ -4227,13 +4231,41 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: Reference {
+            inner: <shared 25>: Tee {
+                inner: <shared 10>,
+                metadata: HydroIrMetadata {
+                    location_id: Tick(2, Cluster(loc2v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                    },
+                },
+            },
+            kind: Singleton,
+            access_counter: Counting(
+                Cell {
+                    value: 0,
+                },
+            ),
+            metadata: HydroIrMetadata {
+                location_id: Tick(2, Cluster(loc2v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             13,
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 24>: Chain {
+                inner: <shared 26>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -4261,7 +4293,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <shared 25>: Map {
+                            inner: <shared 27>: Map {
                                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
                                 input: Cast {
                                     inner: Network {
@@ -4279,91 +4311,81 @@ expression: built.ir()
                                         input: Cast {
                                             inner: YieldConcat {
                                                 inner: Map {
-                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_874_16 ! ([] [| (p2a , max_ballot) | (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) }))]) }),
-                                                    input: CrossSingleton {
-                                                        left: Tee {
-                                                            inner: <shared 26>: Batch {
-                                                                inner: Map {
-                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
-                                                                    input: Cast {
-                                                                        inner: Network {
-                                                                            name: None,
-                                                                            networking_info: Tcp {
-                                                                                fault: FailStop,
-                                                                            },
-                                                                            serialize_fn: Some(
-                                                                                hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                                            ),
-                                                                            instantiate_fn: <network instantiate>,
-                                                                            deserialize_fn: Some(
-                                                                                | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > (& b) . unwrap ()) },
-                                                                            ),
-                                                                            input: YieldConcat {
-                                                                                inner: Cast {
-                                                                                    inner: CrossProduct {
-                                                                                        left: ObserveNonDet {
-                                                                                            inner: Map {
-                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
-                                                                                                input: Cast {
-                                                                                                    inner: Cast {
-                                                                                                        inner: Filter {
-                                                                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_1187_61 ! ([] [| b | * b]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
-                                                                                                            input: Batch {
-                                                                                                                inner: FoldKeyed {
-                                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_36_11 ! ([] [| | false]) }),
-                                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_37_11 ! ([] [| present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } }]) }),
-                                                                                                                    input: Cast {
-                                                                                                                        inner: Map {
-                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; hydro_lang :: __stageleft_quote_src_location_mod_rs_545_16 ! ([] [| (k , v) | (MemberId :: from_tagless (k) , v)]) }),
-                                                                                                                            input: Source {
-                                                                                                                                source: ClusterMembers(
-                                                                                                                                    Cluster(loc2v1),
-                                                                                                                                    Uninit,
-                                                                                                                                ),
-                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Cluster(loc1v1),
-                                                                                                                                    collection_kind: Stream {
-                                                                                                                                        bound: Unbounded,
-                                                                                                                                        order: TotalOrder,
-                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
-                                                                                                                                    },
-                                                                                                                                },
-                                                                                                                            },
+                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_872_16 ! ([a_max_ballot_ref__free = __hydro_singleton_ref_0 ,] [| p2a | { let max_ballot = a_max_ballot_ref__free . clone () ; (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) } ,) ,) }]) }),
+                                                    input: Tee {
+                                                        inner: <shared 28>: Batch {
+                                                            inner: Map {
+                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
+                                                                input: Cast {
+                                                                    inner: Network {
+                                                                        name: None,
+                                                                        networking_info: Tcp {
+                                                                            fault: FailStop,
+                                                                        },
+                                                                        serialize_fn: Some(
+                                                                            hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                                        ),
+                                                                        instantiate_fn: <network instantiate>,
+                                                                        deserialize_fn: Some(
+                                                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > (& b) . unwrap ()) },
+                                                                        ),
+                                                                        input: YieldConcat {
+                                                                            inner: Cast {
+                                                                                inner: CrossProduct {
+                                                                                    left: ObserveNonDet {
+                                                                                        inner: Map {
+                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
+                                                                                            input: Cast {
+                                                                                                inner: Cast {
+                                                                                                    inner: Filter {
+                                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_1187_61 ! ([] [| b | * b]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
+                                                                                                        input: Batch {
+                                                                                                            inner: FoldKeyed {
+                                                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_36_11 ! ([] [| | false]) }),
+                                                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_37_11 ! ([] [| present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } }]) }),
+                                                                                                                input: Cast {
+                                                                                                                    inner: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; hydro_lang :: __stageleft_quote_src_location_mod_rs_545_16 ! ([] [| (k , v) | (MemberId :: from_tagless (k) , v)]) }),
+                                                                                                                        input: Source {
+                                                                                                                            source: ClusterMembers(
+                                                                                                                                Cluster(loc2v1),
+                                                                                                                                Uninit,
+                                                                                                                            ),
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_id: Cluster(loc1v1),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Unbounded,
                                                                                                                                     order: TotalOrder,
                                                                                                                                     retry: ExactlyOnce,
-                                                                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                                                                                 },
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Cluster(loc1v1),
-                                                                                                                            collection_kind: KeyedStream {
+                                                                                                                            collection_kind: Stream {
                                                                                                                                 bound: Unbounded,
-                                                                                                                                value_order: TotalOrder,
-                                                                                                                                value_retry: ExactlyOnce,
-                                                                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                                value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
+                                                                                                                                order: TotalOrder,
+                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                                                                             },
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_id: Cluster(loc1v1),
-                                                                                                                        collection_kind: KeyedSingleton {
-                                                                                                                            bound: MonotonicKeys,
+                                                                                                                        collection_kind: KeyedStream {
+                                                                                                                            bound: Unbounded,
+                                                                                                                            value_order: TotalOrder,
+                                                                                                                            value_retry: ExactlyOnce,
                                                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                            value_type: bool,
+                                                                                                                            value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
                                                                                                                         },
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                                    location_id: Cluster(loc1v1),
                                                                                                                     collection_kind: KeyedSingleton {
-                                                                                                                        bound: Bounded,
+                                                                                                                        bound: MonotonicKeys,
                                                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                                                         value_type: bool,
                                                                                                                     },
@@ -4380,10 +4402,8 @@ expression: built.ir()
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_id: Tick(13, Cluster(loc1v1)),
-                                                                                                            collection_kind: KeyedStream {
+                                                                                                            collection_kind: KeyedSingleton {
                                                                                                                 bound: Bounded,
-                                                                                                                value_order: TotalOrder,
-                                                                                                                value_retry: ExactlyOnce,
                                                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                                                 value_type: bool,
                                                                                                             },
@@ -4391,11 +4411,12 @@ expression: built.ir()
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Tick(13, Cluster(loc1v1)),
-                                                                                                        collection_kind: Stream {
+                                                                                                        collection_kind: KeyedStream {
                                                                                                             bound: Bounded,
-                                                                                                            order: NoOrder,
-                                                                                                            retry: ExactlyOnce,
-                                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
+                                                                                                            value_order: TotalOrder,
+                                                                                                            value_retry: ExactlyOnce,
+                                                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                            value_type: bool,
                                                                                                         },
                                                                                                     },
                                                                                                 },
@@ -4405,58 +4426,47 @@ expression: built.ir()
                                                                                                         bound: Bounded,
                                                                                                         order: NoOrder,
                                                                                                         retry: ExactlyOnce,
-                                                                                                        element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
                                                                                                     },
                                                                                                 },
                                                                                             },
-                                                                                            trusted: true,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(13, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
-                                                                                                    order: TotalOrder,
+                                                                                                    order: NoOrder,
                                                                                                     retry: ExactlyOnce,
                                                                                                     element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                                 },
                                                                                             },
                                                                                         },
-                                                                                        right: Batch {
-                                                                                            inner: Map {
-                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_735_20 ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ,] [move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free . clone () , ballot , slot , value }]) }),
-                                                                                                input: EndAtomic {
-                                                                                                    inner: Tee {
-                                                                                                        inner: <shared 27>: YieldConcat {
-                                                                                                            inner: Map {
-                                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1054_20 ! ([] [| (d , _) | d]) }),
-                                                                                                                input: CrossSingleton {
-                                                                                                                    left: Chain {
-                                                                                                                        first: Map {
-                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_721_16 ! ([] [| ((slot , payload) , ballot) | ((slot , ballot) , Some (payload))]) }),
-                                                                                                                            input: CrossSingleton {
-                                                                                                                                left: Batch {
-                                                                                                                                    inner: YieldConcat {
-                                                                                                                                        inner: Tee {
-                                                                                                                                            inner: <shared 19>,
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Stream {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    order: TotalOrder,
-                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                    element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Atomic(Tick(15, Cluster(loc1v1))),
-                                                                                                                                            collection_kind: Stream {
-                                                                                                                                                bound: Unbounded,
-                                                                                                                                                order: TotalOrder,
-                                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                                element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
+                                                                                        trusted: true,
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_id: Tick(13, Cluster(loc1v1)),
+                                                                                            collection_kind: Stream {
+                                                                                                bound: Bounded,
+                                                                                                order: TotalOrder,
+                                                                                                retry: ExactlyOnce,
+                                                                                                element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                    right: Batch {
+                                                                                        inner: Map {
+                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_734_20 ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ,] [move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free . clone () , ballot , slot , value }]) }),
+                                                                                            input: EndAtomic {
+                                                                                                inner: Tee {
+                                                                                                    inner: <shared 29>: YieldConcat {
+                                                                                                        inner: Map {
+                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1054_20 ! ([] [| (d , _) | d]) }),
+                                                                                                            input: CrossSingleton {
+                                                                                                                left: Chain {
+                                                                                                                    first: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_720_16 ! ([p_ballot_ref__free = __hydro_singleton_ref_0 ,] [| (slot , payload) | ((slot , p_ballot_ref__free . clone ()) , Some (payload))]) }),
+                                                                                                                        input: Batch {
+                                                                                                                            inner: YieldConcat {
+                                                                                                                                inner: Tee {
+                                                                                                                                    inner: <shared 20>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Stream {
@@ -4467,32 +4477,13 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 },
-                                                                                                                                right: Cast {
-                                                                                                                                    inner: Tee {
-                                                                                                                                        inner: <shared 4>,
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                            collection_kind: Singleton {
-                                                                                                                                                bound: Bounded,
-                                                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                        collection_kind: Optional {
-                                                                                                                                            bound: Bounded,
-                                                                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                    location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                                                                                                                     collection_kind: Stream {
-                                                                                                                                        bound: Bounded,
+                                                                                                                                        bound: Unbounded,
                                                                                                                                         order: TotalOrder,
                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                        element_type: ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                                                                        element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                             },
@@ -4502,197 +4493,44 @@ expression: built.ir()
                                                                                                                                     bound: Bounded,
                                                                                                                                     order: TotalOrder,
                                                                                                                                     retry: ExactlyOnce,
-                                                                                                                                    element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                    element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                                                                                                                 },
                                                                                                                             },
                                                                                                                         },
-                                                                                                                        second: Chain {
-                                                                                                                            first: FilterMap {
-                                                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < usize >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_634_23 ! ([f__free = 1usize ,] [move | (((slot , (count , entry)) , ballot) , checkpoint) | { if count > f__free { return None ; } else if let Some (checkpoint) = checkpoint && slot <= checkpoint { return None ; } Some (((slot , ballot) , entry . value)) }]) }),
-                                                                                                                                input: CrossSingleton {
-                                                                                                                                    left: CrossSingleton {
-                                                                                                                                        left: Cast {
-                                                                                                                                            inner: Cast {
-                                                                                                                                                inner: Tee {
-                                                                                                                                                    inner: <shared 22>,
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: KeyedSingleton {
-                                                                                                                                                            bound: Bounded,
-                                                                                                                                                            key_type: usize,
-                                                                                                                                                            value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: KeyedStream {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        value_order: TotalOrder,
-                                                                                                                                                        value_retry: ExactlyOnce,
-                                                                                                                                                        key_type: usize,
-                                                                                                                                                        value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Stream {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    order: NoOrder,
-                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                    element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        right: Cast {
-                                                                                                                                            inner: Tee {
-                                                                                                                                                inner: <shared 4>,
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Singleton {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                            collection_kind: Stream {
+                                                                                                                                bound: Bounded,
+                                                                                                                                order: TotalOrder,
+                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    second: Chain {
+                                                                                                                        first: FilterMap {
+                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_634_23 ! ([f__free = 1usize , p_ballot_ref__free = __hydro_singleton_ref_0 , p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1 ,] [move | (slot , (count , entry)) | { if count > f__free { return None ; } else if let Some (checkpoint) = * p_p1b_max_checkpoint_ref__free && slot <= checkpoint { return None ; } Some (((slot , p_ballot_ref__free . clone ()) , entry . value)) }]) }),
+                                                                                                                            input: Cast {
+                                                                                                                                inner: Cast {
+                                                                                                                                    inner: Tee {
+                                                                                                                                        inner: <shared 23>,
                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                            collection_kind: Stream {
+                                                                                                                                            collection_kind: KeyedSingleton {
                                                                                                                                                 bound: Bounded,
-                                                                                                                                                order: NoOrder,
-                                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                                element_type: ((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot),
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    right: Cast {
-                                                                                                                                        inner: Tee {
-                                                                                                                                            inner: <shared 28>: Cast {
-                                                                                                                                                inner: ChainFirst {
-                                                                                                                                                    first: Map {
-                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
-                                                                                                                                                        input: Reduce {
-                                                                                                                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
-                                                                                                                                                            input: ObserveNonDet {
-                                                                                                                                                                inner: FilterMap {
-                                                                                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_600_23 ! ([] [| (checkpoint , _log) | checkpoint]) }),
-                                                                                                                                                                    input: Tee {
-                                                                                                                                                                        inner: <shared 23>,
-                                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                            collection_kind: Stream {
-                                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                                order: NoOrder,
-                                                                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                                                                element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                        collection_kind: Stream {
-                                                                                                                                                                            bound: Bounded,
-                                                                                                                                                                            order: NoOrder,
-                                                                                                                                                                            retry: ExactlyOnce,
-                                                                                                                                                                            element_type: usize,
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                                trusted: true,
-                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                        order: TotalOrder,
-                                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                                        element_type: usize,
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: usize,
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: core :: option :: Option < usize >,
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    second: Cast {
-                                                                                                                                                        inner: SingletonSource {
-                                                                                                                                                            value: :: std :: option :: Option :: None,
-                                                                                                                                                            first_tick_only: false,
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: core :: option :: Option < usize >,
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: core :: option :: Option < usize >,
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: Optional {
-                                                                                                                                                            bound: Bounded,
-                                                                                                                                                            element_type: core :: option :: Option < usize >,
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Singleton {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        element_type: core :: option :: Option < usize >,
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    element_type: core :: option :: Option < usize >,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                bound: Bounded,
-                                                                                                                                                element_type: core :: option :: Option < usize >,
+                                                                                                                                                key_type: usize,
+                                                                                                                                                value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                        collection_kind: Stream {
+                                                                                                                                        collection_kind: KeyedStream {
                                                                                                                                             bound: Bounded,
-                                                                                                                                            order: NoOrder,
-                                                                                                                                            retry: ExactlyOnce,
-                                                                                                                                            element_type: (((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < usize >),
+                                                                                                                                            value_order: TotalOrder,
+                                                                                                                                            value_retry: ExactlyOnce,
+                                                                                                                                            key_type: usize,
+                                                                                                                                            value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 },
@@ -4702,34 +4540,120 @@ expression: built.ir()
                                                                                                                                         bound: Bounded,
                                                                                                                                         order: NoOrder,
                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                        element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                             },
-                                                                                                                            second: Map {
-                                                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_658_16 ! ([] [move | (slot , ballot) | ((slot , ballot) , None)]) }),
-                                                                                                                                input: CrossSingleton {
-                                                                                                                                    left: Difference {
-                                                                                                                                        pos: FlatMap {
-                                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_649_29 ! ([] [| (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } }]) }),
-                                                                                                                                            input: Cast {
-                                                                                                                                                inner: CrossSingleton {
-                                                                                                                                                    left: Tee {
-                                                                                                                                                        inner: <shared 21>,
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: usize,
-                                                                                                                                                            },
-                                                                                                                                                        },
+                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                collection_kind: Stream {
+                                                                                                                                    bound: Bounded,
+                                                                                                                                    order: NoOrder,
+                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                    element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        second: Map {
+                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < usize , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_657_16 ! ([p_ballot_ref__free = __hydro_singleton_ref_0 ,] [move | slot | ((slot , p_ballot_ref__free . clone ()) , None)]) }),
+                                                                                                                            input: Difference {
+                                                                                                                                pos: FlatMap {
+                                                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_649_29 ! ([] [| (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } }]) }),
+                                                                                                                                    input: Cast {
+                                                                                                                                        inner: CrossSingleton {
+                                                                                                                                            left: Tee {
+                                                                                                                                                inner: <shared 22>,
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    collection_kind: Optional {
+                                                                                                                                                        bound: Bounded,
+                                                                                                                                                        element_type: usize,
                                                                                                                                                     },
-                                                                                                                                                    right: Cast {
-                                                                                                                                                        inner: Tee {
-                                                                                                                                                            inner: <shared 28>,
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            right: Cast {
+                                                                                                                                                inner: Reference {
+                                                                                                                                                    inner: <shared 30>: Cast {
+                                                                                                                                                        inner: ChainFirst {
+                                                                                                                                                            first: Map {
+                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
+                                                                                                                                                                input: Reduce {
+                                                                                                                                                                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
+                                                                                                                                                                    input: ObserveNonDet {
+                                                                                                                                                                        inner: FilterMap {
+                                                                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_600_23 ! ([] [| (checkpoint , _log) | checkpoint]) }),
+                                                                                                                                                                            input: Tee {
+                                                                                                                                                                                inner: <shared 24>,
+                                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                                    collection_kind: Stream {
+                                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                                        order: NoOrder,
+                                                                                                                                                                                        retry: ExactlyOnce,
+                                                                                                                                                                                        element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                                                                                                                    },
+                                                                                                                                                                                },
+                                                                                                                                                                            },
+                                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                                                    bound: Bounded,
+                                                                                                                                                                                    order: NoOrder,
+                                                                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                                                                    element_type: usize,
+                                                                                                                                                                                },
+                                                                                                                                                                            },
+                                                                                                                                                                        },
+                                                                                                                                                                        trusted: true,
+                                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                                                bound: Bounded,
+                                                                                                                                                                                order: TotalOrder,
+                                                                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                                                                element_type: usize,
+                                                                                                                                                                            },
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                        collection_kind: Optional {
+                                                                                                                                                                            bound: Bounded,
+                                                                                                                                                                            element_type: usize,
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                    collection_kind: Optional {
+                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                        element_type: core :: option :: Option < usize >,
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                            second: Cast {
+                                                                                                                                                                inner: SingletonSource {
+                                                                                                                                                                    value: :: std :: option :: Option :: None,
+                                                                                                                                                                    first_tick_only: false,
+                                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                        collection_kind: Singleton {
+                                                                                                                                                                            bound: Bounded,
+                                                                                                                                                                            element_type: core :: option :: Option < usize >,
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                    collection_kind: Optional {
+                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                        element_type: core :: option :: Option < usize >,
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                            },
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Singleton {
+                                                                                                                                                                collection_kind: Optional {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: core :: option :: Option < usize >,
                                                                                                                                                                 },
@@ -4737,83 +4661,39 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
+                                                                                                                                                            collection_kind: Singleton {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: core :: option :: Option < usize >,
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                     },
+                                                                                                                                                    kind: Singleton,
+                                                                                                                                                    access_counter: Counting(
+                                                                                                                                                        Cell {
+                                                                                                                                                            value: 0,
+                                                                                                                                                        },
+                                                                                                                                                    ),
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: Optional {
+                                                                                                                                                        collection_kind: Singleton {
                                                                                                                                                             bound: Bounded,
-                                                                                                                                                            element_type: (usize , core :: option :: Option < usize >),
+                                                                                                                                                            element_type: core :: option :: Option < usize >,
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Stream {
+                                                                                                                                                    collection_kind: Optional {
                                                                                                                                                         bound: Bounded,
-                                                                                                                                                        order: TotalOrder,
-                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                        element_type: (usize , core :: option :: Option < usize >),
+                                                                                                                                                        element_type: core :: option :: Option < usize >,
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                collection_kind: Optional {
                                                                                                                                                     bound: Bounded,
-                                                                                                                                                    order: TotalOrder,
-                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                    element_type: usize,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        neg: Map {
-                                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
-                                                                                                                                            input: Cast {
-                                                                                                                                                inner: Cast {
-                                                                                                                                                    inner: Tee {
-                                                                                                                                                        inner: <shared 22>,
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: KeyedSingleton {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                key_type: usize,
-                                                                                                                                                                value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: KeyedStream {
-                                                                                                                                                            bound: Bounded,
-                                                                                                                                                            value_order: TotalOrder,
-                                                                                                                                                            value_retry: ExactlyOnce,
-                                                                                                                                                            key_type: usize,
-                                                                                                                                                            value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        order: NoOrder,
-                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                        element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Stream {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    order: NoOrder,
-                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                    element_type: usize,
+                                                                                                                                                    element_type: (usize , core :: option :: Option < usize >),
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                         },
@@ -4823,26 +4703,7 @@ expression: built.ir()
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 order: TotalOrder,
                                                                                                                                                 retry: ExactlyOnce,
-                                                                                                                                                element_type: usize,
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    right: Cast {
-                                                                                                                                        inner: Tee {
-                                                                                                                                            inner: <shared 4>,
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                bound: Bounded,
-                                                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                                                element_type: (usize , core :: option :: Option < usize >),
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                     },
@@ -4852,7 +4713,53 @@ expression: built.ir()
                                                                                                                                             bound: Bounded,
                                                                                                                                             order: TotalOrder,
                                                                                                                                             retry: ExactlyOnce,
-                                                                                                                                            element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                                                                            element_type: usize,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                neg: Map {
+                                                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
+                                                                                                                                    input: Cast {
+                                                                                                                                        inner: Cast {
+                                                                                                                                            inner: Tee {
+                                                                                                                                                inner: <shared 23>,
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    collection_kind: KeyedSingleton {
+                                                                                                                                                        bound: Bounded,
+                                                                                                                                                        key_type: usize,
+                                                                                                                                                        value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                collection_kind: KeyedStream {
+                                                                                                                                                    bound: Bounded,
+                                                                                                                                                    value_order: TotalOrder,
+                                                                                                                                                    value_retry: ExactlyOnce,
+                                                                                                                                                    key_type: usize,
+                                                                                                                                                    value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                bound: Bounded,
+                                                                                                                                                order: NoOrder,
+                                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                                element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        collection_kind: Stream {
+                                                                                                                                            bound: Bounded,
+                                                                                                                                            order: NoOrder,
+                                                                                                                                            retry: ExactlyOnce,
+                                                                                                                                            element_type: usize,
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 },
@@ -4862,7 +4769,7 @@ expression: built.ir()
                                                                                                                                         bound: Bounded,
                                                                                                                                         order: TotalOrder,
                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                        element_type: usize,
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                             },
@@ -4870,7 +4777,7 @@ expression: built.ir()
                                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Bounded,
-                                                                                                                                    order: NoOrder,
+                                                                                                                                    order: TotalOrder,
                                                                                                                                     retry: ExactlyOnce,
                                                                                                                                     element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                                 },
@@ -4886,21 +4793,23 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                     },
-                                                                                                                    right: Filter {
-                                                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1053_46 ! ([] [| b | * b]) }),
-                                                                                                                        input: Tee {
-                                                                                                                            inner: <shared 13>,
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                collection_kind: Singleton {
-                                                                                                                                    bound: Bounded,
-                                                                                                                                    element_type: bool,
-                                                                                                                                },
-                                                                                                                            },
+                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                        collection_kind: Stream {
+                                                                                                                            bound: Bounded,
+                                                                                                                            order: NoOrder,
+                                                                                                                            retry: ExactlyOnce,
+                                                                                                                            element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                         },
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                right: Filter {
+                                                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1053_46 ! ([] [| b | * b]) }),
+                                                                                                                    input: Tee {
+                                                                                                                        inner: <shared 13>,
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                            collection_kind: Optional {
+                                                                                                                            collection_kind: Singleton {
                                                                                                                                 bound: Bounded,
                                                                                                                                 element_type: bool,
                                                                                                                             },
@@ -4908,11 +4817,9 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                        collection_kind: Stream {
+                                                                                                                        collection_kind: Optional {
                                                                                                                             bound: Bounded,
-                                                                                                                            order: NoOrder,
-                                                                                                                            retry: ExactlyOnce,
-                                                                                                                            element_type: (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool),
+                                                                                                                            element_type: bool,
                                                                                                                         },
                                                                                                                     },
                                                                                                                 },
@@ -4922,14 +4829,14 @@ expression: built.ir()
                                                                                                                         bound: Bounded,
                                                                                                                         order: NoOrder,
                                                                                                                         retry: ExactlyOnce,
-                                                                                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                        element_type: (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool),
                                                                                                                     },
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                 collection_kind: Stream {
-                                                                                                                    bound: Unbounded,
+                                                                                                                    bound: Bounded,
                                                                                                                     order: NoOrder,
                                                                                                                     retry: ExactlyOnce,
                                                                                                                     element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
@@ -4947,7 +4854,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Cluster(loc1v1),
+                                                                                                        location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Unbounded,
                                                                                                             order: NoOrder,
@@ -4962,14 +4869,14 @@ expression: built.ir()
                                                                                                         bound: Unbounded,
                                                                                                         order: NoOrder,
                                                                                                         retry: ExactlyOnce,
-                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                     },
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                location_id: Cluster(loc1v1),
                                                                                                 collection_kind: Stream {
-                                                                                                    bound: Bounded,
+                                                                                                    bound: Unbounded,
                                                                                                     order: NoOrder,
                                                                                                     retry: ExactlyOnce,
                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -4982,25 +4889,24 @@ expression: built.ir()
                                                                                                 bound: Bounded,
                                                                                                 order: NoOrder,
                                                                                                 retry: ExactlyOnce,
-                                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
+                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                             },
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Tick(13, Cluster(loc1v1)),
-                                                                                        collection_kind: KeyedStream {
+                                                                                        collection_kind: Stream {
                                                                                             bound: Bounded,
-                                                                                            value_order: NoOrder,
-                                                                                            value_retry: ExactlyOnce,
-                                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                            value_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                            order: NoOrder,
+                                                                                            retry: ExactlyOnce,
+                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
                                                                                         },
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Cluster(loc1v1),
+                                                                                    location_id: Tick(13, Cluster(loc1v1)),
                                                                                     collection_kind: KeyedStream {
-                                                                                        bound: Unbounded,
+                                                                                        bound: Bounded,
                                                                                         value_order: NoOrder,
                                                                                         value_retry: ExactlyOnce,
                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -5009,23 +4915,24 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Cluster(loc2v1),
+                                                                                location_id: Cluster(loc1v1),
                                                                                 collection_kind: KeyedStream {
                                                                                     bound: Unbounded,
                                                                                     value_order: NoOrder,
                                                                                     value_retry: ExactlyOnce,
-                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                     value_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                 },
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Cluster(loc2v1),
-                                                                            collection_kind: Stream {
+                                                                            collection_kind: KeyedStream {
                                                                                 bound: Unbounded,
-                                                                                order: NoOrder,
-                                                                                retry: ExactlyOnce,
-                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
+                                                                                value_order: NoOrder,
+                                                                                value_retry: ExactlyOnce,
+                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                value_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                             },
                                                                         },
                                                                     },
@@ -5035,14 +4942,14 @@ expression: built.ir()
                                                                             bound: Unbounded,
                                                                             order: NoOrder,
                                                                             retry: ExactlyOnce,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
                                                                         },
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
+                                                                    location_id: Cluster(loc2v1),
                                                                     collection_kind: Stream {
-                                                                        bound: Bounded,
+                                                                        bound: Unbounded,
                                                                         order: NoOrder,
                                                                         retry: ExactlyOnce,
                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -5059,32 +4966,13 @@ expression: built.ir()
                                                                 },
                                                             },
                                                         },
-                                                        right: Cast {
-                                                            inner: Tee {
-                                                                inner: <shared 10>,
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
-                                                                    collection_kind: Singleton {
-                                                                        bound: Bounded,
-                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                    },
-                                                                },
-                                                            },
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(2, Cluster(loc2v1)),
-                                                                collection_kind: Optional {
-                                                                    bound: Bounded,
-                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                },
-                                                            },
-                                                        },
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(2, Cluster(loc2v1)),
                                                             collection_kind: Stream {
                                                                 bound: Bounded,
                                                                 order: NoOrder,
                                                                 retry: ExactlyOnce,
-                                                                element_type: (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                             },
                                                         },
                                                     },
@@ -5191,19 +5079,19 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 29>: Map {
+                inner: <shared 31>: Map {
                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_134_27 ! ([max__free = 3usize ,] [move | (success , error) | (success + error) >= max__free]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
                                 input: Tee {
-                                    inner: <shared 30>: FoldKeyed {
+                                    inner: <shared 32>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_109_15 ! ([] [move | | (0 , 0)]) }),
                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_110_15 ! ([] [move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } }]) }),
                                         input: Cast {
                                             inner: Tee {
-                                                inner: <shared 24>,
+                                                inner: <shared 26>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(14, Cluster(loc1v1)),
                                                     collection_kind: Stream {
@@ -5311,12 +5199,12 @@ expression: built.ir()
         ),
         input: Difference {
             pos: Tee {
-                inner: <shared 31>: FilterMap {
+                inner: <shared 33>: FilterMap {
                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_122_27 ! ([min__free = 2usize ,] [move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None }]) }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <shared 30>,
+                                inner: <shared 32>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(14, Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
@@ -5368,7 +5256,7 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 29>,
+                inner: <shared 31>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(14, Cluster(loc1v1)),
                     collection_kind: Stream {
@@ -5397,7 +5285,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 32>: Chain {
+                inner: <shared 34>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -5427,7 +5315,7 @@ expression: built.ir()
                         inner: YieldConcat {
                             inner: Batch {
                                 inner: Tee {
-                                    inner: <shared 27>,
+                                    inner: <shared 29>,
                                     metadata: HydroIrMetadata {
                                         location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                         collection_kind: Stream {
@@ -5491,13 +5379,13 @@ expression: built.ir()
             neg: Map {
                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; hydro_std :: __stageleft_quote_src_request_response_rs_39_78 ! ([] [| (key , _) | key]) }),
                 input: Tee {
-                    inner: <shared 33>: Batch {
+                    inner: <shared 35>: Batch {
                         inner: Map {
-                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_751_23 ! ([] [| k | (k , ())]) }),
+                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_750_23 ! ([] [| k | (k , ())]) }),
                             input: YieldConcat {
                                 inner: Difference {
                                     pos: Tee {
-                                        inner: <shared 31>,
+                                        inner: <shared 33>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(14, Cluster(loc1v1)),
                                             collection_kind: Stream {
@@ -5605,6 +5493,34 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: Reference {
+            inner: <shared 36>: Tee {
+                inner: <shared 4>,
+                metadata: HydroIrMetadata {
+                    location_id: Tick(15, Cluster(loc1v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                    },
+                },
+            },
+            kind: Singleton,
+            access_counter: Counting(
+                Cell {
+                    value: 0,
+                },
+            ),
+            metadata: HydroIrMetadata {
+                location_id: Tick(15, Cluster(loc1v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             4,
@@ -5618,7 +5534,7 @@ expression: built.ir()
                                 first: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
                                     input: Tee {
-                                        inner: <shared 34>: Batch {
+                                        inner: <shared 37>: Batch {
                                             inner: CycleSource {
                                                 cycle_id: CycleId(
                                                     2,
@@ -5692,57 +5608,27 @@ expression: built.ir()
                             },
                         },
                         right: Fold {
-                            init: stageleft :: runtime_support :: fn0_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_863_11 ! ([] [| | HashMap :: new ()]) }),
-                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_865_12 ! ([] [| map , (slot , entry) | { map . insert (slot , entry) ; }]) }),
+                            init: stageleft :: runtime_support :: fn0_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_862_11 ! ([] [| | HashMap :: new ()]) }),
+                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_864_12 ! ([] [| map , (slot , entry) | { map . insert (slot , entry) ; }]) }),
                             input: Cast {
                                 inner: Cast {
                                     inner: Batch {
                                         inner: ReduceKeyedWatermark {
-                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_851_15 ! ([] [| prev_entry , entry | { if entry . ballot > prev_entry . ballot { * prev_entry = LogValue { ballot : entry . ballot , value : entry . value , } ; } }]) }),
+                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_850_15 ! ([] [| prev_entry , entry | { if entry . ballot > prev_entry . ballot { * prev_entry = LogValue { ballot : entry . ballot , value : entry . value , } ; } }]) }),
                                             input: ObserveNonDet {
                                                 inner: Cast {
                                                     inner: YieldConcat {
                                                         inner: FilterMap {
-                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_838_23 ! ([] [| (p2a , max_ballot) | if p2a . ballot >= max_ballot { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , })) } else { None }]) }),
-                                                            input: CrossSingleton {
-                                                                left: Tee {
-                                                                    inner: <shared 26>,
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                        collection_kind: Stream {
-                                                                            bound: Bounded,
-                                                                            order: NoOrder,
-                                                                            retry: ExactlyOnce,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                right: Cast {
-                                                                    inner: Tee {
-                                                                        inner: <shared 10>,
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Cluster(loc2v1)),
-                                                                            collection_kind: Singleton {
-                                                                                bound: Bounded,
-                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                        collection_kind: Optional {
-                                                                            bound: Bounded,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                        },
-                                                                    },
-                                                                },
+                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_837_23 ! ([a_max_ballot_ref__free = __hydro_singleton_ref_0 ,] [| p2a | if p2a . ballot >= * a_max_ballot_ref__free { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , })) } else { None }]) }),
+                                                            input: Tee {
+                                                                inner: <shared 28>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(2, Cluster(loc2v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: NoOrder,
                                                                         retry: ExactlyOnce,
-                                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                     },
                                                                 },
                                                             },
@@ -5790,7 +5676,7 @@ expression: built.ir()
                                                 },
                                             },
                                             watermark: Tee {
-                                                inner: <shared 34>,
+                                                inner: <shared 37>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(2, Cluster(loc2v1)),
                                                     collection_kind: Optional {
@@ -5885,11 +5771,11 @@ expression: built.ir()
             3,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_765_21 ! ([] [| (_ , ballot) | ballot]) }),
+            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_764_21 ! ([] [| (_ , ballot) | ballot]) }),
             input: FilterMap {
                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_151_32 ! ([] [move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , }]) }),
                 input: Tee {
-                    inner: <shared 25>,
+                    inner: <shared 27>,
                     metadata: HydroIrMetadata {
                         location_id: Cluster(loc1v1),
                         collection_kind: Stream {
@@ -6006,7 +5892,7 @@ expression: built.ir()
                 f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_49_12 ! ([] [| (sorted_payload , highest_seq) | sorted_payload . seq > * highest_seq]) }),
                 input: CrossSingleton {
                     left: Tee {
-                        inner: <shared 35>: Sort {
+                        inner: <shared 38>: Sort {
                             input: Chain {
                                 first: Batch {
                                     inner: Map {
@@ -6152,13 +6038,13 @@ expression: built.ir()
                                                                     },
                                                                     right: Batch {
                                                                         inner: Map {
-                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_763_29 ! ([] [| ((slot , _ballot) , (value , _)) | (slot , value)]) }),
+                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_762_29 ! ([] [| ((slot , _ballot) , (value , _)) | (slot , value)]) }),
                                                                             input: YieldConcat {
                                                                                 inner: Map {
                                                                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; hydro_std :: __stageleft_quote_src_request_response_rs_37_20 ! ([] [| (key , (meta , resp)) | (key , (meta , resp))]) }),
                                                                                     input: JoinHalf {
                                                                                         left: Tee {
-                                                                                            inner: <shared 32>,
+                                                                                            inner: <shared 34>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
@@ -6170,7 +6056,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         right: Tee {
-                                                                                            inner: <shared 33>,
+                                                                                            inner: <shared 35>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
@@ -6381,12 +6267,12 @@ expression: built.ir()
                     },
                     right: Cast {
                         inner: Tee {
-                            inner: <shared 36>: Fold {
+                            inner: <shared 39>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_31_15 ! ([] [| | 0]) }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_32_15 ! ([] [| new_next_slot , (sorted_payload , next_slot) | { if sorted_payload . seq == std :: cmp :: max (* new_next_slot , next_slot) { * new_next_slot = sorted_payload . seq + 1 ; } }]) }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 35>,
+                                        inner: <shared 38>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(17, Cluster(loc5v1)),
                                             collection_kind: Stream {
@@ -6536,7 +6422,7 @@ expression: built.ir()
             17,
         ),
         input: Tee {
-            inner: <shared 37>: Map {
+            inner: <shared 40>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_78_40 ! ([] [| (_kv_store , next_slot) | next_slot]) }),
                 input: Batch {
                     inner: Fold {
@@ -6544,13 +6430,13 @@ expression: built.ir()
                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_69_15 ! ([] [| (kv_store , next_slot) , payload | { if let Some (kv) = payload . kv { kv_store . insert (kv . key , kv . value) ; } * next_slot = payload . seq + 1 ; }]) }),
                         input: YieldConcat {
                             inner: Tee {
-                                inner: <shared 38>: Map {
+                                inner: <shared 41>: Map {
                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_45_16 ! ([] [| (sorted_payload , _) | { sorted_payload }]) }),
                                     input: Filter {
                                         f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_43_12 ! ([] [| (sorted_payload , highest_seq) | sorted_payload . seq < * highest_seq]) }),
                                         input: CrossSingleton {
                                             left: Tee {
-                                                inner: <shared 35>,
+                                                inner: <shared 38>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(17, Cluster(loc5v1)),
                                                     collection_kind: Stream {
@@ -6563,7 +6449,7 @@ expression: built.ir()
                                             },
                                             right: Cast {
                                                 inner: Tee {
-                                                    inner: <shared 36>,
+                                                    inner: <shared 39>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(17, Cluster(loc5v1)),
                                                         collection_kind: Singleton {
@@ -6669,7 +6555,7 @@ expression: built.ir()
             18,
         ),
         input: Tee {
-            inner: <shared 39>: FilterMap {
+            inner: <shared 42>: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , usize) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_95_12 ! ([checkpoint_frequency__free = 1000usize ,] [move | (max_checkpointed_seq , next_slot) | if max_checkpointed_seq . map (| m | next_slot - m >= checkpoint_frequency__free) . unwrap_or (true) { Some (next_slot) } else { None }]) }),
                 input: Cast {
                     inner: CrossSingleton {
@@ -6788,7 +6674,7 @@ expression: built.ir()
                                 first: DeferTick {
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <shared 37>,
+                                            inner: <shared 40>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(17, Cluster(loc5v1)),
                                                 collection_kind: Singleton {
@@ -6899,7 +6785,7 @@ expression: built.ir()
                                 left: Cast {
                                     inner: Cast {
                                         inner: Tee {
-                                            inner: <shared 40>: Batch {
+                                            inner: <shared 43>: Batch {
                                                 inner: ReduceKeyed {
                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_bench_rs_73_24 ! ([] [| curr_seq , seq | { if seq > * curr_seq { * curr_seq = seq ; } }]) }),
                                                     input: Network {
@@ -7040,7 +6926,7 @@ expression: built.ir()
                                                                         inner: YieldConcat {
                                                                             inner: Cast {
                                                                                 inner: Tee {
-                                                                                    inner: <shared 39>,
+                                                                                    inner: <shared 42>,
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Tick(17, Cluster(loc5v1)),
                                                                                         collection_kind: Optional {
@@ -7181,7 +7067,7 @@ expression: built.ir()
                                                 inner: Cast {
                                                     inner: Cast {
                                                         inner: Tee {
-                                                            inner: <shared 40>,
+                                                            inner: <shared 43>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(19, Cluster(loc2v1)),
                                                                 collection_kind: KeyedSingleton {
@@ -7312,7 +7198,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 41>: Chain {
+                inner: <shared 44>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -7340,7 +7226,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <shared 42>: Map {
+                            inner: <shared 45>: Map {
                                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , i32) , core :: result :: Result < () , () >)) , ((u32 , i32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
                                 input: Cast {
                                     inner: Network {
@@ -7362,7 +7248,7 @@ expression: built.ir()
                                                     inner: FilterMap {
                                                         f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_108_23 ! ([] [| payload | payload . kv]) }),
                                                         input: Tee {
-                                                            inner: <shared 38>,
+                                                            inner: <shared 41>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(17, Cluster(loc5v1)),
                                                                 collection_kind: Stream {
@@ -7486,17 +7372,17 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 43>: FilterMap {
+                inner: <shared 46>: FilterMap {
                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , i32) , (usize , usize)) , core :: option :: Option < (u32 , i32) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_122_27 ! ([min__free = 2usize ,] [move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None }]) }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <shared 44>: FoldKeyed {
+                                inner: <shared 47>: FoldKeyed {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_109_15 ! ([] [move | | (0 , 0)]) }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_110_15 ! ([] [move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } }]) }),
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <shared 41>,
+                                            inner: <shared 44>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(20, Cluster(loc3v1)),
                                                 collection_kind: Stream {
@@ -7624,7 +7510,7 @@ expression: built.ir()
         input: FilterMap {
             f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , i32) , core :: result :: Result < () , () >) , core :: option :: Option < ((u32 , i32) , ()) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_151_32 ! ([] [move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , }]) }),
             input: Tee {
-                inner: <shared 42>,
+                inner: <shared 45>,
                 metadata: HydroIrMetadata {
                     location_id: Cluster(loc3v1),
                     collection_kind: Stream {
@@ -7652,10 +7538,10 @@ expression: built.ir()
             1,
         ),
         input: Tee {
-            inner: <shared 45>: Cast {
+            inner: <shared 48>: Cast {
                 inner: YieldConcat {
                     inner: Tee {
-                        inner: <shared 43>,
+                        inner: <shared 46>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(20, Cluster(loc3v1)),
                             collection_kind: Stream {
@@ -7710,11 +7596,11 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_183_20 ! ([] [| (new , old) | { old . borrow_mut () . add (new) . expect ("Error adding value to histogram") ; old }]) }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 46>: Fold {
+                            inner: <shared 49>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_153_15 ! ([] [move | | Histogram :: < u64 > :: new (3) . unwrap ()]) }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , core :: time :: Duration , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_154_15 ! ([] [move | latencies , latency | { latencies . record (latency . as_nanos () as u64) . unwrap () ; }]) }),
                                 input: Tee {
-                                    inner: <shared 47>: Batch {
+                                    inner: <shared 50>: Batch {
                                         inner: Map {
                                             f: stageleft :: runtime_support :: fnmut1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_bench_rs_118_12 ! ([] [| (_virtual_client_id , (_output , latency)) | latency]) }),
                                             input: Cast {
@@ -7803,7 +7689,7 @@ expression: built.ir()
                                                                                             input: ObserveNonDet {
                                                                                                 inner: Batch {
                                                                                                     inner: Tee {
-                                                                                                        inner: <shared 45>,
+                                                                                                        inner: <shared 48>,
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_id: Cluster(loc3v1),
                                                                                                             collection_kind: KeyedStream {
@@ -8006,11 +7892,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <shared 48>: Map {
+                            inner: <shared 51>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 49>: Cast {
+                                        inner: <shared 52>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -8088,7 +7974,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_935_20 ! ([] [| _ | ()]) }),
                                                             input: Tee {
-                                                                inner: <shared 50>: Reduce {
+                                                                inner: <shared 53>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1589_23 ! ([] [| _ , _ | { }]) }),
                                                                     input: FlatMap {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1955_27 ! ([] [| d | d]) }),
@@ -8268,7 +8154,7 @@ expression: built.ir()
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_187_56 ! ([] [| histogram | Rc :: new (RefCell :: new (histogram))]) }),
                         input: Tee {
-                            inner: <shared 46>,
+                            inner: <shared 49>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(22, Cluster(loc3v1)),
                                 collection_kind: Singleton {
@@ -8321,12 +8207,12 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_174_20 ! ([] [| (new , old) | new + old]) }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 51>: Fold {
+                            inner: <shared 54>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2427_15 ! ([] [| | 0usize]) }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , core :: time :: Duration , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2429_16 ! ([] [| count , _ | * count += 1]) }),
                                 input: ObserveNonDet {
                                     inner: Tee {
-                                        inner: <shared 47>,
+                                        inner: <shared 50>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(22, Cluster(loc3v1)),
                                             collection_kind: Stream {
@@ -8365,11 +8251,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <shared 52>: Map {
+                            inner: <shared 55>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 53>: Cast {
+                                        inner: <shared 56>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -8447,7 +8333,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_935_20 ! ([] [| _ | ()]) }),
                                                             input: Tee {
-                                                                inner: <shared 50>,
+                                                                inner: <shared 53>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                     collection_kind: Optional {
@@ -8566,7 +8452,7 @@ expression: built.ir()
                 },
                 second: Cast {
                     inner: Tee {
-                        inner: <shared 51>,
+                        inner: <shared 54>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(22, Cluster(loc3v1)),
                             collection_kind: Singleton {
@@ -8612,7 +8498,7 @@ expression: built.ir()
                     left: Cast {
                         inner: CrossSingleton {
                             left: Tee {
-                                inner: <shared 54>: Cast {
+                                inner: <shared 57>: Cast {
                                     inner: ChainFirst {
                                         first: DeferTick {
                                             input: CycleSource {
@@ -8713,7 +8599,7 @@ expression: built.ir()
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                                                                         input: CrossSingleton {
                                                                                             left: Tee {
-                                                                                                inner: <shared 49>,
+                                                                                                inner: <shared 52>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                                                     collection_kind: Singleton {
@@ -8733,7 +8619,7 @@ expression: built.ir()
                                                                                                                 input: Map {
                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                                                                                     input: Tee {
-                                                                                                                        inner: <shared 50>,
+                                                                                                                        inner: <shared 53>,
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Tick(22, Cluster(loc3v1)),
                                                                                                                             collection_kind: Optional {
@@ -9002,7 +8888,7 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
                                 input: DeferTick {
                                     input: Tee {
-                                        inner: <shared 55>: Reduce {
+                                        inner: <shared 58>: Reduce {
                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1589_23 ! ([] [| _ , _ | { }]) }),
                                             input: FlatMap {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1955_27 ! ([] [| d | d]) }),
@@ -9179,7 +9065,7 @@ expression: built.ir()
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                                 input: CrossSingleton {
                                                     left: Tee {
-                                                        inner: <shared 53>,
+                                                        inner: <shared 56>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(22, Cluster(loc3v1)),
                                                             collection_kind: Singleton {
@@ -9199,7 +9085,7 @@ expression: built.ir()
                                                                         input: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                                             input: Tee {
-                                                                                inner: <shared 50>,
+                                                                                inner: <shared 53>,
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                                     collection_kind: Optional {
@@ -9368,7 +9254,7 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <shared 56>: Cast {
+                                inner: <shared 59>: Cast {
                                     inner: ChainFirst {
                                         first: DeferTick {
                                             input: CycleSource {
@@ -9446,7 +9332,7 @@ expression: built.ir()
                                                 input: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_935_20 ! ([] [| _ | ()]) }),
                                                     input: Tee {
-                                                        inner: <shared 55>,
+                                                        inner: <shared 58>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(23, Process(loc4v1)),
                                                             collection_kind: Optional {
@@ -9577,7 +9463,7 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 56>,
+                            inner: <shared 59>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(23, Process(loc4v1)),
                                 collection_kind: Singleton {
@@ -9597,7 +9483,7 @@ expression: built.ir()
                                             input: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                 input: Tee {
-                                                    inner: <shared 55>,
+                                                    inner: <shared 58>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(23, Process(loc4v1)),
                                                         collection_kind: Optional {
@@ -9722,7 +9608,7 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <shared 54>,
+                                inner: <shared 57>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(23, Process(loc4v1)),
                                     collection_kind: Singleton {
@@ -9742,7 +9628,7 @@ expression: built.ir()
                                                 input: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                     input: Tee {
-                                                        inner: <shared 55>,
+                                                        inner: <shared 58>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(23, Process(loc4v1)),
                                                             collection_kind: Optional {

--- a/hydro_test/src/cluster/snapshots-nightly/paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots-nightly/paxos_ir@acceptor_mermaid.snap
@@ -20,45 +20,45 @@ linkStyle default stroke:#aaa
 10v1["<div style=text-align:center>(10v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 11v1["<div style=text-align:center>(11v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
 12v1["<div style=text-align:center>(12v1)</div> <code><br>tee()</code>"]:::otherClass
-13v1["<div style=text-align:center>(13v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-14v1["<div style=text-align:center>(14v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-15v1["<div style=text-align:center>(15v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_498_20!(<br>        [] [| ((ballot, max_ballot), log) | (ballot.proposer_id.clone(), (ballot<br>        .clone(), if ballot == max_ballot { Ok(log) } else { Err(max_ballot) }))]<br>    )<br>})</code>"]:::otherClass
-16v1["<div style=text-align:center>(16v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-17v1["<div style=text-align:center>(17v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-19v1["<div style=text-align:center>(19v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
-20v1["<div style=text-align:center>(20v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-21v1["<div style=text-align:center>(21v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::P2a&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>                hydro_test::__staged::cluster::paxos::Proposer,<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-22v1["<div style=text-align:center>(22v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
-23v1["<div style=text-align:center>(23v1)</div> <code><br>tee()</code>"]:::otherClass
-24v1["<div style=text-align:center>(24v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_389;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_872_16!(<br>            [a_max_ballot_ref__free = __hydro_singleton_ref_0,] [| p2a | { let<br>            max_ballot = a_max_ballot_ref__free.clone(); (p2a.sender, ((p2a.slot, p2a<br>            .ballot.clone()), if p2a.ballot == max_ballot { Ok(()) } else {<br>            Err(max_ballot) },),) }]<br>        )<br>    }<br>})</code>"]:::otherClass
-25v1["<div style=text-align:center>(25v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-26v1["<div style=text-align:center>(26v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-27v1["<div style=text-align:center>(27v1)</div> <code><br>tee()</code>"]:::otherClass
-28v1["<div style=text-align:center>(28v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
-29v1["<div style=text-align:center>(29v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-30v1["<div style=text-align:center>(30v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-31v1["<div style=text-align:center>(31v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-32v1["<div style=text-align:center>(32v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_0 = stream_389;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_837_23!(<br>            [a_max_ballot_ref__free = __hydro_singleton_ref_0,] [| p2a | if p2a<br>            .ballot &gt;= * a_max_ballot_ref__free { Some((p2a.slot, LogValue { ballot :<br>            p2a.ballot, value : p2a.value, })) } else { None }]<br>        )<br>    }<br>})</code>"]:::otherClass
-33v1["<div style=text-align:center>(33v1)</div> <code><br>chain()</code>"]:::otherClass
-34v1["<div style=text-align:center>(34v1)</div> <code><br>map(|x| (Some(x), None))</code>"]:::otherClass
-35v1["<div style=text-align:center>(35v1)</div> <code><br>map(|watermark| (None, Some(watermark)))</code>"]:::otherClass
-36v1["<div style=text-align:center>(36v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    || (::std::collections::HashMap::new(), None),<br>    {<br>        let __reduce_keyed_fn = {<br>            &num;[allow(unused_imports)]<br>            __stageleft_quote_src_cluster_paxos_rs_850_15!(<br>                [] [| prev_entry, entry | { if entry.ballot &gt; prev_entry.ballot { *<br>                prev_entry = LogValue { ballot : entry.ballot, value : entry.value,<br>                }; } }]<br>            )<br>        };<br>        move |(map, opt_curr_watermark), (opt_payload, opt_watermark)| {<br>            if let Some((k, v)) = opt_payload {<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if k &lt; curr_watermark {<br>                        return;<br>                    }<br>                }<br>                match map.entry(k) {<br>                    ::std::collections::hash_map::Entry::Vacant(e) =&gt; {<br>                        e.insert(v);<br>                    }<br>                    ::std::collections::hash_map::Entry::Occupied(mut e) =&gt; {<br>                        __reduce_keyed_fn(e.get_mut(), v);<br>                    }<br>                }<br>            } else {<br>                let watermark = opt_watermark.unwrap();<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if watermark &lt;= curr_watermark {<br>                        return;<br>                    }<br>                }<br>                map.retain(|k, _| *k &gt;= watermark);<br>                *opt_curr_watermark = Some(watermark);<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-37v1["<div style=text-align:center>(37v1)</div> <code><br>flat_map(|(map, _curr_watermark)| map)</code>"]:::otherClass
-38v1["<div style=text-align:center>(38v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_862_11!([] [| | HashMap::new()])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_864_12!(<br>            [] [| map, (slot, entry) | { map.insert(slot, entry); }]<br>        )<br>    },<br>)</code>"]:::otherClass
-39v1["<div style=text-align:center>(39v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-40v1["<div style=text-align:center>(40v1)</div> <code><br>identity::&lt;<br>    (<br>        core::option::Option&lt;usize&gt;,<br>        std::collections::hash_map::HashMap&lt;<br>            usize,<br>            hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>            &gt;,<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
-41v1["<div style=text-align:center>(41v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-42v1["<div style=text-align:center>(42v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::kv_replica::Replica,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;usize&gt;(&amp;b).unwrap(),<br>    )<br>})</code>"]:::otherClass
-43v1["<div style=text-align:center>(43v1)</div> <code><br>reduce_keyed::&lt;<br>    'static,<br>&gt;({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_bench_rs_73_24!(<br>        [] [| curr_seq, seq | { if seq &gt; * curr_seq { * curr_seq = seq; } }]<br>    )<br>})</code>"]:::otherClass
-44v1["<div style=text-align:center>(44v1)</div> <code><br>tee()</code>"]:::otherClass
-45v1["<div style=text-align:center>(45v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2427_15!(<br>            [] [| | 0usize]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2429_16!(<br>            [] [| count, _ | * count += 1]<br>        )<br>    },<br>)</code>"]:::otherClass
-46v1["<div style=text-align:center>(46v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_bench_rs_90_32!(<br>        [f__free = 1usize,] [move | num_received | num_received == f__free + 1]<br>    )<br>})</code>"]:::otherClass
-47v1["<div style=text-align:center>(47v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1053_46!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-48v1["<div style=text-align:center>(48v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-49v1["<div style=text-align:center>(49v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-50v1["<div style=text-align:center>(50v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_bench_rs_96_32!([] [| (_sender, seq) | seq])<br>})</code>"]:::otherClass
-51v1["<div style=text-align:center>(51v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1553_23!(<br>        [] [| curr, new | { if new &lt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
-52v1["<div style=text-align:center>(52v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
+14v1["<div style=text-align:center>(14v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+16v1["<div style=text-align:center>(16v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+17v1["<div style=text-align:center>(17v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_178;<br>    let __hydro_singleton_ref_1 = stream_175;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_498_20!(<br>            [a_log_ref__free = __hydro_singleton_ref_0, a_max_ballot_ref__free =<br>            __hydro_singleton_ref_1,] [| ballot | { let max_ballot =<br>            a_max_ballot_ref__free.clone(); let log = a_log_ref__free.clone();<br>            (ballot.proposer_id.clone(), (ballot.clone(), if ballot == max_ballot {<br>            Ok(log) } else { Err(max_ballot) },),) }]<br>        )<br>    }<br>})</code>"]:::otherClass
+18v1["<div style=text-align:center>(18v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+19v1["<div style=text-align:center>(19v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+21v1["<div style=text-align:center>(21v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+22v1["<div style=text-align:center>(22v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+23v1["<div style=text-align:center>(23v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::P2a&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>                hydro_test::__staged::cluster::paxos::Proposer,<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+24v1["<div style=text-align:center>(24v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
+25v1["<div style=text-align:center>(25v1)</div> <code><br>tee()</code>"]:::otherClass
+26v1["<div style=text-align:center>(26v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_391;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_878_16!(<br>            [a_max_ballot_ref__free = __hydro_singleton_ref_0,] [| p2a | { let<br>            max_ballot = a_max_ballot_ref__free.clone(); (p2a.sender, ((p2a.slot, p2a<br>            .ballot.clone()), if p2a.ballot == max_ballot { Ok(()) } else {<br>            Err(max_ballot) },),) }]<br>        )<br>    }<br>})</code>"]:::otherClass
+27v1["<div style=text-align:center>(27v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+28v1["<div style=text-align:center>(28v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+29v1["<div style=text-align:center>(29v1)</div> <code><br>tee()</code>"]:::otherClass
+30v1["<div style=text-align:center>(30v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+31v1["<div style=text-align:center>(31v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+32v1["<div style=text-align:center>(32v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+33v1["<div style=text-align:center>(33v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+34v1["<div style=text-align:center>(34v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_0 = stream_391;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_842_27!(<br>            [a_max_ballot_ref__free = __hydro_singleton_ref_0,] [| p2a | if p2a<br>            .ballot &gt;= * a_max_ballot_ref__free { Some((p2a.slot, LogValue { ballot :<br>            p2a.ballot, value : p2a.value, },)) } else { None }]<br>        )<br>    }<br>})</code>"]:::otherClass
+35v1["<div style=text-align:center>(35v1)</div> <code><br>chain()</code>"]:::otherClass
+36v1["<div style=text-align:center>(36v1)</div> <code><br>map(|x| (Some(x), None))</code>"]:::otherClass
+37v1["<div style=text-align:center>(37v1)</div> <code><br>map(|watermark| (None, Some(watermark)))</code>"]:::otherClass
+38v1["<div style=text-align:center>(38v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    || (::std::collections::HashMap::new(), None),<br>    {<br>        let __reduce_keyed_fn = {<br>            &num;[allow(unused_imports)]<br>            __stageleft_quote_src_cluster_paxos_rs_856_15!(<br>                [] [| prev_entry, entry | { if entry.ballot &gt; prev_entry.ballot { *<br>                prev_entry = LogValue { ballot : entry.ballot, value : entry.value,<br>                }; } }]<br>            )<br>        };<br>        move |(map, opt_curr_watermark), (opt_payload, opt_watermark)| {<br>            if let Some((k, v)) = opt_payload {<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if k &lt; curr_watermark {<br>                        return;<br>                    }<br>                }<br>                match map.entry(k) {<br>                    ::std::collections::hash_map::Entry::Vacant(e) =&gt; {<br>                        e.insert(v);<br>                    }<br>                    ::std::collections::hash_map::Entry::Occupied(mut e) =&gt; {<br>                        __reduce_keyed_fn(e.get_mut(), v);<br>                    }<br>                }<br>            } else {<br>                let watermark = opt_watermark.unwrap();<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if watermark &lt;= curr_watermark {<br>                        return;<br>                    }<br>                }<br>                map.retain(|k, _| *k &gt;= watermark);<br>                *opt_curr_watermark = Some(watermark);<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+39v1["<div style=text-align:center>(39v1)</div> <code><br>flat_map(|(map, _curr_watermark)| map)</code>"]:::otherClass
+40v1["<div style=text-align:center>(40v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_868_11!([] [| | HashMap::new()])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_870_12!(<br>            [] [| map, (slot, entry) | { map.insert(slot, entry); }]<br>        )<br>    },<br>)</code>"]:::otherClass
+41v1["<div style=text-align:center>(41v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+42v1["<div style=text-align:center>(42v1)</div> <code><br>identity::&lt;<br>    (<br>        core::option::Option&lt;usize&gt;,<br>        std::collections::hash_map::HashMap&lt;<br>            usize,<br>            hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>            &gt;,<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
+43v1["<div style=text-align:center>(43v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+44v1["<div style=text-align:center>(44v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::kv_replica::Replica,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;usize&gt;(&amp;b).unwrap(),<br>    )<br>})</code>"]:::otherClass
+45v1["<div style=text-align:center>(45v1)</div> <code><br>reduce_keyed::&lt;<br>    'static,<br>&gt;({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_bench_rs_73_24!(<br>        [] [| curr_seq, seq | { if seq &gt; * curr_seq { * curr_seq = seq; } }]<br>    )<br>})</code>"]:::otherClass
+46v1["<div style=text-align:center>(46v1)</div> <code><br>tee()</code>"]:::otherClass
+47v1["<div style=text-align:center>(47v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2427_15!(<br>            [] [| | 0usize]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2429_16!(<br>            [] [| count, _ | * count += 1]<br>        )<br>    },<br>)</code>"]:::otherClass
+48v1["<div style=text-align:center>(48v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_bench_rs_90_32!(<br>        [f__free = 1usize,] [move | num_received | num_received == f__free + 1]<br>    )<br>})</code>"]:::otherClass
+49v1["<div style=text-align:center>(49v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1053_46!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+50v1["<div style=text-align:center>(50v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+51v1["<div style=text-align:center>(51v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+52v1["<div style=text-align:center>(52v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_bench_rs_96_32!([] [| (_sender, seq) | seq])<br>})</code>"]:::otherClass
+53v1["<div style=text-align:center>(53v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1553_23!(<br>        [] [| curr, new | { if new &lt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
+54v1["<div style=text-align:center>(54v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
 1v1-->2v1
 3v1-->4v1
 4v1-->5v1
@@ -69,190 +69,176 @@ linkStyle default stroke:#aaa
 8v1-->|0|11v1
 10v1-->|1|11v1
 11v1-->12v1
-6v1-->|input|13v1
-12v1-->|single|13v1
-13v1-->|input|14v1
-40v1-->|single|14v1
-14v1-->15v1
-16v1-->17v1
-15v1-->16v1
-12v1-->19v1
-20v1-->21v1
-21v1-->22v1
+12v1-->14v1
+42v1-->16v1
+6v1-->17v1
+18v1-->19v1
+17v1-->18v1
+12v1-->21v1
 22v1-->23v1
 23v1-->24v1
-25v1-->26v1
 24v1-->25v1
-52v1-->27v1
+25v1-->26v1
 27v1-->28v1
+26v1-->27v1
+54v1-->29v1
 29v1-->30v1
-28v1-->|0|31v1
-30v1-->|1|31v1
-23v1-->32v1
-34v1-->|0|33v1
-32v1-->34v1
-35v1-->|1|33v1
-27v1-->35v1
-36v1-->37v1
-33v1-->36v1
-37v1-->38v1
-31v1-->|input|39v1
-38v1-->|single|39v1
+31v1-->32v1
+30v1-->|0|33v1
+32v1-->|1|33v1
+25v1-->34v1
+36v1-->|0|35v1
+34v1-->36v1
+37v1-->|1|35v1
+29v1-->37v1
+38v1-->39v1
+35v1-->38v1
 39v1-->40v1
+33v1-->|input|41v1
+40v1-->|single|41v1
 41v1-->42v1
-42v1-->43v1
 43v1-->44v1
 44v1-->45v1
 45v1-->46v1
 46v1-->47v1
-44v1-->|input|48v1
-47v1-->|single|48v1
+47v1-->48v1
 48v1-->49v1
-49v1-->50v1
+46v1-->|input|50v1
+49v1-->|single|50v1
 50v1-->51v1
 51v1-->52v1
-12v1-->24v1
-12v1-->32v1
+52v1-->53v1
+53v1-->54v1
+42v1-->17v1
+12v1-->17v1
+12v1-->26v1
+12v1-->34v1
 2v1
-25v1
-26v1
+27v1
+28v1
+37v1
+36v1
+18v1
 19v1
-35v1
-34v1
+14v1
 16v1
-17v1
+21v1
 subgraph var_cycle_2 ["var <tt>cycle_2</tt>"]
     style var_cycle_2 fill:transparent
-    52v1
+    54v1
 end
 subgraph var_cycle_4 ["var <tt>cycle_4</tt>"]
     style var_cycle_4 fill:transparent
-    40v1
+    42v1
 end
-subgraph var_reduce_keyed_watermark_chain_519 ["var <tt>reduce_keyed_watermark_chain_519</tt>"]
-    style var_reduce_keyed_watermark_chain_519 fill:transparent
-    33v1
+subgraph var_reduce_keyed_watermark_chain_521 ["var <tt>reduce_keyed_watermark_chain_521</tt>"]
+    style var_reduce_keyed_watermark_chain_521 fill:transparent
+    35v1
 end
-subgraph var_stream_162 ["var <tt>stream_162</tt>"]
-    style var_stream_162 fill:transparent
+subgraph var_stream_160 ["var <tt>stream_160</tt>"]
+    style var_stream_160 fill:transparent
     3v1
     4v1
 end
-subgraph var_stream_164 ["var <tt>stream_164</tt>"]
-    style var_stream_164 fill:transparent
+subgraph var_stream_162 ["var <tt>stream_162</tt>"]
+    style var_stream_162 fill:transparent
     5v1
 end
-subgraph var_stream_166 ["var <tt>stream_166</tt>"]
-    style var_stream_166 fill:transparent
+subgraph var_stream_164 ["var <tt>stream_164</tt>"]
+    style var_stream_164 fill:transparent
     6v1
+end
+subgraph var_stream_165 ["var <tt>stream_165</tt>"]
+    style var_stream_165 fill:transparent
+    7v1
 end
 subgraph var_stream_168 ["var <tt>stream_168</tt>"]
     style var_stream_168 fill:transparent
-    7v1
-end
-subgraph var_stream_171 ["var <tt>stream_171</tt>"]
-    style var_stream_171 fill:transparent
     8v1
 end
-subgraph var_stream_173 ["var <tt>stream_173</tt>"]
-    style var_stream_173 fill:transparent
+subgraph var_stream_170 ["var <tt>stream_170</tt>"]
+    style var_stream_170 fill:transparent
     9v1
     10v1
 end
-subgraph var_stream_175 ["var <tt>stream_175</tt>"]
-    style var_stream_175 fill:transparent
+subgraph var_stream_172 ["var <tt>stream_172</tt>"]
+    style var_stream_172 fill:transparent
     11v1
 end
-subgraph var_stream_177 ["var <tt>stream_177</tt>"]
-    style var_stream_177 fill:transparent
+subgraph var_stream_174 ["var <tt>stream_174</tt>"]
+    style var_stream_174 fill:transparent
     12v1
 end
-subgraph var_stream_179 ["var <tt>stream_179</tt>"]
-    style var_stream_179 fill:transparent
-    13v1
-end
-subgraph var_stream_182 ["var <tt>stream_182</tt>"]
-    style var_stream_182 fill:transparent
-    14v1
-end
-subgraph var_stream_183 ["var <tt>stream_183</tt>"]
-    style var_stream_183 fill:transparent
-    15v1
+subgraph var_stream_185 ["var <tt>stream_185</tt>"]
+    style var_stream_185 fill:transparent
+    17v1
 end
 subgraph var_stream_24 ["var <tt>stream_24</tt>"]
     style var_stream_24 fill:transparent
     1v1
 end
-subgraph var_stream_452 ["var <tt>stream_452</tt>"]
-    style var_stream_452 fill:transparent
-    20v1
-    21v1
-end
 subgraph var_stream_454 ["var <tt>stream_454</tt>"]
     style var_stream_454 fill:transparent
     22v1
+    23v1
 end
 subgraph var_stream_456 ["var <tt>stream_456</tt>"]
     style var_stream_456 fill:transparent
-    23v1
-end
-subgraph var_stream_457 ["var <tt>stream_457</tt>"]
-    style var_stream_457 fill:transparent
     24v1
 end
-subgraph var_stream_506 ["var <tt>stream_506</tt>"]
-    style var_stream_506 fill:transparent
-    27v1
+subgraph var_stream_458 ["var <tt>stream_458</tt>"]
+    style var_stream_458 fill:transparent
+    25v1
 end
-subgraph var_stream_507 ["var <tt>stream_507</tt>"]
-    style var_stream_507 fill:transparent
-    28v1
+subgraph var_stream_459 ["var <tt>stream_459</tt>"]
+    style var_stream_459 fill:transparent
+    26v1
 end
 subgraph var_stream_508 ["var <tt>stream_508</tt>"]
     style var_stream_508 fill:transparent
     29v1
+end
+subgraph var_stream_509 ["var <tt>stream_509</tt>"]
+    style var_stream_509 fill:transparent
     30v1
 end
 subgraph var_stream_510 ["var <tt>stream_510</tt>"]
     style var_stream_510 fill:transparent
     31v1
-end
-subgraph var_stream_514 ["var <tt>stream_514</tt>"]
-    style var_stream_514 fill:transparent
     32v1
 end
-subgraph var_stream_519 ["var <tt>stream_519</tt>"]
-    style var_stream_519 fill:transparent
-    36v1
-    37v1
+subgraph var_stream_512 ["var <tt>stream_512</tt>"]
+    style var_stream_512 fill:transparent
+    33v1
 end
-subgraph var_stream_523 ["var <tt>stream_523</tt>"]
-    style var_stream_523 fill:transparent
+subgraph var_stream_516 ["var <tt>stream_516</tt>"]
+    style var_stream_516 fill:transparent
+    34v1
+end
+subgraph var_stream_521 ["var <tt>stream_521</tt>"]
+    style var_stream_521 fill:transparent
     38v1
-end
-subgraph var_stream_524 ["var <tt>stream_524</tt>"]
-    style var_stream_524 fill:transparent
     39v1
 end
-subgraph var_stream_636 ["var <tt>stream_636</tt>"]
-    style var_stream_636 fill:transparent
-    41v1
-    42v1
+subgraph var_stream_525 ["var <tt>stream_525</tt>"]
+    style var_stream_525 fill:transparent
+    40v1
 end
-subgraph var_stream_637 ["var <tt>stream_637</tt>"]
-    style var_stream_637 fill:transparent
+subgraph var_stream_526 ["var <tt>stream_526</tt>"]
+    style var_stream_526 fill:transparent
+    41v1
+end
+subgraph var_stream_638 ["var <tt>stream_638</tt>"]
+    style var_stream_638 fill:transparent
     43v1
+    44v1
 end
 subgraph var_stream_639 ["var <tt>stream_639</tt>"]
     style var_stream_639 fill:transparent
-    44v1
-end
-subgraph var_stream_646 ["var <tt>stream_646</tt>"]
-    style var_stream_646 fill:transparent
     45v1
 end
-subgraph var_stream_647 ["var <tt>stream_647</tt>"]
-    style var_stream_647 fill:transparent
+subgraph var_stream_641 ["var <tt>stream_641</tt>"]
+    style var_stream_641 fill:transparent
     46v1
 end
 subgraph var_stream_648 ["var <tt>stream_648</tt>"]
@@ -271,7 +257,15 @@ subgraph var_stream_651 ["var <tt>stream_651</tt>"]
     style var_stream_651 fill:transparent
     50v1
 end
+subgraph var_stream_652 ["var <tt>stream_652</tt>"]
+    style var_stream_652 fill:transparent
+    51v1
+end
 subgraph var_stream_653 ["var <tt>stream_653</tt>"]
     style var_stream_653 fill:transparent
-    51v1
+    52v1
+end
+subgraph var_stream_655 ["var <tt>stream_655</tt>"]
+    style var_stream_655 fill:transparent
+    53v1
 end

--- a/hydro_test/src/cluster/snapshots-nightly/paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots-nightly/paxos_ir@acceptor_mermaid.snap
@@ -25,27 +25,26 @@ linkStyle default stroke:#aaa
 15v1["<div style=text-align:center>(15v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_498_20!(<br>        [] [| ((ballot, max_ballot), log) | (ballot.proposer_id.clone(), (ballot<br>        .clone(), if ballot == max_ballot { Ok(log) } else { Err(max_ballot) }))]<br>    )<br>})</code>"]:::otherClass
 16v1["<div style=text-align:center>(16v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
 17v1["<div style=text-align:center>(17v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-18v1["<div style=text-align:center>(18v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-19v1["<div style=text-align:center>(19v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::P2a&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>                hydro_test::__staged::cluster::paxos::Proposer,<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-20v1["<div style=text-align:center>(20v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
-21v1["<div style=text-align:center>(21v1)</div> <code><br>tee()</code>"]:::otherClass
-22v1["<div style=text-align:center>(22v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-23v1["<div style=text-align:center>(23v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_874_16!(<br>        [] [| (p2a, max_ballot) | (p2a.sender, ((p2a.slot, p2a.ballot.clone()), if<br>        p2a.ballot == max_ballot { Ok(()) } else { Err(max_ballot) }))]<br>    )<br>})</code>"]:::otherClass
-24v1["<div style=text-align:center>(24v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-25v1["<div style=text-align:center>(25v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-26v1["<div style=text-align:center>(26v1)</div> <code><br>tee()</code>"]:::otherClass
-27v1["<div style=text-align:center>(27v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
-28v1["<div style=text-align:center>(28v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-29v1["<div style=text-align:center>(29v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-30v1["<div style=text-align:center>(30v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-31v1["<div style=text-align:center>(31v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-32v1["<div style=text-align:center>(32v1)</div> <code><br>filter_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_838_23!(<br>        [] [| (p2a, max_ballot) | if p2a.ballot &gt;= max_ballot { Some((p2a.slot,<br>        LogValue { ballot : p2a.ballot, value : p2a.value, })) } else { None }]<br>    )<br>})</code>"]:::otherClass
+19v1["<div style=text-align:center>(19v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+20v1["<div style=text-align:center>(20v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+21v1["<div style=text-align:center>(21v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::P2a&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>                hydro_test::__staged::cluster::paxos::Proposer,<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+22v1["<div style=text-align:center>(22v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
+23v1["<div style=text-align:center>(23v1)</div> <code><br>tee()</code>"]:::otherClass
+24v1["<div style=text-align:center>(24v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_389;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_872_16!(<br>            [a_max_ballot_ref__free = __hydro_singleton_ref_0,] [| p2a | { let<br>            max_ballot = a_max_ballot_ref__free.clone(); (p2a.sender, ((p2a.slot, p2a<br>            .ballot.clone()), if p2a.ballot == max_ballot { Ok(()) } else {<br>            Err(max_ballot) },),) }]<br>        )<br>    }<br>})</code>"]:::otherClass
+25v1["<div style=text-align:center>(25v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+26v1["<div style=text-align:center>(26v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+27v1["<div style=text-align:center>(27v1)</div> <code><br>tee()</code>"]:::otherClass
+28v1["<div style=text-align:center>(28v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+29v1["<div style=text-align:center>(29v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+30v1["<div style=text-align:center>(30v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+31v1["<div style=text-align:center>(31v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+32v1["<div style=text-align:center>(32v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_0 = stream_389;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_837_23!(<br>            [a_max_ballot_ref__free = __hydro_singleton_ref_0,] [| p2a | if p2a<br>            .ballot &gt;= * a_max_ballot_ref__free { Some((p2a.slot, LogValue { ballot :<br>            p2a.ballot, value : p2a.value, })) } else { None }]<br>        )<br>    }<br>})</code>"]:::otherClass
 33v1["<div style=text-align:center>(33v1)</div> <code><br>chain()</code>"]:::otherClass
 34v1["<div style=text-align:center>(34v1)</div> <code><br>map(|x| (Some(x), None))</code>"]:::otherClass
 35v1["<div style=text-align:center>(35v1)</div> <code><br>map(|watermark| (None, Some(watermark)))</code>"]:::otherClass
-36v1["<div style=text-align:center>(36v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    || (::std::collections::HashMap::new(), None),<br>    {<br>        let __reduce_keyed_fn = {<br>            &num;[allow(unused_imports)]<br>            __stageleft_quote_src_cluster_paxos_rs_851_15!(<br>                [] [| prev_entry, entry | { if entry.ballot &gt; prev_entry.ballot { *<br>                prev_entry = LogValue { ballot : entry.ballot, value : entry.value,<br>                }; } }]<br>            )<br>        };<br>        move |(map, opt_curr_watermark), (opt_payload, opt_watermark)| {<br>            if let Some((k, v)) = opt_payload {<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if k &lt; curr_watermark {<br>                        return;<br>                    }<br>                }<br>                match map.entry(k) {<br>                    ::std::collections::hash_map::Entry::Vacant(e) =&gt; {<br>                        e.insert(v);<br>                    }<br>                    ::std::collections::hash_map::Entry::Occupied(mut e) =&gt; {<br>                        __reduce_keyed_fn(e.get_mut(), v);<br>                    }<br>                }<br>            } else {<br>                let watermark = opt_watermark.unwrap();<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if watermark &lt;= curr_watermark {<br>                        return;<br>                    }<br>                }<br>                map.retain(|k, _| *k &gt;= watermark);<br>                *opt_curr_watermark = Some(watermark);<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+36v1["<div style=text-align:center>(36v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    || (::std::collections::HashMap::new(), None),<br>    {<br>        let __reduce_keyed_fn = {<br>            &num;[allow(unused_imports)]<br>            __stageleft_quote_src_cluster_paxos_rs_850_15!(<br>                [] [| prev_entry, entry | { if entry.ballot &gt; prev_entry.ballot { *<br>                prev_entry = LogValue { ballot : entry.ballot, value : entry.value,<br>                }; } }]<br>            )<br>        };<br>        move |(map, opt_curr_watermark), (opt_payload, opt_watermark)| {<br>            if let Some((k, v)) = opt_payload {<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if k &lt; curr_watermark {<br>                        return;<br>                    }<br>                }<br>                match map.entry(k) {<br>                    ::std::collections::hash_map::Entry::Vacant(e) =&gt; {<br>                        e.insert(v);<br>                    }<br>                    ::std::collections::hash_map::Entry::Occupied(mut e) =&gt; {<br>                        __reduce_keyed_fn(e.get_mut(), v);<br>                    }<br>                }<br>            } else {<br>                let watermark = opt_watermark.unwrap();<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if watermark &lt;= curr_watermark {<br>                        return;<br>                    }<br>                }<br>                map.retain(|k, _| *k &gt;= watermark);<br>                *opt_curr_watermark = Some(watermark);<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
 37v1["<div style=text-align:center>(37v1)</div> <code><br>flat_map(|(map, _curr_watermark)| map)</code>"]:::otherClass
-38v1["<div style=text-align:center>(38v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_863_11!([] [| | HashMap::new()])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_865_12!(<br>            [] [| map, (slot, entry) | { map.insert(slot, entry); }]<br>        )<br>    },<br>)</code>"]:::otherClass
+38v1["<div style=text-align:center>(38v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_862_11!([] [| | HashMap::new()])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_864_12!(<br>            [] [| map, (slot, entry) | { map.insert(slot, entry); }]<br>        )<br>    },<br>)</code>"]:::otherClass
 39v1["<div style=text-align:center>(39v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
 40v1["<div style=text-align:center>(40v1)</div> <code><br>identity::&lt;<br>    (<br>        core::option::Option&lt;usize&gt;,<br>        std::collections::hash_map::HashMap&lt;<br>            usize,<br>            hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>            &gt;,<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
 41v1["<div style=text-align:center>(41v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
@@ -77,30 +76,27 @@ linkStyle default stroke:#aaa
 14v1-->15v1
 16v1-->17v1
 15v1-->16v1
-18v1-->19v1
-19v1-->20v1
+12v1-->19v1
 20v1-->21v1
-21v1-->|input|22v1
-12v1-->|single|22v1
+21v1-->22v1
 22v1-->23v1
-24v1-->25v1
 23v1-->24v1
-52v1-->26v1
-26v1-->27v1
-28v1-->29v1
-27v1-->|0|30v1
-29v1-->|1|30v1
-21v1-->|input|31v1
-12v1-->|single|31v1
-31v1-->32v1
+25v1-->26v1
+24v1-->25v1
+52v1-->27v1
+27v1-->28v1
+29v1-->30v1
+28v1-->|0|31v1
+30v1-->|1|31v1
+23v1-->32v1
 34v1-->|0|33v1
 32v1-->34v1
 35v1-->|1|33v1
-26v1-->35v1
+27v1-->35v1
 36v1-->37v1
 33v1-->36v1
 37v1-->38v1
-30v1-->|input|39v1
+31v1-->|input|39v1
 38v1-->|single|39v1
 39v1-->40v1
 41v1-->42v1
@@ -115,13 +111,16 @@ linkStyle default stroke:#aaa
 49v1-->50v1
 50v1-->51v1
 51v1-->52v1
+12v1-->24v1
+12v1-->32v1
 2v1
+25v1
+26v1
+19v1
 35v1
 34v1
 16v1
 17v1
-24v1
-25v1
 subgraph var_cycle_2 ["var <tt>cycle_2</tt>"]
     style var_cycle_2 fill:transparent
     52v1
@@ -130,8 +129,8 @@ subgraph var_cycle_4 ["var <tt>cycle_4</tt>"]
     style var_cycle_4 fill:transparent
     40v1
 end
-subgraph var_reduce_keyed_watermark_chain_524 ["var <tt>reduce_keyed_watermark_chain_524</tt>"]
-    style var_reduce_keyed_watermark_chain_524 fill:transparent
+subgraph var_reduce_keyed_watermark_chain_519 ["var <tt>reduce_keyed_watermark_chain_519</tt>"]
+    style var_reduce_keyed_watermark_chain_519 fill:transparent
     33v1
 end
 subgraph var_stream_162 ["var <tt>stream_162</tt>"]
@@ -184,103 +183,95 @@ subgraph var_stream_24 ["var <tt>stream_24</tt>"]
     style var_stream_24 fill:transparent
     1v1
 end
+subgraph var_stream_452 ["var <tt>stream_452</tt>"]
+    style var_stream_452 fill:transparent
+    20v1
+    21v1
+end
 subgraph var_stream_454 ["var <tt>stream_454</tt>"]
     style var_stream_454 fill:transparent
-    18v1
-    19v1
+    22v1
 end
 subgraph var_stream_456 ["var <tt>stream_456</tt>"]
     style var_stream_456 fill:transparent
-    20v1
-end
-subgraph var_stream_458 ["var <tt>stream_458</tt>"]
-    style var_stream_458 fill:transparent
-    21v1
-end
-subgraph var_stream_461 ["var <tt>stream_461</tt>"]
-    style var_stream_461 fill:transparent
-    22v1
-end
-subgraph var_stream_462 ["var <tt>stream_462</tt>"]
-    style var_stream_462 fill:transparent
     23v1
 end
-subgraph var_stream_509 ["var <tt>stream_509</tt>"]
-    style var_stream_509 fill:transparent
-    26v1
+subgraph var_stream_457 ["var <tt>stream_457</tt>"]
+    style var_stream_457 fill:transparent
+    24v1
+end
+subgraph var_stream_506 ["var <tt>stream_506</tt>"]
+    style var_stream_506 fill:transparent
+    27v1
+end
+subgraph var_stream_507 ["var <tt>stream_507</tt>"]
+    style var_stream_507 fill:transparent
+    28v1
+end
+subgraph var_stream_508 ["var <tt>stream_508</tt>"]
+    style var_stream_508 fill:transparent
+    29v1
+    30v1
 end
 subgraph var_stream_510 ["var <tt>stream_510</tt>"]
     style var_stream_510 fill:transparent
-    27v1
-end
-subgraph var_stream_511 ["var <tt>stream_511</tt>"]
-    style var_stream_511 fill:transparent
-    28v1
-    29v1
-end
-subgraph var_stream_513 ["var <tt>stream_513</tt>"]
-    style var_stream_513 fill:transparent
-    30v1
-end
-subgraph var_stream_518 ["var <tt>stream_518</tt>"]
-    style var_stream_518 fill:transparent
     31v1
+end
+subgraph var_stream_514 ["var <tt>stream_514</tt>"]
+    style var_stream_514 fill:transparent
+    32v1
 end
 subgraph var_stream_519 ["var <tt>stream_519</tt>"]
     style var_stream_519 fill:transparent
-    32v1
-end
-subgraph var_stream_524 ["var <tt>stream_524</tt>"]
-    style var_stream_524 fill:transparent
     36v1
     37v1
 end
-subgraph var_stream_528 ["var <tt>stream_528</tt>"]
-    style var_stream_528 fill:transparent
+subgraph var_stream_523 ["var <tt>stream_523</tt>"]
+    style var_stream_523 fill:transparent
     38v1
 end
-subgraph var_stream_529 ["var <tt>stream_529</tt>"]
-    style var_stream_529 fill:transparent
+subgraph var_stream_524 ["var <tt>stream_524</tt>"]
+    style var_stream_524 fill:transparent
     39v1
 end
-subgraph var_stream_641 ["var <tt>stream_641</tt>"]
-    style var_stream_641 fill:transparent
+subgraph var_stream_636 ["var <tt>stream_636</tt>"]
+    style var_stream_636 fill:transparent
     41v1
     42v1
 end
-subgraph var_stream_642 ["var <tt>stream_642</tt>"]
-    style var_stream_642 fill:transparent
+subgraph var_stream_637 ["var <tt>stream_637</tt>"]
+    style var_stream_637 fill:transparent
     43v1
 end
-subgraph var_stream_644 ["var <tt>stream_644</tt>"]
-    style var_stream_644 fill:transparent
+subgraph var_stream_639 ["var <tt>stream_639</tt>"]
+    style var_stream_639 fill:transparent
     44v1
+end
+subgraph var_stream_646 ["var <tt>stream_646</tt>"]
+    style var_stream_646 fill:transparent
+    45v1
+end
+subgraph var_stream_647 ["var <tt>stream_647</tt>"]
+    style var_stream_647 fill:transparent
+    46v1
+end
+subgraph var_stream_648 ["var <tt>stream_648</tt>"]
+    style var_stream_648 fill:transparent
+    47v1
+end
+subgraph var_stream_649 ["var <tt>stream_649</tt>"]
+    style var_stream_649 fill:transparent
+    48v1
+end
+subgraph var_stream_650 ["var <tt>stream_650</tt>"]
+    style var_stream_650 fill:transparent
+    49v1
 end
 subgraph var_stream_651 ["var <tt>stream_651</tt>"]
     style var_stream_651 fill:transparent
-    45v1
-end
-subgraph var_stream_652 ["var <tt>stream_652</tt>"]
-    style var_stream_652 fill:transparent
-    46v1
+    50v1
 end
 subgraph var_stream_653 ["var <tt>stream_653</tt>"]
     style var_stream_653 fill:transparent
-    47v1
-end
-subgraph var_stream_654 ["var <tt>stream_654</tt>"]
-    style var_stream_654 fill:transparent
-    48v1
-end
-subgraph var_stream_655 ["var <tt>stream_655</tt>"]
-    style var_stream_655 fill:transparent
-    49v1
-end
-subgraph var_stream_656 ["var <tt>stream_656</tt>"]
-    style var_stream_656 fill:transparent
-    50v1
-end
-subgraph var_stream_658 ["var <tt>stream_658</tt>"]
-    style var_stream_658 fill:transparent
     51v1
 end

--- a/hydro_test/src/cluster/snapshots-nightly/paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots-nightly/paxos_ir@proposer_mermaid.snap
@@ -163,119 +163,114 @@ linkStyle default stroke:#aaa
 153v1["<div style=text-align:center>(153v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 154v1["<div style=text-align:center>(154v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
 155v1["<div style=text-align:center>(155v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-156v1["<div style=text-align:center>(156v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-157v1["<div style=text-align:center>(157v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos_bench::Client,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-158v1["<div style=text-align:center>(158v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
-159v1["<div style=text-align:center>(159v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1053_46!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-160v1["<div style=text-align:center>(160v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-161v1["<div style=text-align:center>(161v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-162v1["<div style=text-align:center>(162v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
-163v1["<div style=text-align:center>(163v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_571_35!(<br>        [] [| v | v]<br>    )<br>})</code>"]:::otherClass
+157v1["<div style=text-align:center>(157v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+158v1["<div style=text-align:center>(158v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_571_35!(<br>        [] [| v | v]<br>    )<br>})</code>"]:::otherClass
+159v1["<div style=text-align:center>(159v1)</div> <code><br>tee()</code>"]:::otherClass
+160v1["<div style=text-align:center>(160v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_604_16!([] [| (_checkpoint, log) | log])<br>})</code>"]:::otherClass
+161v1["<div style=text-align:center>(161v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_764_35!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
+162v1["<div style=text-align:center>(162v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_607_67!([] [| | (0, None)])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_607_85!(<br>            [] [| curr_entry, new_entry | { if let Some(curr_entry_payload) = &amp; mut<br>            curr_entry.1 { let same_values = new_entry.value == curr_entry_payload<br>            .value; let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>            if same_values { curr_entry.0 += 1; } if higher_ballot {<br>            curr_entry_payload.ballot = new_entry.ballot; if ! same_values {<br>            curr_entry.0 = 1; curr_entry_payload.value = new_entry.value; } } } else<br>            { * curr_entry = (1, Some(new_entry)); } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+163v1["<div style=text-align:center>(163v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_484_23!(<br>        [f__free = stageleft::runtime_support::fn1_type_hint:: &lt; (usize,<br>        core::option::Option &lt; hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), (usize,<br>        hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt;) &gt; ({ use crate<br>        ::__staged::__deps:: *; use crate ::__staged::cluster::paxos:: *;<br>        &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_628_16!([] [| (count, entry) | (count,<br>        entry.unwrap())]) }),] [{ let orig = f__free; move | (k, v) | (k, orig(v)) }]<br>    )<br>})</code>"]:::otherClass
 164v1["<div style=text-align:center>(164v1)</div> <code><br>tee()</code>"]:::otherClass
-165v1["<div style=text-align:center>(165v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_604_16!([] [| (_checkpoint, log) | log])<br>})</code>"]:::otherClass
-166v1["<div style=text-align:center>(166v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_764_35!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
-167v1["<div style=text-align:center>(167v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_607_67!([] [| | (0, None)])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_607_85!(<br>            [] [| curr_entry, new_entry | { if let Some(curr_entry_payload) = &amp; mut<br>            curr_entry.1 { let same_values = new_entry.value == curr_entry_payload<br>            .value; let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>            if same_values { curr_entry.0 += 1; } if higher_ballot {<br>            curr_entry_payload.ballot = new_entry.ballot; if ! same_values {<br>            curr_entry.0 = 1; curr_entry_payload.value = new_entry.value; } } } else<br>            { * curr_entry = (1, Some(new_entry)); } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-168v1["<div style=text-align:center>(168v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_484_23!(<br>        [f__free = stageleft::runtime_support::fn1_type_hint:: &lt; (usize,<br>        core::option::Option &lt; hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), (usize,<br>        hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt;) &gt; ({ use crate<br>        ::__staged::__deps:: *; use crate ::__staged::cluster::paxos:: *;<br>        &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_628_16!([] [| (count, entry) | (count,<br>        entry.unwrap())]) }),] [{ let orig = f__free; move | (k, v) | (k, orig(v)) }]<br>    )<br>})</code>"]:::otherClass
-169v1["<div style=text-align:center>(169v1)</div> <code><br>tee()</code>"]:::otherClass
-170v1["<div style=text-align:center>(170v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-171v1["<div style=text-align:center>(171v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1519_23!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
-172v1["<div style=text-align:center>(172v1)</div> <code><br>tee()</code>"]:::otherClass
-173v1["<div style=text-align:center>(173v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_780_71!([] [| s | s + 1])<br>})</code>"]:::otherClass
-174v1["<div style=text-align:center>(174v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-175v1["<div style=text-align:center>(175v1)</div> <code><br>source_iter([<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_776_58!([] [0])<br>    },<br>])</code>"]:::otherClass
-176v1["<div style=text-align:center>(176v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-177v1["<div style=text-align:center>(177v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-178v1["<div style=text-align:center>(178v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-179v1["<div style=text-align:center>(179v1)</div> <code><br>tee()</code>"]:::otherClass
-180v1["<div style=text-align:center>(180v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-181v1["<div style=text-align:center>(181v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_786_20!(<br>        [] [| ((index, payload), base_slot) | (base_slot + index, payload)]<br>    )<br>})</code>"]:::otherClass
-182v1["<div style=text-align:center>(182v1)</div> <code><br>tee()</code>"]:::otherClass
-183v1["<div style=text-align:center>(183v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2427_15!(<br>            [] [| | 0usize]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2429_16!(<br>            [] [| count, _ | * count += 1]<br>        )<br>    },<br>)</code>"]:::otherClass
-184v1["<div style=text-align:center>(184v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-185v1["<div style=text-align:center>(185v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_794_20!(<br>        [] [| (num_payloads, base_slot) | base_slot + num_payloads]<br>    )<br>})</code>"]:::otherClass
-186v1["<div style=text-align:center>(186v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
-187v1["<div style=text-align:center>(187v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-188v1["<div style=text-align:center>(188v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-189v1["<div style=text-align:center>(189v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_545_16!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
-190v1["<div style=text-align:center>(190v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_36_11!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_37_11!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-191v1["<div style=text-align:center>(191v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_1187_61!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-192v1["<div style=text-align:center>(192v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-193v1["<div style=text-align:center>(193v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-194v1["<div style=text-align:center>(194v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_721_16!(<br>        [] [| ((slot, payload), ballot) | ((slot, ballot), Some(payload))]<br>    )<br>})</code>"]:::otherClass
-195v1["<div style=text-align:center>(195v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+165v1["<div style=text-align:center>(165v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+166v1["<div style=text-align:center>(166v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1519_23!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
+167v1["<div style=text-align:center>(167v1)</div> <code><br>tee()</code>"]:::otherClass
+168v1["<div style=text-align:center>(168v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_779_71!([] [| s | s + 1])<br>})</code>"]:::otherClass
+169v1["<div style=text-align:center>(169v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+170v1["<div style=text-align:center>(170v1)</div> <code><br>source_iter([<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_775_58!([] [0])<br>    },<br>])</code>"]:::otherClass
+171v1["<div style=text-align:center>(171v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+172v1["<div style=text-align:center>(172v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+173v1["<div style=text-align:center>(173v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+175v1["<div style=text-align:center>(175v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+176v1["<div style=text-align:center>(176v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos_bench::Client,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+177v1["<div style=text-align:center>(177v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
+178v1["<div style=text-align:center>(178v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1053_46!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+179v1["<div style=text-align:center>(179v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+180v1["<div style=text-align:center>(180v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+181v1["<div style=text-align:center>(181v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
+182v1["<div style=text-align:center>(182v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_362;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_785_20!(<br>            [base_slot_ref__free = __hydro_singleton_ref_0,] [| (index, payload) | (*<br>            base_slot_ref__free + index, payload)]<br>        )<br>    }<br>})</code>"]:::otherClass
+183v1["<div style=text-align:center>(183v1)</div> <code><br>tee()</code>"]:::otherClass
+184v1["<div style=text-align:center>(184v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2427_15!(<br>            [] [| | 0usize]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2429_16!(<br>            [] [| count, _ | * count += 1]<br>        )<br>    },<br>)</code>"]:::otherClass
+185v1["<div style=text-align:center>(185v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+186v1["<div style=text-align:center>(186v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_793_20!(<br>        [] [| (num_payloads, base_slot) | base_slot + num_payloads]<br>    )<br>})</code>"]:::otherClass
+187v1["<div style=text-align:center>(187v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
+188v1["<div style=text-align:center>(188v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+189v1["<div style=text-align:center>(189v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+190v1["<div style=text-align:center>(190v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_545_16!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
+191v1["<div style=text-align:center>(191v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_36_11!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_37_11!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+192v1["<div style=text-align:center>(192v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_1187_61!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+193v1["<div style=text-align:center>(193v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+195v1["<div style=text-align:center>(195v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_405;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_720_16!(<br>            [p_ballot_ref__free = __hydro_singleton_ref_0,] [| (slot, payload) |<br>            ((slot, p_ballot_ref__free.clone()), Some(payload))]<br>        )<br>    }<br>})</code>"]:::otherClass
 196v1["<div style=text-align:center>(196v1)</div> <code><br>filter_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_600_23!(<br>        [] [| (checkpoint, _log) | checkpoint]<br>    )<br>})</code>"]:::otherClass
 197v1["<div style=text-align:center>(197v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1519_23!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
 198v1["<div style=text-align:center>(198v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
 199v1["<div style=text-align:center>(199v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
 200v1["<div style=text-align:center>(200v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 201v1["<div style=text-align:center>(201v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-202v1["<div style=text-align:center>(202v1)</div> <code><br>tee()</code>"]:::otherClass
-203v1["<div style=text-align:center>(203v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-204v1["<div style=text-align:center>(204v1)</div> <code><br>filter_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_634_23!(<br>        [f__free = 1usize,] [move | (((slot, (count, entry)), ballot), checkpoint) |<br>        { if count &gt; f__free { return None; } else if let Some(checkpoint) =<br>        checkpoint &amp;&amp; slot &lt;= checkpoint { return None; } Some(((slot, ballot), entry<br>        .value)) }]<br>    )<br>})</code>"]:::otherClass
-205v1["<div style=text-align:center>(205v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-206v1["<div style=text-align:center>(206v1)</div> <code><br>flat_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_649_29!(<br>        [] [| (max_slot, checkpoint) | { if let Some(checkpoint) = checkpoint {<br>        (checkpoint + 1)..max_slot } else { 0..max_slot } }]<br>    )<br>})</code>"]:::otherClass
-207v1["<div style=text-align:center>(207v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-208v1["<div style=text-align:center>(208v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-209v1["<div style=text-align:center>(209v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-210v1["<div style=text-align:center>(210v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_658_16!(<br>        [] [move | (slot, ballot) | ((slot, ballot), None)]<br>    )<br>})</code>"]:::otherClass
-211v1["<div style=text-align:center>(211v1)</div> <code><br>chain()</code>"]:::otherClass
-212v1["<div style=text-align:center>(212v1)</div> <code><br>chain()</code>"]:::otherClass
-213v1["<div style=text-align:center>(213v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1053_46!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-214v1["<div style=text-align:center>(214v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-215v1["<div style=text-align:center>(215v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-216v1["<div style=text-align:center>(216v1)</div> <code><br>tee()</code>"]:::otherClass
-217v1["<div style=text-align:center>(217v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_735_20!(<br>        [CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),] [move |<br>        ((slot, ballot), value) | P2a { sender : CLUSTER_SELF_ID__free.clone(),<br>        ballot, slot, value }]<br>    )<br>})</code>"]:::otherClass
-218v1["<div style=text-align:center>(218v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-219v1["<div style=text-align:center>(219v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-220v1["<div style=text-align:center>(220v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-221v1["<div style=text-align:center>(221v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-222v1["<div style=text-align:center>(222v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>                core::result::Result&lt;<br>                    (),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-223v1["<div style=text-align:center>(223v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
+203v1["<div style=text-align:center>(203v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_0 = stream_332;<br>    let __hydro_singleton_ref_1 = stream_420;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_634_23!(<br>            [f__free = 1usize, p_ballot_ref__free = __hydro_singleton_ref_0,<br>            p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1,] [move | (slot,<br>            (count, entry)) | { if count &gt; f__free { return None; } else if let<br>            Some(checkpoint) = * p_p1b_max_checkpoint_ref__free &amp;&amp; slot &lt;= checkpoint<br>            { return None; } Some(((slot, p_ballot_ref__free.clone()), entry.value))<br>            }]<br>        )<br>    }<br>})</code>"]:::otherClass
+204v1["<div style=text-align:center>(204v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+205v1["<div style=text-align:center>(205v1)</div> <code><br>flat_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_649_29!(<br>        [] [| (max_slot, checkpoint) | { if let Some(checkpoint) = checkpoint {<br>        (checkpoint + 1)..max_slot } else { 0..max_slot } }]<br>    )<br>})</code>"]:::otherClass
+206v1["<div style=text-align:center>(206v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+207v1["<div style=text-align:center>(207v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+208v1["<div style=text-align:center>(208v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_332;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_657_16!(<br>            [p_ballot_ref__free = __hydro_singleton_ref_0,] [move | slot | ((slot,<br>            p_ballot_ref__free.clone()), None)]<br>        )<br>    }<br>})</code>"]:::otherClass
+209v1["<div style=text-align:center>(209v1)</div> <code><br>chain()</code>"]:::otherClass
+210v1["<div style=text-align:center>(210v1)</div> <code><br>chain()</code>"]:::otherClass
+211v1["<div style=text-align:center>(211v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1053_46!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+212v1["<div style=text-align:center>(212v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+213v1["<div style=text-align:center>(213v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+214v1["<div style=text-align:center>(214v1)</div> <code><br>tee()</code>"]:::otherClass
+215v1["<div style=text-align:center>(215v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_734_20!(<br>        [CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),] [move |<br>        ((slot, ballot), value) | P2a { sender : CLUSTER_SELF_ID__free.clone(),<br>        ballot, slot, value }]<br>    )<br>})</code>"]:::otherClass
+216v1["<div style=text-align:center>(216v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+217v1["<div style=text-align:center>(217v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+218v1["<div style=text-align:center>(218v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+219v1["<div style=text-align:center>(219v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+220v1["<div style=text-align:center>(220v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>                core::result::Result&lt;<br>                    (),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+221v1["<div style=text-align:center>(221v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
+222v1["<div style=text-align:center>(222v1)</div> <code><br>tee()</code>"]:::otherClass
+223v1["<div style=text-align:center>(223v1)</div> <code><br>chain()</code>"]:::otherClass
 224v1["<div style=text-align:center>(224v1)</div> <code><br>tee()</code>"]:::otherClass
-225v1["<div style=text-align:center>(225v1)</div> <code><br>chain()</code>"]:::otherClass
+225v1["<div style=text-align:center>(225v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_109_15!([] [move | | (0, 0)])<br>    },<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_110_15!(<br>            [] [move | accum, value | { if value.is_ok() { accum.0 += 1; } else {<br>            accum.1 += 1; } }]<br>        )<br>    },<br>)</code>"]:::otherClass
 226v1["<div style=text-align:center>(226v1)</div> <code><br>tee()</code>"]:::otherClass
-227v1["<div style=text-align:center>(227v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_109_15!([] [move | | (0, 0)])<br>    },<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_110_15!(<br>            [] [move | accum, value | { if value.is_ok() { accum.0 += 1; } else {<br>            accum.1 += 1; } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-228v1["<div style=text-align:center>(228v1)</div> <code><br>tee()</code>"]:::otherClass
-229v1["<div style=text-align:center>(229v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; (usize,<br>        usize), bool &gt; ({ use hydro_std::__staged::__deps:: *; use<br>        hydro_std::__staged::quorum:: *;<br>        hydro_std::__stageleft_quote_src_quorum_rs_134_27!([max__free = 3usize,]<br>        [move | (success, error) | (success + error) &gt;= max__free]) }),] [{ let orig<br>        = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-230v1["<div style=text-align:center>(230v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-231v1["<div style=text-align:center>(231v1)</div> <code><br>tee()</code>"]:::otherClass
-232v1["<div style=text-align:center>(232v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-233v1["<div style=text-align:center>(233v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::result::Result&lt;(), hydro_test::__staged::cluster::paxos::Ballot&gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
-234v1["<div style=text-align:center>(234v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_122_27!(<br>        [min__free = 2usize,] [move | (key, (success, _error)) | if success &gt;=<br>        min__free { Some(key) } else { None }]<br>    )<br>})</code>"]:::otherClass
-235v1["<div style=text-align:center>(235v1)</div> <code><br>tee()</code>"]:::otherClass
-236v1["<div style=text-align:center>(236v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-237v1["<div style=text-align:center>(237v1)</div> <code><br>identity::&lt;(usize, hydro_test::__staged::cluster::paxos::Ballot)&gt;()</code>"]:::otherClass
-238v1["<div style=text-align:center>(238v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-239v1["<div style=text-align:center>(239v1)</div> <code><br>chain()</code>"]:::otherClass
-240v1["<div style=text-align:center>(240v1)</div> <code><br>tee()</code>"]:::otherClass
-241v1["<div style=text-align:center>(241v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-242v1["<div style=text-align:center>(242v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-243v1["<div style=text-align:center>(243v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_751_23!([] [| k | (k, ())])<br>})</code>"]:::otherClass
-244v1["<div style=text-align:center>(244v1)</div> <code><br>tee()</code>"]:::otherClass
-245v1["<div style=text-align:center>(245v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_39_78!(<br>        [] [| (key, _) | key]<br>    )<br>})</code>"]:::otherClass
-246v1["<div style=text-align:center>(246v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-247v1["<div style=text-align:center>(247v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::option::Option&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
-248v1["<div style=text-align:center>(248v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_151_32!(<br>        [] [move | (key, res) | match res { Ok(_) =&gt; None, Err(e) =&gt; Some((key, e)),<br>        }]<br>    )<br>})</code>"]:::otherClass
-249v1["<div style=text-align:center>(249v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_765_21!([] [| (_, ballot) | ballot])<br>})</code>"]:::otherClass
-250v1["<div style=text-align:center>(250v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
-251v1["<div style=text-align:center>(251v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_34!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-252v1["<div style=text-align:center>(252v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-253v1["<div style=text-align:center>(253v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_51!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-254v1["<div style=text-align:center>(254v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
-255v1["<div style=text-align:center>(255v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-256v1["<div style=text-align:center>(256v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_545_16!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
-257v1["<div style=text-align:center>(257v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_36_11!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_37_11!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-258v1["<div style=text-align:center>(258v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_1187_61!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-259v1["<div style=text-align:center>(259v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-260v1["<div style=text-align:center>(260v1)</div> <code><br>join_multiset_half::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-261v1["<div style=text-align:center>(261v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_37_20!(<br>        [] [| (key, (meta, resp)) | (key, (meta, resp))]<br>    )<br>})</code>"]:::otherClass
-262v1["<div style=text-align:center>(262v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_763_29!(<br>        [] [| ((slot, _ballot), (value, _)) | (slot, value)]<br>    )<br>})</code>"]:::otherClass
-263v1["<div style=text-align:center>(263v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-264v1["<div style=text-align:center>(264v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-265v1["<div style=text-align:center>(265v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+227v1["<div style=text-align:center>(227v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; (usize,<br>        usize), bool &gt; ({ use hydro_std::__staged::__deps:: *; use<br>        hydro_std::__staged::quorum:: *;<br>        hydro_std::__stageleft_quote_src_quorum_rs_134_27!([max__free = 3usize,]<br>        [move | (success, error) | (success + error) &gt;= max__free]) }),] [{ let orig<br>        = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+228v1["<div style=text-align:center>(228v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+229v1["<div style=text-align:center>(229v1)</div> <code><br>tee()</code>"]:::otherClass
+230v1["<div style=text-align:center>(230v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+231v1["<div style=text-align:center>(231v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::result::Result&lt;(), hydro_test::__staged::cluster::paxos::Ballot&gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
+232v1["<div style=text-align:center>(232v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_122_27!(<br>        [min__free = 2usize,] [move | (key, (success, _error)) | if success &gt;=<br>        min__free { Some(key) } else { None }]<br>    )<br>})</code>"]:::otherClass
+233v1["<div style=text-align:center>(233v1)</div> <code><br>tee()</code>"]:::otherClass
+234v1["<div style=text-align:center>(234v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+235v1["<div style=text-align:center>(235v1)</div> <code><br>identity::&lt;(usize, hydro_test::__staged::cluster::paxos::Ballot)&gt;()</code>"]:::otherClass
+236v1["<div style=text-align:center>(236v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+237v1["<div style=text-align:center>(237v1)</div> <code><br>chain()</code>"]:::otherClass
+238v1["<div style=text-align:center>(238v1)</div> <code><br>tee()</code>"]:::otherClass
+239v1["<div style=text-align:center>(239v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+240v1["<div style=text-align:center>(240v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+241v1["<div style=text-align:center>(241v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_750_23!([] [| k | (k, ())])<br>})</code>"]:::otherClass
+242v1["<div style=text-align:center>(242v1)</div> <code><br>tee()</code>"]:::otherClass
+243v1["<div style=text-align:center>(243v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_39_78!(<br>        [] [| (key, _) | key]<br>    )<br>})</code>"]:::otherClass
+244v1["<div style=text-align:center>(244v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+245v1["<div style=text-align:center>(245v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::option::Option&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
+246v1["<div style=text-align:center>(246v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+247v1["<div style=text-align:center>(247v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_151_32!(<br>        [] [move | (key, res) | match res { Ok(_) =&gt; None, Err(e) =&gt; Some((key, e)),<br>        }]<br>    )<br>})</code>"]:::otherClass
+248v1["<div style=text-align:center>(248v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_764_21!([] [| (_, ballot) | ballot])<br>})</code>"]:::otherClass
+249v1["<div style=text-align:center>(249v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
+250v1["<div style=text-align:center>(250v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_34!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+251v1["<div style=text-align:center>(251v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+252v1["<div style=text-align:center>(252v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_51!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+253v1["<div style=text-align:center>(253v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+254v1["<div style=text-align:center>(254v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+255v1["<div style=text-align:center>(255v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_545_16!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
+256v1["<div style=text-align:center>(256v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_36_11!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_37_11!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+257v1["<div style=text-align:center>(257v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_1187_61!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+258v1["<div style=text-align:center>(258v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+259v1["<div style=text-align:center>(259v1)</div> <code><br>join_multiset_half::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+260v1["<div style=text-align:center>(260v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_37_20!(<br>        [] [| (key, (meta, resp)) | (key, (meta, resp))]<br>    )<br>})</code>"]:::otherClass
+261v1["<div style=text-align:center>(261v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_762_29!(<br>        [] [| ((slot, _ballot), (value, _)) | (slot, value)]<br>    )<br>})</code>"]:::otherClass
+262v1["<div style=text-align:center>(262v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+263v1["<div style=text-align:center>(263v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+264v1["<div style=text-align:center>(264v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
 1v1-->2v1
 132v1-->|0|3v1
-250v1-->|1|3v1
+249v1-->|1|3v1
 3v1-->|0|4v1
 50v1-->|1|4v1
 4v1-->5v1
@@ -441,135 +436,130 @@ linkStyle default stroke:#aaa
 152v1-->|1|153v1
 154v1-->155v1
 153v1-->154v1
-156v1-->157v1
-157v1-->158v1
-128v1-->159v1
-158v1-->|input|160v1
-159v1-->|single|160v1
+25v1-->157v1
+117v1-->158v1
+158v1-->159v1
+159v1-->160v1
 160v1-->161v1
 161v1-->162v1
-117v1-->163v1
+162v1-->163v1
 163v1-->164v1
 164v1-->165v1
 165v1-->166v1
 166v1-->167v1
 167v1-->168v1
-168v1-->169v1
-169v1-->170v1
+187v1--o169v1; linkStyle 180 stroke:red
 170v1-->171v1
-171v1-->172v1
-172v1-->173v1
-186v1--o174v1; linkStyle 186 stroke:red
+169v1-->|0|172v1
+171v1-->|1|172v1
+168v1-->|0|173v1
+172v1-->|1|173v1
+173v1-->|single|185v1
 175v1-->176v1
-174v1-->|0|177v1
-176v1-->|1|177v1
-173v1-->|0|178v1
-177v1-->|1|178v1
-178v1-->179v1
-162v1-->|input|180v1
-179v1-->|single|180v1
+176v1-->177v1
+128v1-->178v1
+177v1-->|input|179v1
+178v1-->|single|179v1
+179v1-->180v1
 180v1-->181v1
 181v1-->182v1
 182v1-->183v1
-183v1-->|input|184v1
-179v1-->|single|184v1
-184v1-->185v1
+183v1-->184v1
+184v1-->|input|185v1
 185v1-->186v1
-233v1--o187v1; linkStyle 202 stroke:red
-188v1-->189v1
+186v1-->187v1
+231v1--o188v1; linkStyle 200 stroke:red
 189v1-->190v1
 190v1-->191v1
 191v1-->192v1
-182v1-->|input|193v1
-25v1-->|single|193v1
-193v1-->194v1
-169v1-->|input|195v1
-25v1-->|single|195v1
-164v1-->196v1
+192v1-->193v1
+25v1-->246v1
+183v1-->195v1
+159v1-->196v1
 196v1-->197v1
 197v1-->198v1
 199v1-->200v1
 198v1-->|0|201v1
 200v1-->|1|201v1
-201v1-->202v1
-195v1-->|input|203v1
-202v1-->|single|203v1
-203v1-->204v1
-172v1-->|input|205v1
-202v1-->|single|205v1
-205v1-->206v1
-169v1-->207v1
-206v1-->|pos|208v1
-207v1-->|neg|208v1
-208v1-->|input|209v1
-25v1-->|single|209v1
-209v1-->210v1
-204v1-->|0|211v1
-210v1-->|1|211v1
-194v1-->|0|212v1
-211v1-->|1|212v1
-128v1-->213v1
-212v1-->|input|214v1
-213v1-->|single|214v1
+201v1-->|single|204v1
+164v1-->203v1
+167v1-->|input|204v1
+204v1-->205v1
+164v1-->206v1
+205v1-->|pos|207v1
+206v1-->|neg|207v1
+207v1-->208v1
+203v1-->|0|209v1
+208v1-->|1|209v1
+195v1-->|0|210v1
+209v1-->|1|210v1
+128v1-->211v1
+210v1-->|input|212v1
+211v1-->|single|212v1
+212v1-->213v1
+213v1-->214v1
 214v1-->215v1
-215v1-->216v1
+193v1-->|0|216v1
+215v1-->|1|216v1
+217v1-->218v1
 216v1-->217v1
-192v1-->|0|218v1
-217v1-->|1|218v1
 219v1-->220v1
-218v1-->219v1
+220v1-->221v1
 221v1-->222v1
-222v1-->223v1
+188v1-->|0|223v1
+222v1-->|1|223v1
 223v1-->224v1
-187v1-->|0|225v1
-224v1-->|1|225v1
+224v1-->225v1
 225v1-->226v1
 226v1-->227v1
 227v1-->228v1
 228v1-->229v1
-229v1-->230v1
+224v1-->|pos|230v1
+229v1-->|neg|230v1
 230v1-->231v1
-226v1-->|pos|232v1
-231v1-->|neg|232v1
+226v1-->232v1
 232v1-->233v1
-228v1-->234v1
+233v1-->|pos|234v1
+229v1-->|neg|234v1
 234v1-->235v1
-235v1-->|pos|236v1
-231v1-->|neg|236v1
-236v1-->237v1
-247v1--o238v1; linkStyle 264 stroke:red
-238v1-->|0|239v1
-216v1-->|1|239v1
-239v1-->240v1
-237v1--o241v1; linkStyle 268 stroke:red
-235v1-->|pos|242v1
-241v1-->|neg|242v1
+245v1--o236v1; linkStyle 254 stroke:red
+236v1-->|0|237v1
+214v1-->|1|237v1
+237v1-->238v1
+235v1--o239v1; linkStyle 258 stroke:red
+233v1-->|pos|240v1
+239v1-->|neg|240v1
+240v1-->241v1
+241v1-->242v1
 242v1-->243v1
-243v1-->244v1
+238v1-->|pos|244v1
+243v1-->|neg|244v1
 244v1-->245v1
-240v1-->|pos|246v1
-245v1-->|neg|246v1
-246v1-->247v1
-224v1-->248v1
+222v1-->247v1
+247v1-->248v1
 248v1-->249v1
-249v1-->250v1
-149v1-->251v1
-25v1-->|input|252v1
-251v1-->|single|252v1
+149v1-->250v1
+25v1-->|input|251v1
+250v1-->|single|251v1
+251v1-->252v1
 252v1-->253v1
-253v1-->254v1
+254v1-->255v1
 255v1-->256v1
 256v1-->257v1
 257v1-->258v1
-258v1-->259v1
-240v1-->|probe|260v1
-244v1-->|build|260v1
+238v1-->|probe|259v1
+242v1-->|build|259v1
+259v1-->260v1
 260v1-->261v1
-261v1-->262v1
-259v1-->|0|263v1
-262v1-->|1|263v1
-264v1-->265v1
+258v1-->|0|262v1
+261v1-->|1|262v1
 263v1-->264v1
+262v1-->263v1
+173v1-->182v1
+25v1-->195v1
+25v1-->203v1
+201v1-->203v1
+25v1-->208v1
 2v1
 44v1
 45v1
@@ -577,34 +567,36 @@ linkStyle default stroke:#aaa
 87v1
 154v1
 155v1
-219v1
-220v1
-254v1
+157v1
+217v1
+218v1
+246v1
+253v1
+263v1
 264v1
-265v1
 subgraph var_cycle_10 ["var <tt>cycle_10</tt>"]
     style var_cycle_10 fill:transparent
     105v1
 end
 subgraph var_cycle_12 ["var <tt>cycle_12</tt>"]
     style var_cycle_12 fill:transparent
-    186v1
+    187v1
 end
 subgraph var_cycle_13 ["var <tt>cycle_13</tt>"]
     style var_cycle_13 fill:transparent
-    233v1
+    231v1
 end
 subgraph var_cycle_14 ["var <tt>cycle_14</tt>"]
     style var_cycle_14 fill:transparent
-    237v1
+    235v1
 end
 subgraph var_cycle_15 ["var <tt>cycle_15</tt>"]
     style var_cycle_15 fill:transparent
-    247v1
+    245v1
 end
 subgraph var_cycle_3 ["var <tt>cycle_3</tt>"]
     style var_cycle_3 fill:transparent
-    250v1
+    249v1
 end
 subgraph var_cycle_5 ["var <tt>cycle_5</tt>"]
     style var_cycle_5 fill:transparent
@@ -1028,106 +1020,94 @@ subgraph var_stream_33 ["var <tt>stream_33</tt>"]
     style var_stream_33 fill:transparent
     5v1
 end
+subgraph var_stream_336 ["var <tt>stream_336</tt>"]
+    style var_stream_336 fill:transparent
+    158v1
+end
 subgraph var_stream_337 ["var <tt>stream_337</tt>"]
     style var_stream_337 fill:transparent
-    156v1
-    157v1
+    159v1
+end
+subgraph var_stream_338 ["var <tt>stream_338</tt>"]
+    style var_stream_338 fill:transparent
+    160v1
 end
 subgraph var_stream_339 ["var <tt>stream_339</tt>"]
     style var_stream_339 fill:transparent
-    158v1
+    161v1
+end
+subgraph var_stream_341 ["var <tt>stream_341</tt>"]
+    style var_stream_341 fill:transparent
+    162v1
+end
+subgraph var_stream_342 ["var <tt>stream_342</tt>"]
+    style var_stream_342 fill:transparent
+    163v1
 end
 subgraph var_stream_343 ["var <tt>stream_343</tt>"]
     style var_stream_343 fill:transparent
-    159v1
+    164v1
 end
-subgraph var_stream_344 ["var <tt>stream_344</tt>"]
-    style var_stream_344 fill:transparent
-    160v1
-end
-subgraph var_stream_345 ["var <tt>stream_345</tt>"]
-    style var_stream_345 fill:transparent
-    161v1
+subgraph var_stream_346 ["var <tt>stream_346</tt>"]
+    style var_stream_346 fill:transparent
+    165v1
 end
 subgraph var_stream_348 ["var <tt>stream_348</tt>"]
     style var_stream_348 fill:transparent
-    162v1
+    166v1
+end
+subgraph var_stream_349 ["var <tt>stream_349</tt>"]
+    style var_stream_349 fill:transparent
+    167v1
 end
 subgraph var_stream_35 ["var <tt>stream_35</tt>"]
     style var_stream_35 fill:transparent
     6v1
 end
-subgraph var_stream_351 ["var <tt>stream_351</tt>"]
-    style var_stream_351 fill:transparent
-    163v1
-end
 subgraph var_stream_352 ["var <tt>stream_352</tt>"]
     style var_stream_352 fill:transparent
-    164v1
-end
-subgraph var_stream_353 ["var <tt>stream_353</tt>"]
-    style var_stream_353 fill:transparent
-    165v1
+    168v1
 end
 subgraph var_stream_354 ["var <tt>stream_354</tt>"]
     style var_stream_354 fill:transparent
-    166v1
+    169v1
 end
-subgraph var_stream_356 ["var <tt>stream_356</tt>"]
-    style var_stream_356 fill:transparent
-    167v1
+subgraph var_stream_355 ["var <tt>stream_355</tt>"]
+    style var_stream_355 fill:transparent
+    170v1
+    171v1
 end
 subgraph var_stream_357 ["var <tt>stream_357</tt>"]
     style var_stream_357 fill:transparent
-    168v1
-end
-subgraph var_stream_358 ["var <tt>stream_358</tt>"]
-    style var_stream_358 fill:transparent
-    169v1
+    172v1
 end
 subgraph var_stream_36 ["var <tt>stream_36</tt>"]
     style var_stream_36 fill:transparent
     7v1
 end
-subgraph var_stream_361 ["var <tt>stream_361</tt>"]
-    style var_stream_361 fill:transparent
-    170v1
-end
-subgraph var_stream_363 ["var <tt>stream_363</tt>"]
-    style var_stream_363 fill:transparent
-    171v1
-end
-subgraph var_stream_364 ["var <tt>stream_364</tt>"]
-    style var_stream_364 fill:transparent
-    172v1
-end
-subgraph var_stream_367 ["var <tt>stream_367</tt>"]
-    style var_stream_367 fill:transparent
+subgraph var_stream_360 ["var <tt>stream_360</tt>"]
+    style var_stream_360 fill:transparent
     173v1
 end
 subgraph var_stream_369 ["var <tt>stream_369</tt>"]
     style var_stream_369 fill:transparent
-    174v1
-end
-subgraph var_stream_370 ["var <tt>stream_370</tt>"]
-    style var_stream_370 fill:transparent
     175v1
     176v1
 end
-subgraph var_stream_372 ["var <tt>stream_372</tt>"]
-    style var_stream_372 fill:transparent
+subgraph var_stream_371 ["var <tt>stream_371</tt>"]
+    style var_stream_371 fill:transparent
     177v1
 end
 subgraph var_stream_375 ["var <tt>stream_375</tt>"]
     style var_stream_375 fill:transparent
     178v1
 end
-subgraph var_stream_377 ["var <tt>stream_377</tt>"]
-    style var_stream_377 fill:transparent
+subgraph var_stream_376 ["var <tt>stream_376</tt>"]
+    style var_stream_376 fill:transparent
     179v1
 end
-subgraph var_stream_379 ["var <tt>stream_379</tt>"]
-    style var_stream_379 fill:transparent
+subgraph var_stream_377 ["var <tt>stream_377</tt>"]
+    style var_stream_377 fill:transparent
     180v1
 end
 subgraph var_stream_380 ["var <tt>stream_380</tt>"]
@@ -1142,101 +1122,93 @@ subgraph var_stream_382 ["var <tt>stream_382</tt>"]
     style var_stream_382 fill:transparent
     183v1
 end
-subgraph var_stream_384 ["var <tt>stream_384</tt>"]
-    style var_stream_384 fill:transparent
+subgraph var_stream_383 ["var <tt>stream_383</tt>"]
+    style var_stream_383 fill:transparent
     184v1
 end
-subgraph var_stream_386 ["var <tt>stream_386</tt>"]
-    style var_stream_386 fill:transparent
+subgraph var_stream_385 ["var <tt>stream_385</tt>"]
+    style var_stream_385 fill:transparent
     185v1
 end
-subgraph var_stream_388 ["var <tt>stream_388</tt>"]
-    style var_stream_388 fill:transparent
-    187v1
-end
-subgraph var_stream_389 ["var <tt>stream_389</tt>"]
-    style var_stream_389 fill:transparent
-    188v1
+subgraph var_stream_387 ["var <tt>stream_387</tt>"]
+    style var_stream_387 fill:transparent
+    186v1
 end
 subgraph var_stream_39 ["var <tt>stream_39</tt>"]
     style var_stream_39 fill:transparent
     8v1
 end
-subgraph var_stream_390 ["var <tt>stream_390</tt>"]
-    style var_stream_390 fill:transparent
-    189v1
-end
 subgraph var_stream_392 ["var <tt>stream_392</tt>"]
     style var_stream_392 fill:transparent
-    190v1
+    188v1
 end
 subgraph var_stream_394 ["var <tt>stream_394</tt>"]
     style var_stream_394 fill:transparent
-    191v1
+    189v1
+end
+subgraph var_stream_395 ["var <tt>stream_395</tt>"]
+    style var_stream_395 fill:transparent
+    190v1
 end
 subgraph var_stream_397 ["var <tt>stream_397</tt>"]
     style var_stream_397 fill:transparent
+    191v1
+end
+subgraph var_stream_399 ["var <tt>stream_399</tt>"]
+    style var_stream_399 fill:transparent
     192v1
 end
-subgraph var_stream_404 ["var <tt>stream_404</tt>"]
-    style var_stream_404 fill:transparent
+subgraph var_stream_402 ["var <tt>stream_402</tt>"]
+    style var_stream_402 fill:transparent
     193v1
 end
-subgraph var_stream_405 ["var <tt>stream_405</tt>"]
-    style var_stream_405 fill:transparent
-    194v1
-end
-subgraph var_stream_411 ["var <tt>stream_411</tt>"]
-    style var_stream_411 fill:transparent
+subgraph var_stream_409 ["var <tt>stream_409</tt>"]
+    style var_stream_409 fill:transparent
     195v1
 end
-subgraph var_stream_413 ["var <tt>stream_413</tt>"]
-    style var_stream_413 fill:transparent
+subgraph var_stream_412 ["var <tt>stream_412</tt>"]
+    style var_stream_412 fill:transparent
     196v1
+end
+subgraph var_stream_414 ["var <tt>stream_414</tt>"]
+    style var_stream_414 fill:transparent
+    197v1
 end
 subgraph var_stream_415 ["var <tt>stream_415</tt>"]
     style var_stream_415 fill:transparent
-    197v1
+    198v1
 end
 subgraph var_stream_416 ["var <tt>stream_416</tt>"]
     style var_stream_416 fill:transparent
-    198v1
-end
-subgraph var_stream_417 ["var <tt>stream_417</tt>"]
-    style var_stream_417 fill:transparent
     199v1
     200v1
 end
-subgraph var_stream_419 ["var <tt>stream_419</tt>"]
-    style var_stream_419 fill:transparent
+subgraph var_stream_418 ["var <tt>stream_418</tt>"]
+    style var_stream_418 fill:transparent
     201v1
-end
-subgraph var_stream_421 ["var <tt>stream_421</tt>"]
-    style var_stream_421 fill:transparent
-    202v1
-end
-subgraph var_stream_423 ["var <tt>stream_423</tt>"]
-    style var_stream_423 fill:transparent
-    203v1
 end
 subgraph var_stream_424 ["var <tt>stream_424</tt>"]
     style var_stream_424 fill:transparent
+    203v1
+end
+subgraph var_stream_429 ["var <tt>stream_429</tt>"]
+    style var_stream_429 fill:transparent
     204v1
 end
-subgraph var_stream_428 ["var <tt>stream_428</tt>"]
-    style var_stream_428 fill:transparent
+subgraph var_stream_431 ["var <tt>stream_431</tt>"]
+    style var_stream_431 fill:transparent
     205v1
-end
-subgraph var_stream_430 ["var <tt>stream_430</tt>"]
-    style var_stream_430 fill:transparent
-    206v1
-end
-subgraph var_stream_434 ["var <tt>stream_434</tt>"]
-    style var_stream_434 fill:transparent
-    207v1
 end
 subgraph var_stream_435 ["var <tt>stream_435</tt>"]
     style var_stream_435 fill:transparent
+    206v1
+end
+subgraph var_stream_436 ["var <tt>stream_436</tt>"]
+    style var_stream_436 fill:transparent
+    207v1
+end
+subgraph var_stream_437 ["var <tt>stream_437</tt>"]
+    style var_stream_437 fill:transparent
     208v1
 end
 subgraph var_stream_438 ["var <tt>stream_438</tt>"]
@@ -1247,54 +1219,58 @@ subgraph var_stream_439 ["var <tt>stream_439</tt>"]
     style var_stream_439 fill:transparent
     210v1
 end
-subgraph var_stream_440 ["var <tt>stream_440</tt>"]
-    style var_stream_440 fill:transparent
-    211v1
-end
 subgraph var_stream_441 ["var <tt>stream_441</tt>"]
     style var_stream_441 fill:transparent
+    211v1
+end
+subgraph var_stream_442 ["var <tt>stream_442</tt>"]
+    style var_stream_442 fill:transparent
     212v1
 end
 subgraph var_stream_443 ["var <tt>stream_443</tt>"]
     style var_stream_443 fill:transparent
     213v1
 end
-subgraph var_stream_444 ["var <tt>stream_444</tt>"]
-    style var_stream_444 fill:transparent
-    214v1
-end
 subgraph var_stream_445 ["var <tt>stream_445</tt>"]
     style var_stream_445 fill:transparent
-    215v1
+    214v1
 end
 subgraph var_stream_447 ["var <tt>stream_447</tt>"]
     style var_stream_447 fill:transparent
-    216v1
+    215v1
 end
 subgraph var_stream_449 ["var <tt>stream_449</tt>"]
     style var_stream_449 fill:transparent
-    217v1
+    216v1
 end
 subgraph var_stream_45 ["var <tt>stream_45</tt>"]
     style var_stream_45 fill:transparent
     9v1
 end
-subgraph var_stream_451 ["var <tt>stream_451</tt>"]
-    style var_stream_451 fill:transparent
-    218v1
+subgraph var_stream_460 ["var <tt>stream_460</tt>"]
+    style var_stream_460 fill:transparent
+    219v1
+    220v1
+end
+subgraph var_stream_462 ["var <tt>stream_462</tt>"]
+    style var_stream_462 fill:transparent
+    221v1
+end
+subgraph var_stream_463 ["var <tt>stream_463</tt>"]
+    style var_stream_463 fill:transparent
+    222v1
 end
 subgraph var_stream_465 ["var <tt>stream_465</tt>"]
     style var_stream_465 fill:transparent
-    221v1
-    222v1
-end
-subgraph var_stream_467 ["var <tt>stream_467</tt>"]
-    style var_stream_467 fill:transparent
     223v1
 end
-subgraph var_stream_468 ["var <tt>stream_468</tt>"]
-    style var_stream_468 fill:transparent
+subgraph var_stream_466 ["var <tt>stream_466</tt>"]
+    style var_stream_466 fill:transparent
     224v1
+end
+subgraph var_stream_469 ["var <tt>stream_469</tt>"]
+    style var_stream_469 fill:transparent
+    225v1
 end
 subgraph var_stream_47 ["var <tt>stream_47</tt>"]
     style var_stream_47 fill:transparent
@@ -1302,26 +1278,22 @@ subgraph var_stream_47 ["var <tt>stream_47</tt>"]
 end
 subgraph var_stream_470 ["var <tt>stream_470</tt>"]
     style var_stream_470 fill:transparent
-    225v1
+    226v1
 end
 subgraph var_stream_471 ["var <tt>stream_471</tt>"]
     style var_stream_471 fill:transparent
-    226v1
+    227v1
 end
 subgraph var_stream_474 ["var <tt>stream_474</tt>"]
     style var_stream_474 fill:transparent
-    227v1
+    228v1
 end
 subgraph var_stream_475 ["var <tt>stream_475</tt>"]
     style var_stream_475 fill:transparent
-    228v1
+    229v1
 end
 subgraph var_stream_476 ["var <tt>stream_476</tt>"]
     style var_stream_476 fill:transparent
-    229v1
-end
-subgraph var_stream_479 ["var <tt>stream_479</tt>"]
-    style var_stream_479 fill:transparent
     230v1
 end
 subgraph var_stream_48 ["var <tt>stream_48</tt>"]
@@ -1331,39 +1303,43 @@ subgraph var_stream_48 ["var <tt>stream_48</tt>"]
 end
 subgraph var_stream_480 ["var <tt>stream_480</tt>"]
     style var_stream_480 fill:transparent
-    231v1
+    232v1
 end
 subgraph var_stream_481 ["var <tt>stream_481</tt>"]
     style var_stream_481 fill:transparent
-    232v1
+    233v1
+end
+subgraph var_stream_483 ["var <tt>stream_483</tt>"]
+    style var_stream_483 fill:transparent
+    234v1
 end
 subgraph var_stream_485 ["var <tt>stream_485</tt>"]
     style var_stream_485 fill:transparent
-    234v1
-end
-subgraph var_stream_486 ["var <tt>stream_486</tt>"]
-    style var_stream_486 fill:transparent
-    235v1
-end
-subgraph var_stream_488 ["var <tt>stream_488</tt>"]
-    style var_stream_488 fill:transparent
     236v1
 end
 subgraph var_stream_490 ["var <tt>stream_490</tt>"]
     style var_stream_490 fill:transparent
+    237v1
+end
+subgraph var_stream_491 ["var <tt>stream_491</tt>"]
+    style var_stream_491 fill:transparent
     238v1
+end
+subgraph var_stream_494 ["var <tt>stream_494</tt>"]
+    style var_stream_494 fill:transparent
+    239v1
 end
 subgraph var_stream_495 ["var <tt>stream_495</tt>"]
     style var_stream_495 fill:transparent
-    239v1
-end
-subgraph var_stream_496 ["var <tt>stream_496</tt>"]
-    style var_stream_496 fill:transparent
     240v1
+end
+subgraph var_stream_497 ["var <tt>stream_497</tt>"]
+    style var_stream_497 fill:transparent
+    241v1
 end
 subgraph var_stream_499 ["var <tt>stream_499</tt>"]
     style var_stream_499 fill:transparent
-    241v1
+    242v1
 end
 subgraph var_stream_50 ["var <tt>stream_50</tt>"]
     style var_stream_50 fill:transparent
@@ -1371,43 +1347,39 @@ subgraph var_stream_50 ["var <tt>stream_50</tt>"]
 end
 subgraph var_stream_500 ["var <tt>stream_500</tt>"]
     style var_stream_500 fill:transparent
-    242v1
-end
-subgraph var_stream_502 ["var <tt>stream_502</tt>"]
-    style var_stream_502 fill:transparent
     243v1
 end
-subgraph var_stream_504 ["var <tt>stream_504</tt>"]
-    style var_stream_504 fill:transparent
+subgraph var_stream_501 ["var <tt>stream_501</tt>"]
+    style var_stream_501 fill:transparent
     244v1
-end
-subgraph var_stream_505 ["var <tt>stream_505</tt>"]
-    style var_stream_505 fill:transparent
-    245v1
-end
-subgraph var_stream_506 ["var <tt>stream_506</tt>"]
-    style var_stream_506 fill:transparent
-    246v1
 end
 subgraph var_stream_52 ["var <tt>stream_52</tt>"]
     style var_stream_52 fill:transparent
     14v1
 end
+subgraph var_stream_529 ["var <tt>stream_529</tt>"]
+    style var_stream_529 fill:transparent
+    247v1
+end
+subgraph var_stream_530 ["var <tt>stream_530</tt>"]
+    style var_stream_530 fill:transparent
+    248v1
+end
+subgraph var_stream_533 ["var <tt>stream_533</tt>"]
+    style var_stream_533 fill:transparent
+    250v1
+end
 subgraph var_stream_534 ["var <tt>stream_534</tt>"]
     style var_stream_534 fill:transparent
-    248v1
+    251v1
 end
 subgraph var_stream_535 ["var <tt>stream_535</tt>"]
     style var_stream_535 fill:transparent
-    249v1
-end
-subgraph var_stream_538 ["var <tt>stream_538</tt>"]
-    style var_stream_538 fill:transparent
-    251v1
+    252v1
 end
 subgraph var_stream_539 ["var <tt>stream_539</tt>"]
     style var_stream_539 fill:transparent
-    252v1
+    254v1
 end
 subgraph var_stream_54 ["var <tt>stream_54</tt>"]
     style var_stream_54 fill:transparent
@@ -1415,51 +1387,43 @@ subgraph var_stream_54 ["var <tt>stream_54</tt>"]
 end
 subgraph var_stream_540 ["var <tt>stream_540</tt>"]
     style var_stream_540 fill:transparent
-    253v1
+    255v1
+end
+subgraph var_stream_542 ["var <tt>stream_542</tt>"]
+    style var_stream_542 fill:transparent
+    256v1
 end
 subgraph var_stream_544 ["var <tt>stream_544</tt>"]
     style var_stream_544 fill:transparent
-    255v1
-end
-subgraph var_stream_545 ["var <tt>stream_545</tt>"]
-    style var_stream_545 fill:transparent
-    256v1
+    257v1
 end
 subgraph var_stream_547 ["var <tt>stream_547</tt>"]
     style var_stream_547 fill:transparent
-    257v1
-end
-subgraph var_stream_549 ["var <tt>stream_549</tt>"]
-    style var_stream_549 fill:transparent
     258v1
 end
 subgraph var_stream_55 ["var <tt>stream_55</tt>"]
     style var_stream_55 fill:transparent
     16v1
 end
+subgraph var_stream_551 ["var <tt>stream_551</tt>"]
+    style var_stream_551 fill:transparent
+    259v1
+end
 subgraph var_stream_552 ["var <tt>stream_552</tt>"]
     style var_stream_552 fill:transparent
-    259v1
+    260v1
+end
+subgraph var_stream_554 ["var <tt>stream_554</tt>"]
+    style var_stream_554 fill:transparent
+    261v1
 end
 subgraph var_stream_556 ["var <tt>stream_556</tt>"]
     style var_stream_556 fill:transparent
-    260v1
-end
-subgraph var_stream_557 ["var <tt>stream_557</tt>"]
-    style var_stream_557 fill:transparent
-    261v1
-end
-subgraph var_stream_559 ["var <tt>stream_559</tt>"]
-    style var_stream_559 fill:transparent
     262v1
 end
 subgraph var_stream_56 ["var <tt>stream_56</tt>"]
     style var_stream_56 fill:transparent
     18v1
-end
-subgraph var_stream_561 ["var <tt>stream_561</tt>"]
-    style var_stream_561 fill:transparent
-    263v1
 end
 subgraph var_stream_57 ["var <tt>stream_57</tt>"]
     style var_stream_57 fill:transparent

--- a/hydro_test/src/cluster/snapshots-nightly/paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots-nightly/paxos_ir@proposer_mermaid.snap
@@ -58,43 +58,43 @@ linkStyle default stroke:#aaa
 48v1["<div style=text-align:center>(48v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
 49v1["<div style=text-align:center>(49v1)</div> <code><br>tee()</code>"]:::otherClass
 50v1["<div style=text-align:center>(50v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
-51v1["<div style=text-align:center>(51v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-52v1["<div style=text-align:center>(52v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-53v1["<div style=text-align:center>(53v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_545_16!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
-54v1["<div style=text-align:center>(54v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_36_11!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_37_11!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-55v1["<div style=text-align:center>(55v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_1187_61!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-56v1["<div style=text-align:center>(56v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-57v1["<div style=text-align:center>(57v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2016_15!(<br>            [] [| | None]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2018_16!(<br>            [] [| latest, _ | { * latest = Some(Instant::now()); }]<br>        )<br>    },<br>)</code>"]:::otherClass
-58v1["<div style=text-align:center>(58v1)</div> <code><br>filter_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2027_27!(<br>        [duration__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_438_15!([i_am_leader_check_timeout__free<br>        = 10u64,] [Duration::from_secs(i_am_leader_check_timeout__free)]) },] [move |<br>        latest_received | { if let Some(latest_received) = latest_received { if<br>        Instant::now().duration_since(latest_received) &gt; duration__free { Some(()) }<br>        else { None } } else { Some(()) } }]<br>    )<br>})</code>"]:::otherClass
-59v1["<div style=text-align:center>(59v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_1078_20!(<br>        [] [| b | ! b]<br>    )<br>})</code>"]:::otherClass
-60v1["<div style=text-align:center>(60v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_1105_34!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-61v1["<div style=text-align:center>(61v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-62v1["<div style=text-align:center>(62v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_1105_51!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-63v1["<div style=text-align:center>(63v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_906_20!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
-64v1["<div style=text-align:center>(64v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
-65v1["<div style=text-align:center>(65v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-66v1["<div style=text-align:center>(66v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-67v1["<div style=text-align:center>(67v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-68v1["<div style=text-align:center>(68v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_908_20!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
-69v1["<div style=text-align:center>(69v1)</div> <code><br>source_stream({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_1439_30!(<br>        [delay__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_453_19!([CLUSTER_SELF_ID__free =<br>        hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),<br>        i_am_leader_check_timeout_delay_multiplier__free = 15usize,]<br>        [Duration::from_secs((CLUSTER_SELF_ID__free.get_raw_id() *<br>        i_am_leader_check_timeout_delay_multiplier__free as u32).into())]) },<br>        interval__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_458_19!([i_am_leader_check_timeout__free<br>        = 10u64,] [Duration::from_secs(i_am_leader_check_timeout__free)]) },]<br>        [tokio_stream::StreamExt::map(tokio_stream::wrappers::IntervalStream::new(tokio::time::interval_at(tokio::time::Instant::now()<br>        + delay__free, interval__free,)), | _ | ())]<br>    )<br>})</code>"]:::otherClass
-70v1["<div style=text-align:center>(70v1)</div> <code><br>scan::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1915_27!(<br>            [] [| | None]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1918_24!(<br>            [f__free = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt; (),<br>            (),<br>            hydro_test::__staged::__deps::hydro_lang::live_collections::keyed_stream::Generate<br>            &lt; () &gt; &gt; ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1588_37!([]<br>            [| _, item | Generate::Return(item)]) }), init__free =<br>            stageleft::runtime_support::fn0_type_hint:: &lt; () &gt; ({ use<br>            hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1588_26!([]<br>            [| | ()]) }),] [move | state : &amp; mut Option &lt; Option &lt; _ &gt; &gt;, v | { if<br>            state.is_none() { * state = Some(Some(init__free())); } match state {<br>            Some(Some(state_value)) =&gt; match f__free(state_value, v) {<br>            Generate::Yield(out) =&gt; Some(Some(out)), Generate::Return(out) =&gt; { *<br>            state = Some(None); Some(Some(out)) } Generate::Break =&gt; None,<br>            Generate::Continue =&gt; Some(None), }, _ =&gt; None, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-71v1["<div style=text-align:center>(71v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1955_27!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
-72v1["<div style=text-align:center>(72v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1589_23!(<br>        [] [| _, _ | {}]<br>    )<br>})</code>"]:::otherClass
-73v1["<div style=text-align:center>(73v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_906_20!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
-74v1["<div style=text-align:center>(74v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
-75v1["<div style=text-align:center>(75v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-76v1["<div style=text-align:center>(76v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-77v1["<div style=text-align:center>(77v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-78v1["<div style=text-align:center>(78v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_908_20!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
-79v1["<div style=text-align:center>(79v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-80v1["<div style=text-align:center>(80v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_1144_31!(<br>        [] [| (a, b) | a &amp;&amp; b]<br>    )<br>})</code>"]:::otherClass
-81v1["<div style=text-align:center>(81v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_34!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-82v1["<div style=text-align:center>(82v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-83v1["<div style=text-align:center>(83v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_51!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-84v1["<div style=text-align:center>(84v1)</div> <code><br>inspect({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_317_20!(<br>        [] [| _ | println!(&quot;Proposer leader expired, sending P1a&quot;)]<br>    )<br>})</code>"]:::otherClass
-85v1["<div style=text-align:center>(85v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-86v1["<div style=text-align:center>(86v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-87v1["<div style=text-align:center>(87v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+51v1["<div style=text-align:center>(51v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+52v1["<div style=text-align:center>(52v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_545_16!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
+53v1["<div style=text-align:center>(53v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_36_11!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_37_11!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+54v1["<div style=text-align:center>(54v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_1187_61!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+55v1["<div style=text-align:center>(55v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+56v1["<div style=text-align:center>(56v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2016_15!(<br>            [] [| | None]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2018_16!(<br>            [] [| latest, _ | { * latest = Some(Instant::now()); }]<br>        )<br>    },<br>)</code>"]:::otherClass
+57v1["<div style=text-align:center>(57v1)</div> <code><br>filter_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2027_27!(<br>        [duration__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_438_15!([i_am_leader_check_timeout__free<br>        = 10u64,] [Duration::from_secs(i_am_leader_check_timeout__free)]) },] [move |<br>        latest_received | { if let Some(latest_received) = latest_received { if<br>        Instant::now().duration_since(latest_received) &gt; duration__free { Some(()) }<br>        else { None } } else { Some(()) } }]<br>    )<br>})</code>"]:::otherClass
+58v1["<div style=text-align:center>(58v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_1078_20!(<br>        [] [| b | ! b]<br>    )<br>})</code>"]:::otherClass
+59v1["<div style=text-align:center>(59v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_1105_34!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+60v1["<div style=text-align:center>(60v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+61v1["<div style=text-align:center>(61v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_1105_51!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+62v1["<div style=text-align:center>(62v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_906_20!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
+63v1["<div style=text-align:center>(63v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+64v1["<div style=text-align:center>(64v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+65v1["<div style=text-align:center>(65v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+66v1["<div style=text-align:center>(66v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+67v1["<div style=text-align:center>(67v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_908_20!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
+68v1["<div style=text-align:center>(68v1)</div> <code><br>source_stream({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_1439_30!(<br>        [delay__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_453_19!([CLUSTER_SELF_ID__free =<br>        hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),<br>        i_am_leader_check_timeout_delay_multiplier__free = 15usize,]<br>        [Duration::from_secs((CLUSTER_SELF_ID__free.get_raw_id() *<br>        i_am_leader_check_timeout_delay_multiplier__free as u32).into())]) },<br>        interval__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_458_19!([i_am_leader_check_timeout__free<br>        = 10u64,] [Duration::from_secs(i_am_leader_check_timeout__free)]) },]<br>        [tokio_stream::StreamExt::map(tokio_stream::wrappers::IntervalStream::new(tokio::time::interval_at(tokio::time::Instant::now()<br>        + delay__free, interval__free,)), | _ | ())]<br>    )<br>})</code>"]:::otherClass
+69v1["<div style=text-align:center>(69v1)</div> <code><br>scan::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1915_27!(<br>            [] [| | None]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1918_24!(<br>            [f__free = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt; (),<br>            (),<br>            hydro_test::__staged::__deps::hydro_lang::live_collections::keyed_stream::Generate<br>            &lt; () &gt; &gt; ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1588_37!([]<br>            [| _, item | Generate::Return(item)]) }), init__free =<br>            stageleft::runtime_support::fn0_type_hint:: &lt; () &gt; ({ use<br>            hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1588_26!([]<br>            [| | ()]) }),] [move | state : &amp; mut Option &lt; Option &lt; _ &gt; &gt;, v | { if<br>            state.is_none() { * state = Some(Some(init__free())); } match state {<br>            Some(Some(state_value)) =&gt; match f__free(state_value, v) {<br>            Generate::Yield(out) =&gt; Some(Some(out)), Generate::Return(out) =&gt; { *<br>            state = Some(None); Some(Some(out)) } Generate::Break =&gt; None,<br>            Generate::Continue =&gt; Some(None), }, _ =&gt; None, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+70v1["<div style=text-align:center>(70v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1955_27!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
+71v1["<div style=text-align:center>(71v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1589_23!(<br>        [] [| _, _ | {}]<br>    )<br>})</code>"]:::otherClass
+72v1["<div style=text-align:center>(72v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_906_20!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
+73v1["<div style=text-align:center>(73v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+74v1["<div style=text-align:center>(74v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+75v1["<div style=text-align:center>(75v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+76v1["<div style=text-align:center>(76v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+77v1["<div style=text-align:center>(77v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_908_20!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
+78v1["<div style=text-align:center>(78v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+79v1["<div style=text-align:center>(79v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_1144_31!(<br>        [] [| (a, b) | a &amp;&amp; b]<br>    )<br>})</code>"]:::otherClass
+80v1["<div style=text-align:center>(80v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_34!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+81v1["<div style=text-align:center>(81v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+82v1["<div style=text-align:center>(82v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_51!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+83v1["<div style=text-align:center>(83v1)</div> <code><br>inspect({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_317_20!(<br>        [] [| _ | println!(&quot;Proposer leader expired, sending P1a&quot;)]<br>    )<br>})</code>"]:::otherClass
+84v1["<div style=text-align:center>(84v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+85v1["<div style=text-align:center>(85v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+86v1["<div style=text-align:center>(86v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+87v1["<div style=text-align:center>(87v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
 88v1["<div style=text-align:center>(88v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
 89v1["<div style=text-align:center>(89v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                hydro_test::__staged::cluster::paxos::Ballot,<br>                core::result::Result&lt;<br>                    (<br>                        core::option::Option&lt;usize&gt;,<br>                        std::collections::hash_map::HashMap&lt;<br>                            usize,<br>                            hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                                (<br>                                    u32,<br>                                    (<br>                                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                                        &gt;,<br>                                        i32,<br>                                    ),<br>                                ),<br>                            &gt;,<br>                        &gt;,<br>                    ),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
 90v1["<div style=text-align:center>(90v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
@@ -119,11 +119,11 @@ linkStyle default stroke:#aaa
 109v1["<div style=text-align:center>(109v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
 110v1["<div style=text-align:center>(110v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 111v1["<div style=text-align:center>(111v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_74_42!(<br>        [] [move | (key, res) | match res { Ok(v) =&gt; Some((key, v)), Err(_) =&gt; None,<br>        }]<br>    )<br>})</code>"]:::otherClass
-112v1["<div style=text-align:center>(112v1)</div> <code><br>scan::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1629_27!(<br>            [] [| | HashMap::new()]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1632_24!(<br>            [f__free = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt;<br>            core::option::Option &lt; std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt;,<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;),<br>            hydro_test::__staged::__deps::hydro_lang::live_collections::keyed_stream::Generate<br>            &lt; std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; &gt;<br>            ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::keyed_stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1737_15!([f__free<br>            = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt; std::vec::Vec<br>            &lt; (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt;,<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), bool<br>            &gt; ({ use crate ::__staged::__deps:: *; use crate<br>            ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>            __stageleft_quote_src_cluster_paxos_rs_544_15!([quorum_size__free =<br>            2usize,] [move | logs, log | { logs.push(log); logs.len() &gt;=<br>            quorum_size__free }]) }),] [move | key_state, v | { if let<br>            Some(key_state_value) = key_state.as_mut() { if f__free(key_state_value,<br>            v) { Generate::Return(key_state.take().unwrap()) } else {<br>            Generate::Continue } } else { unreachable!() } }]) }), init__free =<br>            stageleft::runtime_support::fn0_type_hint:: &lt; core::option::Option &lt;<br>            std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; &gt;<br>            ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::keyed_stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1736_15!([init__free<br>            = stageleft::runtime_support::fn0_type_hint:: &lt; std::vec::Vec &lt;<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; ({<br>            *; &num;[allow(unused_imports)] use crate :: *;<br>            __stageleft_quote_src_cluster_paxos_rs_543_15!([] [| | vec![]]) }),]<br>            [move | | Some(init__free())]) }),] [move | acc : &amp; mut HashMap &lt; _, _ &gt;,<br>            (k, v) | { let existing_state = acc.entry(Clone::clone(&amp; k))<br>            .or_insert_with(| | Some(init__free())); if let<br>            Some(existing_state_value) = existing_state { match<br>            f__free(existing_state_value, v) { Generate::Yield(out) =&gt; Some(Some((k,<br>            out))), Generate::Return(out) =&gt; { let _ = existing_state.take();<br>            Some(Some((k, out))) } Generate::Break =&gt; { let _ = existing_state<br>            .take(); Some(None) } Generate::Continue =&gt; Some(None), } } else {<br>            Some(None) } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+112v1["<div style=text-align:center>(112v1)</div> <code><br>scan::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1629_27!(<br>            [] [| | HashMap::new()]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1632_24!(<br>            [f__free = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt;<br>            core::option::Option &lt; std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt;,<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;),<br>            hydro_test::__staged::__deps::hydro_lang::live_collections::keyed_stream::Generate<br>            &lt; std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; &gt;<br>            ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::keyed_stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1737_15!([f__free<br>            = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt; std::vec::Vec<br>            &lt; (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt;,<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), bool<br>            &gt; ({ use crate ::__staged::__deps:: *; use crate<br>            ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>            __stageleft_quote_src_cluster_paxos_rs_548_15!([quorum_size__free =<br>            2usize,] [move | logs, log | { logs.push(log); logs.len() &gt;=<br>            quorum_size__free }]) }),] [move | key_state, v | { if let<br>            Some(key_state_value) = key_state.as_mut() { if f__free(key_state_value,<br>            v) { Generate::Return(key_state.take().unwrap()) } else {<br>            Generate::Continue } } else { unreachable!() } }]) }), init__free =<br>            stageleft::runtime_support::fn0_type_hint:: &lt; core::option::Option &lt;<br>            std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; &gt;<br>            ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::keyed_stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1736_15!([init__free<br>            = stageleft::runtime_support::fn0_type_hint:: &lt; std::vec::Vec &lt;<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; ({<br>            *; &num;[allow(unused_imports)] use crate :: *;<br>            __stageleft_quote_src_cluster_paxos_rs_547_15!([] [| | vec![]]) }),]<br>            [move | | Some(init__free())]) }),] [move | acc : &amp; mut HashMap &lt; _, _ &gt;,<br>            (k, v) | { let existing_state = acc.entry(Clone::clone(&amp; k))<br>            .or_insert_with(| | Some(init__free())); if let<br>            Some(existing_state_value) = existing_state { match<br>            f__free(existing_state_value, v) { Generate::Yield(out) =&gt; Some(Some((k,<br>            out))), Generate::Return(out) =&gt; { let _ = existing_state.take();<br>            Some(Some((k, out))) } Generate::Break =&gt; { let _ = existing_state<br>            .take(); Some(None) } Generate::Continue =&gt; Some(None), } } else {<br>            Some(None) } }]<br>        )<br>    },<br>)</code>"]:::otherClass
 113v1["<div style=text-align:center>(113v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1667_27!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
 114v1["<div style=text-align:center>(114v1)</div> <code><br>reduce::&lt;<br>    'static,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1549_16!(<br>        [] [move | curr, new | { if new.0 &gt; curr.0 { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
 115v1["<div style=text-align:center>(115v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-116v1["<div style=text-align:center>(116v1)</div> <code><br>filter_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_564_12!(<br>        [] [move | ((quorum_ballot, quorum_accepted), my_ballot) | if quorum_ballot<br>        == my_ballot { Some(quorum_accepted) } else { None }]<br>    )<br>})</code>"]:::otherClass
+116v1["<div style=text-align:center>(116v1)</div> <code><br>filter_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_568_12!(<br>        [] [move | ((quorum_ballot, quorum_accepted), my_ballot) | if quorum_ballot<br>        == my_ballot { Some(quorum_accepted) } else { None }]<br>    )<br>})</code>"]:::otherClass
 117v1["<div style=text-align:center>(117v1)</div> <code><br>tee()</code>"]:::otherClass
 118v1["<div style=text-align:center>(118v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_906_20!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
 119v1["<div style=text-align:center>(119v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
@@ -138,7 +138,7 @@ linkStyle default stroke:#aaa
 128v1["<div style=text-align:center>(128v1)</div> <code><br>tee()</code>"]:::otherClass
 129v1["<div style=text-align:center>(129v1)</div> <code><br>identity::&lt;bool&gt;()</code>"]:::otherClass
 130v1["<div style=text-align:center>(130v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_82_32!(<br>        [] [move | (key, res) | match res { Ok(_) =&gt; None, Err(e) =&gt; Some((key, e)),<br>        }]<br>    )<br>})</code>"]:::otherClass
-131v1["<div style=text-align:center>(131v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_580_21!([] [| (_, ballot) | ballot])<br>})</code>"]:::otherClass
+131v1["<div style=text-align:center>(131v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_584_21!([] [| (_, ballot) | ballot])<br>})</code>"]:::otherClass
 132v1["<div style=text-align:center>(132v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
 133v1["<div style=text-align:center>(133v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
 134v1["<div style=text-align:center>(134v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_545_16!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
@@ -166,17 +166,17 @@ linkStyle default stroke:#aaa
 157v1["<div style=text-align:center>(157v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
 158v1["<div style=text-align:center>(158v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_571_35!(<br>        [] [| v | v]<br>    )<br>})</code>"]:::otherClass
 159v1["<div style=text-align:center>(159v1)</div> <code><br>tee()</code>"]:::otherClass
-160v1["<div style=text-align:center>(160v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_604_16!([] [| (_checkpoint, log) | log])<br>})</code>"]:::otherClass
+160v1["<div style=text-align:center>(160v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_608_16!([] [| (_checkpoint, log) | log])<br>})</code>"]:::otherClass
 161v1["<div style=text-align:center>(161v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_764_35!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
-162v1["<div style=text-align:center>(162v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_607_67!([] [| | (0, None)])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_607_85!(<br>            [] [| curr_entry, new_entry | { if let Some(curr_entry_payload) = &amp; mut<br>            curr_entry.1 { let same_values = new_entry.value == curr_entry_payload<br>            .value; let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>            if same_values { curr_entry.0 += 1; } if higher_ballot {<br>            curr_entry_payload.ballot = new_entry.ballot; if ! same_values {<br>            curr_entry.0 = 1; curr_entry_payload.value = new_entry.value; } } } else<br>            { * curr_entry = (1, Some(new_entry)); } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-163v1["<div style=text-align:center>(163v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_484_23!(<br>        [f__free = stageleft::runtime_support::fn1_type_hint:: &lt; (usize,<br>        core::option::Option &lt; hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), (usize,<br>        hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt;) &gt; ({ use crate<br>        ::__staged::__deps:: *; use crate ::__staged::cluster::paxos:: *;<br>        &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_628_16!([] [| (count, entry) | (count,<br>        entry.unwrap())]) }),] [{ let orig = f__free; move | (k, v) | (k, orig(v)) }]<br>    )<br>})</code>"]:::otherClass
+162v1["<div style=text-align:center>(162v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_611_67!([] [| | (0, None)])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_611_85!(<br>            [] [| curr_entry, new_entry | { if let Some(curr_entry_payload) = &amp; mut<br>            curr_entry.1 { let same_values = new_entry.value == curr_entry_payload<br>            .value; let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>            if same_values { curr_entry.0 += 1; } if higher_ballot {<br>            curr_entry_payload.ballot = new_entry.ballot; if ! same_values {<br>            curr_entry.0 = 1; curr_entry_payload.value = new_entry.value; } } } else<br>            { * curr_entry = (1, Some(new_entry)); } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+163v1["<div style=text-align:center>(163v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_484_23!(<br>        [f__free = stageleft::runtime_support::fn1_type_hint:: &lt; (usize,<br>        core::option::Option &lt; hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), (usize,<br>        hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt;) &gt; ({ use crate<br>        ::__staged::__deps:: *; use crate ::__staged::cluster::paxos:: *;<br>        &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_632_16!([] [| (count, entry) | (count,<br>        entry.unwrap())]) }),] [{ let orig = f__free; move | (k, v) | (k, orig(v)) }]<br>    )<br>})</code>"]:::otherClass
 164v1["<div style=text-align:center>(164v1)</div> <code><br>tee()</code>"]:::otherClass
 165v1["<div style=text-align:center>(165v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
 166v1["<div style=text-align:center>(166v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1519_23!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
 167v1["<div style=text-align:center>(167v1)</div> <code><br>tee()</code>"]:::otherClass
-168v1["<div style=text-align:center>(168v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_779_71!([] [| s | s + 1])<br>})</code>"]:::otherClass
+168v1["<div style=text-align:center>(168v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_783_71!([] [| s | s + 1])<br>})</code>"]:::otherClass
 169v1["<div style=text-align:center>(169v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-170v1["<div style=text-align:center>(170v1)</div> <code><br>source_iter([<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_775_58!([] [0])<br>    },<br>])</code>"]:::otherClass
+170v1["<div style=text-align:center>(170v1)</div> <code><br>source_iter([<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_779_58!([] [0])<br>    },<br>])</code>"]:::otherClass
 171v1["<div style=text-align:center>(171v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 172v1["<div style=text-align:center>(172v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
 173v1["<div style=text-align:center>(173v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
@@ -187,11 +187,11 @@ linkStyle default stroke:#aaa
 179v1["<div style=text-align:center>(179v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
 180v1["<div style=text-align:center>(180v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
 181v1["<div style=text-align:center>(181v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
-182v1["<div style=text-align:center>(182v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_362;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_785_20!(<br>            [base_slot_ref__free = __hydro_singleton_ref_0,] [| (index, payload) | (*<br>            base_slot_ref__free + index, payload)]<br>        )<br>    }<br>})</code>"]:::otherClass
+182v1["<div style=text-align:center>(182v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_364;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_789_20!(<br>            [base_slot_ref__free = __hydro_singleton_ref_0,] [| (index, payload) | (*<br>            base_slot_ref__free + index, payload)]<br>        )<br>    }<br>})</code>"]:::otherClass
 183v1["<div style=text-align:center>(183v1)</div> <code><br>tee()</code>"]:::otherClass
 184v1["<div style=text-align:center>(184v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2427_15!(<br>            [] [| | 0usize]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2429_16!(<br>            [] [| count, _ | * count += 1]<br>        )<br>    },<br>)</code>"]:::otherClass
 185v1["<div style=text-align:center>(185v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-186v1["<div style=text-align:center>(186v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_793_20!(<br>        [] [| (num_payloads, base_slot) | base_slot + num_payloads]<br>    )<br>})</code>"]:::otherClass
+186v1["<div style=text-align:center>(186v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_797_20!(<br>        [] [| (num_payloads, base_slot) | base_slot + num_payloads]<br>    )<br>})</code>"]:::otherClass
 187v1["<div style=text-align:center>(187v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
 188v1["<div style=text-align:center>(188v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
 189v1["<div style=text-align:center>(189v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
@@ -199,26 +199,26 @@ linkStyle default stroke:#aaa
 191v1["<div style=text-align:center>(191v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_36_11!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_37_11!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
 192v1["<div style=text-align:center>(192v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_1187_61!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
 193v1["<div style=text-align:center>(193v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-195v1["<div style=text-align:center>(195v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_405;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_720_16!(<br>            [p_ballot_ref__free = __hydro_singleton_ref_0,] [| (slot, payload) |<br>            ((slot, p_ballot_ref__free.clone()), Some(payload))]<br>        )<br>    }<br>})</code>"]:::otherClass
-196v1["<div style=text-align:center>(196v1)</div> <code><br>filter_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_600_23!(<br>        [] [| (checkpoint, _log) | checkpoint]<br>    )<br>})</code>"]:::otherClass
+195v1["<div style=text-align:center>(195v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_407;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_724_16!(<br>            [p_ballot_ref__free = __hydro_singleton_ref_0,] [| (slot, payload) |<br>            ((slot, p_ballot_ref__free.clone()), Some(payload))]<br>        )<br>    }<br>})</code>"]:::otherClass
+196v1["<div style=text-align:center>(196v1)</div> <code><br>filter_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_604_23!(<br>        [] [| (checkpoint, _log) | checkpoint]<br>    )<br>})</code>"]:::otherClass
 197v1["<div style=text-align:center>(197v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1519_23!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
 198v1["<div style=text-align:center>(198v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
 199v1["<div style=text-align:center>(199v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
 200v1["<div style=text-align:center>(200v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 201v1["<div style=text-align:center>(201v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-203v1["<div style=text-align:center>(203v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_0 = stream_332;<br>    let __hydro_singleton_ref_1 = stream_420;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_634_23!(<br>            [f__free = 1usize, p_ballot_ref__free = __hydro_singleton_ref_0,<br>            p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1,] [move | (slot,<br>            (count, entry)) | { if count &gt; f__free { return None; } else if let<br>            Some(checkpoint) = * p_p1b_max_checkpoint_ref__free &amp;&amp; slot &lt;= checkpoint<br>            { return None; } Some(((slot, p_ballot_ref__free.clone()), entry.value))<br>            }]<br>        )<br>    }<br>})</code>"]:::otherClass
+203v1["<div style=text-align:center>(203v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_0 = stream_334;<br>    let __hydro_singleton_ref_1 = stream_422;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_638_23!(<br>            [f__free = 1usize, p_ballot_ref__free = __hydro_singleton_ref_0,<br>            p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1,] [move | (slot,<br>            (count, entry)) | { if count &gt; f__free { return None; } else if let<br>            Some(checkpoint) = * p_p1b_max_checkpoint_ref__free &amp;&amp; slot &lt;= checkpoint<br>            { return None; } Some(((slot, p_ballot_ref__free.clone()), entry.value))<br>            }]<br>        )<br>    }<br>})</code>"]:::otherClass
 204v1["<div style=text-align:center>(204v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-205v1["<div style=text-align:center>(205v1)</div> <code><br>flat_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_649_29!(<br>        [] [| (max_slot, checkpoint) | { if let Some(checkpoint) = checkpoint {<br>        (checkpoint + 1)..max_slot } else { 0..max_slot } }]<br>    )<br>})</code>"]:::otherClass
+205v1["<div style=text-align:center>(205v1)</div> <code><br>flat_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_653_29!(<br>        [] [| (max_slot, checkpoint) | { if let Some(checkpoint) = checkpoint {<br>        (checkpoint + 1)..max_slot } else { 0..max_slot } }]<br>    )<br>})</code>"]:::otherClass
 206v1["<div style=text-align:center>(206v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
 207v1["<div style=text-align:center>(207v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-208v1["<div style=text-align:center>(208v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_332;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_657_16!(<br>            [p_ballot_ref__free = __hydro_singleton_ref_0,] [move | slot | ((slot,<br>            p_ballot_ref__free.clone()), None)]<br>        )<br>    }<br>})</code>"]:::otherClass
+208v1["<div style=text-align:center>(208v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_334;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_661_16!(<br>            [p_ballot_ref__free = __hydro_singleton_ref_0,] [move | slot | ((slot,<br>            p_ballot_ref__free.clone()), None)]<br>        )<br>    }<br>})</code>"]:::otherClass
 209v1["<div style=text-align:center>(209v1)</div> <code><br>chain()</code>"]:::otherClass
 210v1["<div style=text-align:center>(210v1)</div> <code><br>chain()</code>"]:::otherClass
 211v1["<div style=text-align:center>(211v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1053_46!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
 212v1["<div style=text-align:center>(212v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
 213v1["<div style=text-align:center>(213v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
 214v1["<div style=text-align:center>(214v1)</div> <code><br>tee()</code>"]:::otherClass
-215v1["<div style=text-align:center>(215v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_734_20!(<br>        [CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),] [move |<br>        ((slot, ballot), value) | P2a { sender : CLUSTER_SELF_ID__free.clone(),<br>        ballot, slot, value }]<br>    )<br>})</code>"]:::otherClass
+215v1["<div style=text-align:center>(215v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_738_20!(<br>        [CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),] [move |<br>        ((slot, ballot), value) | P2a { sender : CLUSTER_SELF_ID__free.clone(),<br>        ballot, slot, value }]<br>    )<br>})</code>"]:::otherClass
 216v1["<div style=text-align:center>(216v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 217v1["<div style=text-align:center>(217v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
 218v1["<div style=text-align:center>(218v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
@@ -244,14 +244,14 @@ linkStyle default stroke:#aaa
 238v1["<div style=text-align:center>(238v1)</div> <code><br>tee()</code>"]:::otherClass
 239v1["<div style=text-align:center>(239v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
 240v1["<div style=text-align:center>(240v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-241v1["<div style=text-align:center>(241v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_750_23!([] [| k | (k, ())])<br>})</code>"]:::otherClass
+241v1["<div style=text-align:center>(241v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_754_23!([] [| k | (k, ())])<br>})</code>"]:::otherClass
 242v1["<div style=text-align:center>(242v1)</div> <code><br>tee()</code>"]:::otherClass
 243v1["<div style=text-align:center>(243v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_39_78!(<br>        [] [| (key, _) | key]<br>    )<br>})</code>"]:::otherClass
 244v1["<div style=text-align:center>(244v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 245v1["<div style=text-align:center>(245v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::option::Option&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
 246v1["<div style=text-align:center>(246v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
 247v1["<div style=text-align:center>(247v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_151_32!(<br>        [] [move | (key, res) | match res { Ok(_) =&gt; None, Err(e) =&gt; Some((key, e)),<br>        }]<br>    )<br>})</code>"]:::otherClass
-248v1["<div style=text-align:center>(248v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_764_21!([] [| (_, ballot) | ballot])<br>})</code>"]:::otherClass
+248v1["<div style=text-align:center>(248v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_768_21!([] [| (_, ballot) | ballot])<br>})</code>"]:::otherClass
 249v1["<div style=text-align:center>(249v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
 250v1["<div style=text-align:center>(250v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_34!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
 251v1["<div style=text-align:center>(251v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
@@ -264,7 +264,7 @@ linkStyle default stroke:#aaa
 258v1["<div style=text-align:center>(258v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
 259v1["<div style=text-align:center>(259v1)</div> <code><br>join_multiset_half::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 260v1["<div style=text-align:center>(260v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_37_20!(<br>        [] [| (key, (meta, resp)) | (key, (meta, resp))]<br>    )<br>})</code>"]:::otherClass
-261v1["<div style=text-align:center>(261v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_762_29!(<br>        [] [| ((slot, _ballot), (value, _)) | (slot, value)]<br>    )<br>})</code>"]:::otherClass
+261v1["<div style=text-align:center>(261v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_766_29!(<br>        [] [| ((slot, _ballot), (value, _)) | (slot, value)]<br>    )<br>})</code>"]:::otherClass
 262v1["<div style=text-align:center>(262v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 263v1["<div style=text-align:center>(263v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
 264v1["<div style=text-align:center>(264v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
@@ -320,50 +320,50 @@ linkStyle default stroke:#aaa
 47v1-->48v1
 48v1-->49v1
 49v1-->50v1
-101v1--o51v1; linkStyle 52 stroke:red
+51v1-->52v1
 52v1-->53v1
 53v1-->54v1
 54v1-->55v1
-55v1-->56v1
-49v1-->57v1
-57v1-->58v1
-26v1-->59v1
-59v1-->60v1
-58v1-->|input|61v1
-60v1-->|single|61v1
+49v1-->56v1
+56v1-->57v1
+26v1-->58v1
+58v1-->59v1
+57v1-->|input|60v1
+59v1-->|single|60v1
+60v1-->61v1
 61v1-->62v1
 62v1-->63v1
-63v1-->64v1
-65v1-->66v1
-64v1-->|0|67v1
-66v1-->|1|67v1
-67v1-->68v1
+64v1-->65v1
+63v1-->|0|66v1
+65v1-->|1|66v1
+66v1-->67v1
+68v1-->69v1
 69v1-->70v1
 70v1-->71v1
 71v1-->72v1
 72v1-->73v1
-73v1-->74v1
-75v1-->76v1
-74v1-->|0|77v1
-76v1-->|1|77v1
-77v1-->78v1
-68v1-->|input|79v1
-78v1-->|single|79v1
+74v1-->75v1
+73v1-->|0|76v1
+75v1-->|1|76v1
+76v1-->77v1
+67v1-->|input|78v1
+77v1-->|single|78v1
+78v1-->79v1
 79v1-->80v1
-80v1-->81v1
-25v1-->|input|82v1
-81v1-->|single|82v1
+25v1-->|input|81v1
+80v1-->|single|81v1
+81v1-->82v1
 82v1-->83v1
-83v1-->84v1
-56v1-->|0|85v1
-84v1-->|1|85v1
-86v1-->87v1
+55v1-->|0|84v1
+83v1-->|1|84v1
 85v1-->86v1
+84v1-->85v1
+101v1--o87v1; linkStyle 90 stroke:red
 88v1-->89v1
 89v1-->90v1
 90v1-->91v1
 91v1-->92v1
-51v1-->|0|93v1
+87v1-->|0|93v1
 92v1-->|1|93v1
 93v1-->94v1
 94v1-->95v1
@@ -563,8 +563,8 @@ linkStyle default stroke:#aaa
 2v1
 44v1
 45v1
+85v1
 86v1
-87v1
 154v1
 155v1
 157v1
@@ -631,12 +631,12 @@ subgraph var_stream_104 ["var <tt>stream_104</tt>"]
     style var_stream_104 fill:transparent
     49v1
 end
-subgraph var_stream_106 ["var <tt>stream_106</tt>"]
-    style var_stream_106 fill:transparent
+subgraph var_stream_105 ["var <tt>stream_105</tt>"]
+    style var_stream_105 fill:transparent
     51v1
 end
-subgraph var_stream_107 ["var <tt>stream_107</tt>"]
-    style var_stream_107 fill:transparent
+subgraph var_stream_106 ["var <tt>stream_106</tt>"]
+    style var_stream_106 fill:transparent
     52v1
 end
 subgraph var_stream_108 ["var <tt>stream_108</tt>"]
@@ -647,297 +647,293 @@ subgraph var_stream_110 ["var <tt>stream_110</tt>"]
     style var_stream_110 fill:transparent
     54v1
 end
-subgraph var_stream_112 ["var <tt>stream_112</tt>"]
-    style var_stream_112 fill:transparent
+subgraph var_stream_113 ["var <tt>stream_113</tt>"]
+    style var_stream_113 fill:transparent
     55v1
 end
-subgraph var_stream_115 ["var <tt>stream_115</tt>"]
-    style var_stream_115 fill:transparent
+subgraph var_stream_118 ["var <tt>stream_118</tt>"]
+    style var_stream_118 fill:transparent
     56v1
 end
 subgraph var_stream_120 ["var <tt>stream_120</tt>"]
     style var_stream_120 fill:transparent
     57v1
 end
-subgraph var_stream_122 ["var <tt>stream_122</tt>"]
-    style var_stream_122 fill:transparent
+subgraph var_stream_124 ["var <tt>stream_124</tt>"]
+    style var_stream_124 fill:transparent
     58v1
+end
+subgraph var_stream_125 ["var <tt>stream_125</tt>"]
+    style var_stream_125 fill:transparent
+    59v1
 end
 subgraph var_stream_126 ["var <tt>stream_126</tt>"]
     style var_stream_126 fill:transparent
-    59v1
+    60v1
 end
 subgraph var_stream_127 ["var <tt>stream_127</tt>"]
     style var_stream_127 fill:transparent
-    60v1
+    61v1
 end
 subgraph var_stream_128 ["var <tt>stream_128</tt>"]
     style var_stream_128 fill:transparent
-    61v1
+    62v1
 end
 subgraph var_stream_129 ["var <tt>stream_129</tt>"]
     style var_stream_129 fill:transparent
-    62v1
+    63v1
 end
 subgraph var_stream_130 ["var <tt>stream_130</tt>"]
     style var_stream_130 fill:transparent
-    63v1
-end
-subgraph var_stream_131 ["var <tt>stream_131</tt>"]
-    style var_stream_131 fill:transparent
     64v1
+    65v1
 end
 subgraph var_stream_132 ["var <tt>stream_132</tt>"]
     style var_stream_132 fill:transparent
-    65v1
     66v1
 end
 subgraph var_stream_134 ["var <tt>stream_134</tt>"]
     style var_stream_134 fill:transparent
     67v1
 end
-subgraph var_stream_136 ["var <tt>stream_136</tt>"]
-    style var_stream_136 fill:transparent
+subgraph var_stream_135 ["var <tt>stream_135</tt>"]
+    style var_stream_135 fill:transparent
     68v1
 end
 subgraph var_stream_137 ["var <tt>stream_137</tt>"]
     style var_stream_137 fill:transparent
     69v1
 end
+subgraph var_stream_138 ["var <tt>stream_138</tt>"]
+    style var_stream_138 fill:transparent
+    70v1
+end
 subgraph var_stream_139 ["var <tt>stream_139</tt>"]
     style var_stream_139 fill:transparent
-    70v1
+    71v1
 end
 subgraph var_stream_140 ["var <tt>stream_140</tt>"]
     style var_stream_140 fill:transparent
-    71v1
+    72v1
 end
 subgraph var_stream_141 ["var <tt>stream_141</tt>"]
     style var_stream_141 fill:transparent
-    72v1
+    73v1
 end
 subgraph var_stream_142 ["var <tt>stream_142</tt>"]
     style var_stream_142 fill:transparent
-    73v1
-end
-subgraph var_stream_143 ["var <tt>stream_143</tt>"]
-    style var_stream_143 fill:transparent
     74v1
+    75v1
 end
 subgraph var_stream_144 ["var <tt>stream_144</tt>"]
     style var_stream_144 fill:transparent
-    75v1
     76v1
 end
 subgraph var_stream_146 ["var <tt>stream_146</tt>"]
     style var_stream_146 fill:transparent
     77v1
 end
-subgraph var_stream_148 ["var <tt>stream_148</tt>"]
-    style var_stream_148 fill:transparent
+subgraph var_stream_147 ["var <tt>stream_147</tt>"]
+    style var_stream_147 fill:transparent
     78v1
 end
 subgraph var_stream_149 ["var <tt>stream_149</tt>"]
     style var_stream_149 fill:transparent
     79v1
 end
+subgraph var_stream_150 ["var <tt>stream_150</tt>"]
+    style var_stream_150 fill:transparent
+    80v1
+end
 subgraph var_stream_151 ["var <tt>stream_151</tt>"]
     style var_stream_151 fill:transparent
-    80v1
+    81v1
 end
 subgraph var_stream_152 ["var <tt>stream_152</tt>"]
     style var_stream_152 fill:transparent
-    81v1
-end
-subgraph var_stream_153 ["var <tt>stream_153</tt>"]
-    style var_stream_153 fill:transparent
     82v1
 end
-subgraph var_stream_154 ["var <tt>stream_154</tt>"]
-    style var_stream_154 fill:transparent
+subgraph var_stream_155 ["var <tt>stream_155</tt>"]
+    style var_stream_155 fill:transparent
     83v1
 end
 subgraph var_stream_157 ["var <tt>stream_157</tt>"]
     style var_stream_157 fill:transparent
     84v1
 end
-subgraph var_stream_159 ["var <tt>stream_159</tt>"]
-    style var_stream_159 fill:transparent
-    85v1
-end
-subgraph var_stream_186 ["var <tt>stream_186</tt>"]
-    style var_stream_186 fill:transparent
-    88v1
-    89v1
+subgraph var_stream_181 ["var <tt>stream_181</tt>"]
+    style var_stream_181 fill:transparent
+    87v1
 end
 subgraph var_stream_188 ["var <tt>stream_188</tt>"]
     style var_stream_188 fill:transparent
-    90v1
-end
-subgraph var_stream_189 ["var <tt>stream_189</tt>"]
-    style var_stream_189 fill:transparent
-    91v1
+    88v1
+    89v1
 end
 subgraph var_stream_190 ["var <tt>stream_190</tt>"]
     style var_stream_190 fill:transparent
-    92v1
+    90v1
+end
+subgraph var_stream_191 ["var <tt>stream_191</tt>"]
+    style var_stream_191 fill:transparent
+    91v1
 end
 subgraph var_stream_192 ["var <tt>stream_192</tt>"]
     style var_stream_192 fill:transparent
+    92v1
+end
+subgraph var_stream_194 ["var <tt>stream_194</tt>"]
+    style var_stream_194 fill:transparent
     93v1
 end
-subgraph var_stream_193 ["var <tt>stream_193</tt>"]
-    style var_stream_193 fill:transparent
+subgraph var_stream_195 ["var <tt>stream_195</tt>"]
+    style var_stream_195 fill:transparent
     94v1
-end
-subgraph var_stream_196 ["var <tt>stream_196</tt>"]
-    style var_stream_196 fill:transparent
-    95v1
-end
-subgraph var_stream_197 ["var <tt>stream_197</tt>"]
-    style var_stream_197 fill:transparent
-    96v1
 end
 subgraph var_stream_198 ["var <tt>stream_198</tt>"]
     style var_stream_198 fill:transparent
+    95v1
+end
+subgraph var_stream_199 ["var <tt>stream_199</tt>"]
+    style var_stream_199 fill:transparent
+    96v1
+end
+subgraph var_stream_200 ["var <tt>stream_200</tt>"]
+    style var_stream_200 fill:transparent
     97v1
-end
-subgraph var_stream_201 ["var <tt>stream_201</tt>"]
-    style var_stream_201 fill:transparent
-    98v1
-end
-subgraph var_stream_202 ["var <tt>stream_202</tt>"]
-    style var_stream_202 fill:transparent
-    99v1
 end
 subgraph var_stream_203 ["var <tt>stream_203</tt>"]
     style var_stream_203 fill:transparent
-    100v1
+    98v1
+end
+subgraph var_stream_204 ["var <tt>stream_204</tt>"]
+    style var_stream_204 fill:transparent
+    99v1
 end
 subgraph var_stream_205 ["var <tt>stream_205</tt>"]
     style var_stream_205 fill:transparent
-    102v1
+    100v1
 end
-subgraph var_stream_208 ["var <tt>stream_208</tt>"]
-    style var_stream_208 fill:transparent
-    103v1
+subgraph var_stream_207 ["var <tt>stream_207</tt>"]
+    style var_stream_207 fill:transparent
+    102v1
 end
 subgraph var_stream_210 ["var <tt>stream_210</tt>"]
     style var_stream_210 fill:transparent
+    103v1
+end
+subgraph var_stream_212 ["var <tt>stream_212</tt>"]
+    style var_stream_212 fill:transparent
     104v1
 end
-subgraph var_stream_213 ["var <tt>stream_213</tt>"]
-    style var_stream_213 fill:transparent
+subgraph var_stream_215 ["var <tt>stream_215</tt>"]
+    style var_stream_215 fill:transparent
     106v1
 end
-subgraph var_stream_216 ["var <tt>stream_216</tt>"]
-    style var_stream_216 fill:transparent
+subgraph var_stream_218 ["var <tt>stream_218</tt>"]
+    style var_stream_218 fill:transparent
     107v1
-end
-subgraph var_stream_217 ["var <tt>stream_217</tt>"]
-    style var_stream_217 fill:transparent
-    108v1
 end
 subgraph var_stream_219 ["var <tt>stream_219</tt>"]
     style var_stream_219 fill:transparent
-    109v1
+    108v1
 end
 subgraph var_stream_22 ["var <tt>stream_22</tt>"]
     style var_stream_22 fill:transparent
     1v1
 end
-subgraph var_stream_220 ["var <tt>stream_220</tt>"]
-    style var_stream_220 fill:transparent
-    110v1
-end
 subgraph var_stream_221 ["var <tt>stream_221</tt>"]
     style var_stream_221 fill:transparent
+    109v1
+end
+subgraph var_stream_222 ["var <tt>stream_222</tt>"]
+    style var_stream_222 fill:transparent
+    110v1
+end
+subgraph var_stream_223 ["var <tt>stream_223</tt>"]
+    style var_stream_223 fill:transparent
     111v1
 end
-subgraph var_stream_225 ["var <tt>stream_225</tt>"]
-    style var_stream_225 fill:transparent
+subgraph var_stream_227 ["var <tt>stream_227</tt>"]
+    style var_stream_227 fill:transparent
     112v1
 end
-subgraph var_stream_226 ["var <tt>stream_226</tt>"]
-    style var_stream_226 fill:transparent
+subgraph var_stream_228 ["var <tt>stream_228</tt>"]
+    style var_stream_228 fill:transparent
     113v1
 end
-subgraph var_stream_231 ["var <tt>stream_231</tt>"]
-    style var_stream_231 fill:transparent
+subgraph var_stream_233 ["var <tt>stream_233</tt>"]
+    style var_stream_233 fill:transparent
     114v1
-end
-subgraph var_stream_235 ["var <tt>stream_235</tt>"]
-    style var_stream_235 fill:transparent
-    115v1
-end
-subgraph var_stream_236 ["var <tt>stream_236</tt>"]
-    style var_stream_236 fill:transparent
-    116v1
 end
 subgraph var_stream_237 ["var <tt>stream_237</tt>"]
     style var_stream_237 fill:transparent
-    117v1
+    115v1
 end
 subgraph var_stream_238 ["var <tt>stream_238</tt>"]
     style var_stream_238 fill:transparent
-    118v1
+    116v1
 end
 subgraph var_stream_239 ["var <tt>stream_239</tt>"]
     style var_stream_239 fill:transparent
-    119v1
+    117v1
 end
 subgraph var_stream_240 ["var <tt>stream_240</tt>"]
     style var_stream_240 fill:transparent
-    120v1
-    121v1
+    118v1
+end
+subgraph var_stream_241 ["var <tt>stream_241</tt>"]
+    style var_stream_241 fill:transparent
+    119v1
 end
 subgraph var_stream_242 ["var <tt>stream_242</tt>"]
     style var_stream_242 fill:transparent
-    122v1
+    120v1
+    121v1
 end
 subgraph var_stream_244 ["var <tt>stream_244</tt>"]
     style var_stream_244 fill:transparent
-    123v1
+    122v1
 end
-subgraph var_stream_247 ["var <tt>stream_247</tt>"]
-    style var_stream_247 fill:transparent
-    124v1
+subgraph var_stream_246 ["var <tt>stream_246</tt>"]
+    style var_stream_246 fill:transparent
+    123v1
 end
 subgraph var_stream_249 ["var <tt>stream_249</tt>"]
     style var_stream_249 fill:transparent
-    125v1
+    124v1
 end
-subgraph var_stream_252 ["var <tt>stream_252</tt>"]
-    style var_stream_252 fill:transparent
-    126v1
+subgraph var_stream_251 ["var <tt>stream_251</tt>"]
+    style var_stream_251 fill:transparent
+    125v1
 end
 subgraph var_stream_254 ["var <tt>stream_254</tt>"]
     style var_stream_254 fill:transparent
-    127v1
+    126v1
 end
-subgraph var_stream_255 ["var <tt>stream_255</tt>"]
-    style var_stream_255 fill:transparent
-    128v1
+subgraph var_stream_256 ["var <tt>stream_256</tt>"]
+    style var_stream_256 fill:transparent
+    127v1
 end
 subgraph var_stream_257 ["var <tt>stream_257</tt>"]
     style var_stream_257 fill:transparent
+    128v1
+end
+subgraph var_stream_259 ["var <tt>stream_259</tt>"]
+    style var_stream_259 fill:transparent
     130v1
 end
-subgraph var_stream_258 ["var <tt>stream_258</tt>"]
-    style var_stream_258 fill:transparent
+subgraph var_stream_260 ["var <tt>stream_260</tt>"]
+    style var_stream_260 fill:transparent
     131v1
 end
-subgraph var_stream_276 ["var <tt>stream_276</tt>"]
-    style var_stream_276 fill:transparent
+subgraph var_stream_278 ["var <tt>stream_278</tt>"]
+    style var_stream_278 fill:transparent
     133v1
-end
-subgraph var_stream_277 ["var <tt>stream_277</tt>"]
-    style var_stream_277 fill:transparent
-    134v1
 end
 subgraph var_stream_279 ["var <tt>stream_279</tt>"]
     style var_stream_279 fill:transparent
-    135v1
+    134v1
 end
 subgraph var_stream_28 ["var <tt>stream_28</tt>"]
     style var_stream_28 fill:transparent
@@ -945,355 +941,359 @@ subgraph var_stream_28 ["var <tt>stream_28</tt>"]
 end
 subgraph var_stream_281 ["var <tt>stream_281</tt>"]
     style var_stream_281 fill:transparent
+    135v1
+end
+subgraph var_stream_283 ["var <tt>stream_283</tt>"]
+    style var_stream_283 fill:transparent
     136v1
 end
-subgraph var_stream_284 ["var <tt>stream_284</tt>"]
-    style var_stream_284 fill:transparent
+subgraph var_stream_286 ["var <tt>stream_286</tt>"]
+    style var_stream_286 fill:transparent
     137v1
-end
-subgraph var_stream_289 ["var <tt>stream_289</tt>"]
-    style var_stream_289 fill:transparent
-    138v1
-end
-subgraph var_stream_290 ["var <tt>stream_290</tt>"]
-    style var_stream_290 fill:transparent
-    139v1
 end
 subgraph var_stream_291 ["var <tt>stream_291</tt>"]
     style var_stream_291 fill:transparent
-    140v1
+    138v1
 end
 subgraph var_stream_292 ["var <tt>stream_292</tt>"]
     style var_stream_292 fill:transparent
-    141v1
+    139v1
 end
 subgraph var_stream_293 ["var <tt>stream_293</tt>"]
     style var_stream_293 fill:transparent
-    142v1
+    140v1
 end
 subgraph var_stream_294 ["var <tt>stream_294</tt>"]
     style var_stream_294 fill:transparent
-    143v1
-    144v1
+    141v1
+end
+subgraph var_stream_295 ["var <tt>stream_295</tt>"]
+    style var_stream_295 fill:transparent
+    142v1
 end
 subgraph var_stream_296 ["var <tt>stream_296</tt>"]
     style var_stream_296 fill:transparent
-    145v1
+    143v1
+    144v1
 end
 subgraph var_stream_298 ["var <tt>stream_298</tt>"]
     style var_stream_298 fill:transparent
-    146v1
-end
-subgraph var_stream_299 ["var <tt>stream_299</tt>"]
-    style var_stream_299 fill:transparent
-    147v1
+    145v1
 end
 subgraph var_stream_30 ["var <tt>stream_30</tt>"]
     style var_stream_30 fill:transparent
     4v1
 end
+subgraph var_stream_300 ["var <tt>stream_300</tt>"]
+    style var_stream_300 fill:transparent
+    146v1
+end
 subgraph var_stream_301 ["var <tt>stream_301</tt>"]
     style var_stream_301 fill:transparent
-    148v1
-end
-subgraph var_stream_302 ["var <tt>stream_302</tt>"]
-    style var_stream_302 fill:transparent
-    149v1
+    147v1
 end
 subgraph var_stream_303 ["var <tt>stream_303</tt>"]
     style var_stream_303 fill:transparent
-    150v1
+    148v1
 end
 subgraph var_stream_304 ["var <tt>stream_304</tt>"]
     style var_stream_304 fill:transparent
-    151v1
+    149v1
 end
 subgraph var_stream_305 ["var <tt>stream_305</tt>"]
     style var_stream_305 fill:transparent
+    150v1
+end
+subgraph var_stream_306 ["var <tt>stream_306</tt>"]
+    style var_stream_306 fill:transparent
+    151v1
+end
+subgraph var_stream_307 ["var <tt>stream_307</tt>"]
+    style var_stream_307 fill:transparent
     152v1
 end
-subgraph var_stream_309 ["var <tt>stream_309</tt>"]
-    style var_stream_309 fill:transparent
+subgraph var_stream_311 ["var <tt>stream_311</tt>"]
+    style var_stream_311 fill:transparent
     153v1
 end
 subgraph var_stream_33 ["var <tt>stream_33</tt>"]
     style var_stream_33 fill:transparent
     5v1
 end
-subgraph var_stream_336 ["var <tt>stream_336</tt>"]
-    style var_stream_336 fill:transparent
-    158v1
-end
-subgraph var_stream_337 ["var <tt>stream_337</tt>"]
-    style var_stream_337 fill:transparent
-    159v1
-end
 subgraph var_stream_338 ["var <tt>stream_338</tt>"]
     style var_stream_338 fill:transparent
-    160v1
+    158v1
 end
 subgraph var_stream_339 ["var <tt>stream_339</tt>"]
     style var_stream_339 fill:transparent
-    161v1
+    159v1
+end
+subgraph var_stream_340 ["var <tt>stream_340</tt>"]
+    style var_stream_340 fill:transparent
+    160v1
 end
 subgraph var_stream_341 ["var <tt>stream_341</tt>"]
     style var_stream_341 fill:transparent
-    162v1
-end
-subgraph var_stream_342 ["var <tt>stream_342</tt>"]
-    style var_stream_342 fill:transparent
-    163v1
+    161v1
 end
 subgraph var_stream_343 ["var <tt>stream_343</tt>"]
     style var_stream_343 fill:transparent
-    164v1
+    162v1
 end
-subgraph var_stream_346 ["var <tt>stream_346</tt>"]
-    style var_stream_346 fill:transparent
-    165v1
+subgraph var_stream_344 ["var <tt>stream_344</tt>"]
+    style var_stream_344 fill:transparent
+    163v1
+end
+subgraph var_stream_345 ["var <tt>stream_345</tt>"]
+    style var_stream_345 fill:transparent
+    164v1
 end
 subgraph var_stream_348 ["var <tt>stream_348</tt>"]
     style var_stream_348 fill:transparent
-    166v1
-end
-subgraph var_stream_349 ["var <tt>stream_349</tt>"]
-    style var_stream_349 fill:transparent
-    167v1
+    165v1
 end
 subgraph var_stream_35 ["var <tt>stream_35</tt>"]
     style var_stream_35 fill:transparent
     6v1
 end
-subgraph var_stream_352 ["var <tt>stream_352</tt>"]
-    style var_stream_352 fill:transparent
-    168v1
+subgraph var_stream_350 ["var <tt>stream_350</tt>"]
+    style var_stream_350 fill:transparent
+    166v1
+end
+subgraph var_stream_351 ["var <tt>stream_351</tt>"]
+    style var_stream_351 fill:transparent
+    167v1
 end
 subgraph var_stream_354 ["var <tt>stream_354</tt>"]
     style var_stream_354 fill:transparent
-    169v1
+    168v1
 end
-subgraph var_stream_355 ["var <tt>stream_355</tt>"]
-    style var_stream_355 fill:transparent
-    170v1
-    171v1
+subgraph var_stream_356 ["var <tt>stream_356</tt>"]
+    style var_stream_356 fill:transparent
+    169v1
 end
 subgraph var_stream_357 ["var <tt>stream_357</tt>"]
     style var_stream_357 fill:transparent
+    170v1
+    171v1
+end
+subgraph var_stream_359 ["var <tt>stream_359</tt>"]
+    style var_stream_359 fill:transparent
     172v1
 end
 subgraph var_stream_36 ["var <tt>stream_36</tt>"]
     style var_stream_36 fill:transparent
     7v1
 end
-subgraph var_stream_360 ["var <tt>stream_360</tt>"]
-    style var_stream_360 fill:transparent
+subgraph var_stream_362 ["var <tt>stream_362</tt>"]
+    style var_stream_362 fill:transparent
     173v1
-end
-subgraph var_stream_369 ["var <tt>stream_369</tt>"]
-    style var_stream_369 fill:transparent
-    175v1
-    176v1
 end
 subgraph var_stream_371 ["var <tt>stream_371</tt>"]
     style var_stream_371 fill:transparent
+    175v1
+    176v1
+end
+subgraph var_stream_373 ["var <tt>stream_373</tt>"]
+    style var_stream_373 fill:transparent
     177v1
-end
-subgraph var_stream_375 ["var <tt>stream_375</tt>"]
-    style var_stream_375 fill:transparent
-    178v1
-end
-subgraph var_stream_376 ["var <tt>stream_376</tt>"]
-    style var_stream_376 fill:transparent
-    179v1
 end
 subgraph var_stream_377 ["var <tt>stream_377</tt>"]
     style var_stream_377 fill:transparent
+    178v1
+end
+subgraph var_stream_378 ["var <tt>stream_378</tt>"]
+    style var_stream_378 fill:transparent
+    179v1
+end
+subgraph var_stream_379 ["var <tt>stream_379</tt>"]
+    style var_stream_379 fill:transparent
     180v1
-end
-subgraph var_stream_380 ["var <tt>stream_380</tt>"]
-    style var_stream_380 fill:transparent
-    181v1
-end
-subgraph var_stream_381 ["var <tt>stream_381</tt>"]
-    style var_stream_381 fill:transparent
-    182v1
 end
 subgraph var_stream_382 ["var <tt>stream_382</tt>"]
     style var_stream_382 fill:transparent
-    183v1
+    181v1
 end
 subgraph var_stream_383 ["var <tt>stream_383</tt>"]
     style var_stream_383 fill:transparent
-    184v1
+    182v1
+end
+subgraph var_stream_384 ["var <tt>stream_384</tt>"]
+    style var_stream_384 fill:transparent
+    183v1
 end
 subgraph var_stream_385 ["var <tt>stream_385</tt>"]
     style var_stream_385 fill:transparent
-    185v1
+    184v1
 end
 subgraph var_stream_387 ["var <tt>stream_387</tt>"]
     style var_stream_387 fill:transparent
+    185v1
+end
+subgraph var_stream_389 ["var <tt>stream_389</tt>"]
+    style var_stream_389 fill:transparent
     186v1
 end
 subgraph var_stream_39 ["var <tt>stream_39</tt>"]
     style var_stream_39 fill:transparent
     8v1
 end
-subgraph var_stream_392 ["var <tt>stream_392</tt>"]
-    style var_stream_392 fill:transparent
-    188v1
-end
 subgraph var_stream_394 ["var <tt>stream_394</tt>"]
     style var_stream_394 fill:transparent
-    189v1
+    188v1
 end
-subgraph var_stream_395 ["var <tt>stream_395</tt>"]
-    style var_stream_395 fill:transparent
-    190v1
+subgraph var_stream_396 ["var <tt>stream_396</tt>"]
+    style var_stream_396 fill:transparent
+    189v1
 end
 subgraph var_stream_397 ["var <tt>stream_397</tt>"]
     style var_stream_397 fill:transparent
-    191v1
+    190v1
 end
 subgraph var_stream_399 ["var <tt>stream_399</tt>"]
     style var_stream_399 fill:transparent
+    191v1
+end
+subgraph var_stream_401 ["var <tt>stream_401</tt>"]
+    style var_stream_401 fill:transparent
     192v1
 end
-subgraph var_stream_402 ["var <tt>stream_402</tt>"]
-    style var_stream_402 fill:transparent
+subgraph var_stream_404 ["var <tt>stream_404</tt>"]
+    style var_stream_404 fill:transparent
     193v1
 end
-subgraph var_stream_409 ["var <tt>stream_409</tt>"]
-    style var_stream_409 fill:transparent
+subgraph var_stream_411 ["var <tt>stream_411</tt>"]
+    style var_stream_411 fill:transparent
     195v1
-end
-subgraph var_stream_412 ["var <tt>stream_412</tt>"]
-    style var_stream_412 fill:transparent
-    196v1
 end
 subgraph var_stream_414 ["var <tt>stream_414</tt>"]
     style var_stream_414 fill:transparent
-    197v1
-end
-subgraph var_stream_415 ["var <tt>stream_415</tt>"]
-    style var_stream_415 fill:transparent
-    198v1
+    196v1
 end
 subgraph var_stream_416 ["var <tt>stream_416</tt>"]
     style var_stream_416 fill:transparent
-    199v1
-    200v1
+    197v1
+end
+subgraph var_stream_417 ["var <tt>stream_417</tt>"]
+    style var_stream_417 fill:transparent
+    198v1
 end
 subgraph var_stream_418 ["var <tt>stream_418</tt>"]
     style var_stream_418 fill:transparent
+    199v1
+    200v1
+end
+subgraph var_stream_420 ["var <tt>stream_420</tt>"]
+    style var_stream_420 fill:transparent
     201v1
 end
-subgraph var_stream_424 ["var <tt>stream_424</tt>"]
-    style var_stream_424 fill:transparent
+subgraph var_stream_426 ["var <tt>stream_426</tt>"]
+    style var_stream_426 fill:transparent
     203v1
-end
-subgraph var_stream_429 ["var <tt>stream_429</tt>"]
-    style var_stream_429 fill:transparent
-    204v1
 end
 subgraph var_stream_431 ["var <tt>stream_431</tt>"]
     style var_stream_431 fill:transparent
+    204v1
+end
+subgraph var_stream_433 ["var <tt>stream_433</tt>"]
+    style var_stream_433 fill:transparent
     205v1
-end
-subgraph var_stream_435 ["var <tt>stream_435</tt>"]
-    style var_stream_435 fill:transparent
-    206v1
-end
-subgraph var_stream_436 ["var <tt>stream_436</tt>"]
-    style var_stream_436 fill:transparent
-    207v1
 end
 subgraph var_stream_437 ["var <tt>stream_437</tt>"]
     style var_stream_437 fill:transparent
-    208v1
+    206v1
 end
 subgraph var_stream_438 ["var <tt>stream_438</tt>"]
     style var_stream_438 fill:transparent
-    209v1
+    207v1
 end
 subgraph var_stream_439 ["var <tt>stream_439</tt>"]
     style var_stream_439 fill:transparent
-    210v1
+    208v1
+end
+subgraph var_stream_440 ["var <tt>stream_440</tt>"]
+    style var_stream_440 fill:transparent
+    209v1
 end
 subgraph var_stream_441 ["var <tt>stream_441</tt>"]
     style var_stream_441 fill:transparent
-    211v1
-end
-subgraph var_stream_442 ["var <tt>stream_442</tt>"]
-    style var_stream_442 fill:transparent
-    212v1
+    210v1
 end
 subgraph var_stream_443 ["var <tt>stream_443</tt>"]
     style var_stream_443 fill:transparent
-    213v1
+    211v1
+end
+subgraph var_stream_444 ["var <tt>stream_444</tt>"]
+    style var_stream_444 fill:transparent
+    212v1
 end
 subgraph var_stream_445 ["var <tt>stream_445</tt>"]
     style var_stream_445 fill:transparent
-    214v1
+    213v1
 end
 subgraph var_stream_447 ["var <tt>stream_447</tt>"]
     style var_stream_447 fill:transparent
-    215v1
+    214v1
 end
 subgraph var_stream_449 ["var <tt>stream_449</tt>"]
     style var_stream_449 fill:transparent
-    216v1
+    215v1
 end
 subgraph var_stream_45 ["var <tt>stream_45</tt>"]
     style var_stream_45 fill:transparent
     9v1
 end
-subgraph var_stream_460 ["var <tt>stream_460</tt>"]
-    style var_stream_460 fill:transparent
-    219v1
-    220v1
+subgraph var_stream_451 ["var <tt>stream_451</tt>"]
+    style var_stream_451 fill:transparent
+    216v1
 end
 subgraph var_stream_462 ["var <tt>stream_462</tt>"]
     style var_stream_462 fill:transparent
-    221v1
+    219v1
+    220v1
 end
-subgraph var_stream_463 ["var <tt>stream_463</tt>"]
-    style var_stream_463 fill:transparent
-    222v1
+subgraph var_stream_464 ["var <tt>stream_464</tt>"]
+    style var_stream_464 fill:transparent
+    221v1
 end
 subgraph var_stream_465 ["var <tt>stream_465</tt>"]
     style var_stream_465 fill:transparent
+    222v1
+end
+subgraph var_stream_467 ["var <tt>stream_467</tt>"]
+    style var_stream_467 fill:transparent
     223v1
 end
-subgraph var_stream_466 ["var <tt>stream_466</tt>"]
-    style var_stream_466 fill:transparent
+subgraph var_stream_468 ["var <tt>stream_468</tt>"]
+    style var_stream_468 fill:transparent
     224v1
-end
-subgraph var_stream_469 ["var <tt>stream_469</tt>"]
-    style var_stream_469 fill:transparent
-    225v1
 end
 subgraph var_stream_47 ["var <tt>stream_47</tt>"]
     style var_stream_47 fill:transparent
     10v1
 end
-subgraph var_stream_470 ["var <tt>stream_470</tt>"]
-    style var_stream_470 fill:transparent
-    226v1
-end
 subgraph var_stream_471 ["var <tt>stream_471</tt>"]
     style var_stream_471 fill:transparent
+    225v1
+end
+subgraph var_stream_472 ["var <tt>stream_472</tt>"]
+    style var_stream_472 fill:transparent
+    226v1
+end
+subgraph var_stream_473 ["var <tt>stream_473</tt>"]
+    style var_stream_473 fill:transparent
     227v1
-end
-subgraph var_stream_474 ["var <tt>stream_474</tt>"]
-    style var_stream_474 fill:transparent
-    228v1
-end
-subgraph var_stream_475 ["var <tt>stream_475</tt>"]
-    style var_stream_475 fill:transparent
-    229v1
 end
 subgraph var_stream_476 ["var <tt>stream_476</tt>"]
     style var_stream_476 fill:transparent
+    228v1
+end
+subgraph var_stream_477 ["var <tt>stream_477</tt>"]
+    style var_stream_477 fill:transparent
+    229v1
+end
+subgraph var_stream_478 ["var <tt>stream_478</tt>"]
+    style var_stream_478 fill:transparent
     230v1
 end
 subgraph var_stream_48 ["var <tt>stream_48</tt>"]
@@ -1301,124 +1301,124 @@ subgraph var_stream_48 ["var <tt>stream_48</tt>"]
     11v1
     12v1
 end
-subgraph var_stream_480 ["var <tt>stream_480</tt>"]
-    style var_stream_480 fill:transparent
+subgraph var_stream_482 ["var <tt>stream_482</tt>"]
+    style var_stream_482 fill:transparent
     232v1
-end
-subgraph var_stream_481 ["var <tt>stream_481</tt>"]
-    style var_stream_481 fill:transparent
-    233v1
 end
 subgraph var_stream_483 ["var <tt>stream_483</tt>"]
     style var_stream_483 fill:transparent
-    234v1
+    233v1
 end
 subgraph var_stream_485 ["var <tt>stream_485</tt>"]
     style var_stream_485 fill:transparent
+    234v1
+end
+subgraph var_stream_487 ["var <tt>stream_487</tt>"]
+    style var_stream_487 fill:transparent
     236v1
 end
-subgraph var_stream_490 ["var <tt>stream_490</tt>"]
-    style var_stream_490 fill:transparent
+subgraph var_stream_492 ["var <tt>stream_492</tt>"]
+    style var_stream_492 fill:transparent
     237v1
 end
-subgraph var_stream_491 ["var <tt>stream_491</tt>"]
-    style var_stream_491 fill:transparent
+subgraph var_stream_493 ["var <tt>stream_493</tt>"]
+    style var_stream_493 fill:transparent
     238v1
 end
-subgraph var_stream_494 ["var <tt>stream_494</tt>"]
-    style var_stream_494 fill:transparent
+subgraph var_stream_496 ["var <tt>stream_496</tt>"]
+    style var_stream_496 fill:transparent
     239v1
-end
-subgraph var_stream_495 ["var <tt>stream_495</tt>"]
-    style var_stream_495 fill:transparent
-    240v1
 end
 subgraph var_stream_497 ["var <tt>stream_497</tt>"]
     style var_stream_497 fill:transparent
-    241v1
+    240v1
 end
 subgraph var_stream_499 ["var <tt>stream_499</tt>"]
     style var_stream_499 fill:transparent
-    242v1
+    241v1
 end
 subgraph var_stream_50 ["var <tt>stream_50</tt>"]
     style var_stream_50 fill:transparent
     13v1
 end
-subgraph var_stream_500 ["var <tt>stream_500</tt>"]
-    style var_stream_500 fill:transparent
-    243v1
-end
 subgraph var_stream_501 ["var <tt>stream_501</tt>"]
     style var_stream_501 fill:transparent
+    242v1
+end
+subgraph var_stream_502 ["var <tt>stream_502</tt>"]
+    style var_stream_502 fill:transparent
+    243v1
+end
+subgraph var_stream_503 ["var <tt>stream_503</tt>"]
+    style var_stream_503 fill:transparent
     244v1
 end
 subgraph var_stream_52 ["var <tt>stream_52</tt>"]
     style var_stream_52 fill:transparent
     14v1
 end
-subgraph var_stream_529 ["var <tt>stream_529</tt>"]
-    style var_stream_529 fill:transparent
+subgraph var_stream_531 ["var <tt>stream_531</tt>"]
+    style var_stream_531 fill:transparent
     247v1
 end
-subgraph var_stream_530 ["var <tt>stream_530</tt>"]
-    style var_stream_530 fill:transparent
+subgraph var_stream_532 ["var <tt>stream_532</tt>"]
+    style var_stream_532 fill:transparent
     248v1
-end
-subgraph var_stream_533 ["var <tt>stream_533</tt>"]
-    style var_stream_533 fill:transparent
-    250v1
-end
-subgraph var_stream_534 ["var <tt>stream_534</tt>"]
-    style var_stream_534 fill:transparent
-    251v1
 end
 subgraph var_stream_535 ["var <tt>stream_535</tt>"]
     style var_stream_535 fill:transparent
-    252v1
+    250v1
 end
-subgraph var_stream_539 ["var <tt>stream_539</tt>"]
-    style var_stream_539 fill:transparent
-    254v1
+subgraph var_stream_536 ["var <tt>stream_536</tt>"]
+    style var_stream_536 fill:transparent
+    251v1
+end
+subgraph var_stream_537 ["var <tt>stream_537</tt>"]
+    style var_stream_537 fill:transparent
+    252v1
 end
 subgraph var_stream_54 ["var <tt>stream_54</tt>"]
     style var_stream_54 fill:transparent
     15v1
 end
-subgraph var_stream_540 ["var <tt>stream_540</tt>"]
-    style var_stream_540 fill:transparent
-    255v1
+subgraph var_stream_541 ["var <tt>stream_541</tt>"]
+    style var_stream_541 fill:transparent
+    254v1
 end
 subgraph var_stream_542 ["var <tt>stream_542</tt>"]
     style var_stream_542 fill:transparent
-    256v1
+    255v1
 end
 subgraph var_stream_544 ["var <tt>stream_544</tt>"]
     style var_stream_544 fill:transparent
+    256v1
+end
+subgraph var_stream_546 ["var <tt>stream_546</tt>"]
+    style var_stream_546 fill:transparent
     257v1
 end
-subgraph var_stream_547 ["var <tt>stream_547</tt>"]
-    style var_stream_547 fill:transparent
+subgraph var_stream_549 ["var <tt>stream_549</tt>"]
+    style var_stream_549 fill:transparent
     258v1
 end
 subgraph var_stream_55 ["var <tt>stream_55</tt>"]
     style var_stream_55 fill:transparent
     16v1
 end
-subgraph var_stream_551 ["var <tt>stream_551</tt>"]
-    style var_stream_551 fill:transparent
+subgraph var_stream_553 ["var <tt>stream_553</tt>"]
+    style var_stream_553 fill:transparent
     259v1
-end
-subgraph var_stream_552 ["var <tt>stream_552</tt>"]
-    style var_stream_552 fill:transparent
-    260v1
 end
 subgraph var_stream_554 ["var <tt>stream_554</tt>"]
     style var_stream_554 fill:transparent
-    261v1
+    260v1
 end
 subgraph var_stream_556 ["var <tt>stream_556</tt>"]
     style var_stream_556 fill:transparent
+    261v1
+end
+subgraph var_stream_558 ["var <tt>stream_558</tt>"]
+    style var_stream_558 fill:transparent
     262v1
 end
 subgraph var_stream_56 ["var <tt>stream_56</tt>"]

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -3614,85 +3614,102 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: Reference {
+            inner: <shared 19>: Tee {
+                inner: <shared 4>,
+                metadata: HydroIrMetadata {
+                    location_id: Tick(15, Cluster(loc1v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                    },
+                },
+            },
+            kind: Singleton,
+            access_counter: Counting(
+                Cell {
+                    value: 0,
+                },
+            ),
+            metadata: HydroIrMetadata {
+                location_id: Tick(15, Cluster(loc1v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             12,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_794_20 ! ([] [| (num_payloads , base_slot) | base_slot + num_payloads]) }),
+            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_793_20 ! ([] [| (num_payloads , base_slot) | base_slot + num_payloads]) }),
             input: Cast {
                 inner: CrossSingleton {
                     left: Fold {
                         init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2427_15 ! ([] [| | 0usize]) }),
                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2429_16 ! ([] [| count , _ | * count += 1]) }),
                         input: Tee {
-                            inner: <shared 19>: Map {
-                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , usize) , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_786_20 ! ([] [| ((index , payload) , base_slot) | (base_slot + index , payload)]) }),
-                                input: CrossSingleton {
-                                    left: Enumerate {
-                                        input: Batch {
-                                            inner: YieldConcat {
-                                                inner: Map {
-                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1054_20 ! ([] [| (d , _) | d]) }),
-                                                    input: CrossSingleton {
-                                                        left: Batch {
-                                                            inner: ObserveNonDet {
-                                                                inner: Map {
-                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
-                                                                    input: Cast {
-                                                                        inner: Network {
-                                                                            name: None,
-                                                                            networking_info: Tcp {
-                                                                                fault: FailStop,
-                                                                            },
-                                                                            serialize_fn: Some(
-                                                                                hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                                            ),
-                                                                            instantiate_fn: <network instantiate>,
-                                                                            deserialize_fn: Some(
-                                                                                | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > (& b) . unwrap ()) },
-                                                                            ),
-                                                                            input: Cast {
-                                                                                inner: Map {
-                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_with_client_rs_88_24 ! ([] [move | (payload , leader_id) | (leader_id , payload)]) }),
-                                                                                    input: YieldConcat {
-                                                                                        inner: CrossSingleton {
-                                                                                            left: Tee {
-                                                                                                inner: <shared 15>,
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(11, Cluster(loc3v1)),
-                                                                                                    collection_kind: Stream {
-                                                                                                        bound: Bounded,
-                                                                                                        order: TotalOrder,
-                                                                                                        retry: ExactlyOnce,
-                                                                                                        element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
-                                                                                                    },
-                                                                                                },
-                                                                                            },
-                                                                                            right: Tee {
-                                                                                                inner: <shared 17>,
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(11, Cluster(loc3v1)),
-                                                                                                    collection_kind: Optional {
-                                                                                                        bound: Bounded,
-                                                                                                        element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                                                    },
-                                                                                                },
-                                                                                            },
+                            inner: <shared 20>: Map {
+                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_785_20 ! ([base_slot_ref__free = __hydro_singleton_ref_0 ,] [| (index , payload) | (* base_slot_ref__free + index , payload)]) }),
+                                input: Enumerate {
+                                    input: Batch {
+                                        inner: YieldConcat {
+                                            inner: Map {
+                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1054_20 ! ([] [| (d , _) | d]) }),
+                                                input: CrossSingleton {
+                                                    left: Batch {
+                                                        inner: ObserveNonDet {
+                                                            inner: Map {
+                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
+                                                                input: Cast {
+                                                                    inner: Network {
+                                                                        name: None,
+                                                                        networking_info: Tcp {
+                                                                            fault: FailStop,
+                                                                        },
+                                                                        serialize_fn: Some(
+                                                                            hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                                        ),
+                                                                        instantiate_fn: <network instantiate>,
+                                                                        deserialize_fn: Some(
+                                                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > (& b) . unwrap ()) },
+                                                                        ),
+                                                                        input: Cast {
+                                                                            inner: Map {
+                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_with_client_rs_88_24 ! ([] [move | (payload , leader_id) | (leader_id , payload)]) }),
+                                                                                input: YieldConcat {
+                                                                                    inner: CrossSingleton {
+                                                                                        left: Tee {
+                                                                                            inner: <shared 15>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(11, Cluster(loc3v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
                                                                                                     order: TotalOrder,
                                                                                                     retry: ExactlyOnce,
-                                                                                                    element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >),
+                                                                                                    element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                        right: Tee {
+                                                                                            inner: <shared 17>,
+                                                                                            metadata: HydroIrMetadata {
+                                                                                                location_id: Tick(11, Cluster(loc3v1)),
+                                                                                                collection_kind: Optional {
+                                                                                                    bound: Bounded,
+                                                                                                    element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                                 },
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Cluster(loc3v1),
+                                                                                            location_id: Tick(11, Cluster(loc3v1)),
                                                                                             collection_kind: Stream {
-                                                                                                bound: Unbounded,
+                                                                                                bound: Bounded,
                                                                                                 order: TotalOrder,
                                                                                                 retry: ExactlyOnce,
                                                                                                 element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >),
@@ -3705,39 +3722,39 @@ expression: built.ir()
                                                                                             bound: Unbounded,
                                                                                             order: TotalOrder,
                                                                                             retry: ExactlyOnce,
-                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
+                                                                                            element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >),
                                                                                         },
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Cluster(loc3v1),
-                                                                                    collection_kind: KeyedStream {
+                                                                                    collection_kind: Stream {
                                                                                         bound: Unbounded,
-                                                                                        value_order: TotalOrder,
-                                                                                        value_retry: ExactlyOnce,
-                                                                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                                        value_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                                                        order: TotalOrder,
+                                                                                        retry: ExactlyOnce,
+                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                                                                     },
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Cluster(loc1v1),
+                                                                                location_id: Cluster(loc3v1),
                                                                                 collection_kind: KeyedStream {
                                                                                     bound: Unbounded,
                                                                                     value_order: TotalOrder,
                                                                                     value_retry: ExactlyOnce,
-                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
+                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                     value_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                                                                 },
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Cluster(loc1v1),
-                                                                            collection_kind: Stream {
+                                                                            collection_kind: KeyedStream {
                                                                                 bound: Unbounded,
-                                                                                order: NoOrder,
-                                                                                retry: ExactlyOnce,
-                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
+                                                                                value_order: TotalOrder,
+                                                                                value_retry: ExactlyOnce,
+                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
+                                                                                value_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                                                             },
                                                                         },
                                                                     },
@@ -3747,48 +3764,28 @@ expression: built.ir()
                                                                             bound: Unbounded,
                                                                             order: NoOrder,
                                                                             retry: ExactlyOnce,
-                                                                            element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                                                         },
                                                                     },
                                                                 },
-                                                                trusted: false,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Cluster(loc1v1),
                                                                     collection_kind: Stream {
                                                                         bound: Unbounded,
-                                                                        order: TotalOrder,
+                                                                        order: NoOrder,
                                                                         retry: ExactlyOnce,
                                                                         element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                                                     },
                                                                 },
                                                             },
+                                                            trusted: false,
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                location_id: Cluster(loc1v1),
                                                                 collection_kind: Stream {
-                                                                    bound: Bounded,
+                                                                    bound: Unbounded,
                                                                     order: TotalOrder,
                                                                     retry: ExactlyOnce,
                                                                     element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
-                                                                },
-                                                            },
-                                                        },
-                                                        right: Filter {
-                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1053_46 ! ([] [| b | * b]) }),
-                                                            input: Tee {
-                                                                inner: <shared 13>,
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                    collection_kind: Singleton {
-                                                                        bound: Bounded,
-                                                                        element_type: bool,
-                                                                    },
-                                                                },
-                                                            },
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                collection_kind: Optional {
-                                                                    bound: Bounded,
-                                                                    element_type: bool,
                                                                 },
                                                             },
                                                         },
@@ -3798,7 +3795,27 @@ expression: built.ir()
                                                                 bound: Bounded,
                                                                 order: TotalOrder,
                                                                 retry: ExactlyOnce,
-                                                                element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool),
+                                                                element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                            },
+                                                        },
+                                                    },
+                                                    right: Filter {
+                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1053_46 ! ([] [| b | * b]) }),
+                                                        input: Tee {
+                                                            inner: <shared 13>,
+                                                            metadata: HydroIrMetadata {
+                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                collection_kind: Singleton {
+                                                                    bound: Bounded,
+                                                                    element_type: bool,
+                                                                },
+                                                            },
+                                                        },
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                            collection_kind: Optional {
+                                                                bound: Bounded,
+                                                                element_type: bool,
                                                             },
                                                         },
                                                     },
@@ -3808,14 +3825,14 @@ expression: built.ir()
                                                             bound: Bounded,
                                                             order: TotalOrder,
                                                             retry: ExactlyOnce,
-                                                            element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
+                                                            element_type: ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool),
                                                         },
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                    location_id: Tick(15, Cluster(loc1v1)),
                                                     collection_kind: Stream {
-                                                        bound: Unbounded,
+                                                        bound: Bounded,
                                                         order: TotalOrder,
                                                         retry: ExactlyOnce,
                                                         element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
@@ -3823,9 +3840,9 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                                 collection_kind: Stream {
-                                                    bound: Bounded,
+                                                    bound: Unbounded,
                                                     order: TotalOrder,
                                                     retry: ExactlyOnce,
                                                     element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
@@ -3838,318 +3855,7 @@ expression: built.ir()
                                                 bound: Bounded,
                                                 order: TotalOrder,
                                                 retry: ExactlyOnce,
-                                                element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
-                                            },
-                                        },
-                                    },
-                                    right: Cast {
-                                        inner: Tee {
-                                            inner: <shared 20>: Cast {
-                                                inner: ChainFirst {
-                                                    first: Map {
-                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_780_71 ! ([] [| s | s + 1]) }),
-                                                        input: Batch {
-                                                            inner: YieldConcat {
-                                                                inner: Tee {
-                                                                    inner: <shared 21>: Reduce {
-                                                                        f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
-                                                                        input: ObserveNonDet {
-                                                                            inner: Map {
-                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
-                                                                                input: Cast {
-                                                                                    inner: Cast {
-                                                                                        inner: Tee {
-                                                                                            inner: <shared 22>: Map {
-                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_484_23 ! ([f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_628_16 ! ([] [| (count , entry) | (count , entry . unwrap ())]) }) ,] [{ let orig = f__free ; move | (k , v) | (k , orig (v)) }]) }),
-                                                                                                input: FoldKeyed {
-                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_607_67 ! ([] [| | (0 , None)]) }),
-                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_607_85 ! ([] [| curr_entry , new_entry | { if let Some (curr_entry_payload) = & mut curr_entry . 1 { let same_values = new_entry . value == curr_entry_payload . value ; let higher_ballot = new_entry . ballot > curr_entry_payload . ballot ; if same_values { curr_entry . 0 += 1 ; } if higher_ballot { curr_entry_payload . ballot = new_entry . ballot ; if ! same_values { curr_entry . 0 = 1 ; curr_entry_payload . value = new_entry . value ; } } } else { * curr_entry = (1 , Some (new_entry)) ; } }]) }),
-                                                                                                    input: Cast {
-                                                                                                        inner: FlatMap {
-                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_764_35 ! ([] [| d | d]) }),
-                                                                                                            input: Map {
-                                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_604_16 ! ([] [| (_checkpoint , log) | log]) }),
-                                                                                                                input: Tee {
-                                                                                                                    inner: <shared 23>: FlatMap {
-                                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_571_35 ! ([] [| v | v]) }),
-                                                                                                                        input: Cast {
-                                                                                                                            inner: Tee {
-                                                                                                                                inner: <shared 14>,
-                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                    collection_kind: Optional {
-                                                                                                                                        bound: Bounded,
-                                                                                                                                        element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
-                                                                                                                                    },
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                collection_kind: Stream {
-                                                                                                                                    bound: Bounded,
-                                                                                                                                    order: TotalOrder,
-                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                    element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                            collection_kind: Stream {
-                                                                                                                                bound: Bounded,
-                                                                                                                                order: NoOrder,
-                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                        collection_kind: Stream {
-                                                                                                                            bound: Bounded,
-                                                                                                                            order: NoOrder,
-                                                                                                                            retry: ExactlyOnce,
-                                                                                                                            element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                    collection_kind: Stream {
-                                                                                                                        bound: Bounded,
-                                                                                                                        order: NoOrder,
-                                                                                                                        retry: ExactlyOnce,
-                                                                                                                        element_type: std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                            },
-                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                collection_kind: Stream {
-                                                                                                                    bound: Bounded,
-                                                                                                                    order: NoOrder,
-                                                                                                                    retry: ExactlyOnce,
-                                                                                                                    element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                                },
-                                                                                                            },
-                                                                                                        },
-                                                                                                        metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                            collection_kind: KeyedStream {
-                                                                                                                bound: Bounded,
-                                                                                                                value_order: NoOrder,
-                                                                                                                value_retry: ExactlyOnce,
-                                                                                                                key_type: usize,
-                                                                                                                value_type: hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >,
-                                                                                                            },
-                                                                                                        },
-                                                                                                    },
-                                                                                                    metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                        collection_kind: KeyedSingleton {
-                                                                                                            bound: Bounded,
-                                                                                                            key_type: usize,
-                                                                                                            value_type: (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                                                        },
-                                                                                                    },
-                                                                                                },
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                    collection_kind: KeyedSingleton {
-                                                                                                        bound: Bounded,
-                                                                                                        key_type: usize,
-                                                                                                        value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                    },
-                                                                                                },
-                                                                                            },
-                                                                                            metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                collection_kind: KeyedSingleton {
-                                                                                                    bound: Bounded,
-                                                                                                    key_type: usize,
-                                                                                                    value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                },
-                                                                                            },
-                                                                                        },
-                                                                                        metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                            collection_kind: KeyedStream {
-                                                                                                bound: Bounded,
-                                                                                                value_order: TotalOrder,
-                                                                                                value_retry: ExactlyOnce,
-                                                                                                key_type: usize,
-                                                                                                value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                            },
-                                                                                        },
-                                                                                    },
-                                                                                    metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                        collection_kind: Stream {
-                                                                                            bound: Bounded,
-                                                                                            order: NoOrder,
-                                                                                            retry: ExactlyOnce,
-                                                                                            element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
-                                                                                        },
-                                                                                    },
-                                                                                },
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                    collection_kind: Stream {
-                                                                                        bound: Bounded,
-                                                                                        order: NoOrder,
-                                                                                        retry: ExactlyOnce,
-                                                                                        element_type: usize,
-                                                                                    },
-                                                                                },
-                                                                            },
-                                                                            trusted: true,
-                                                                            metadata: HydroIrMetadata {
-                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                collection_kind: Stream {
-                                                                                    bound: Bounded,
-                                                                                    order: TotalOrder,
-                                                                                    retry: ExactlyOnce,
-                                                                                    element_type: usize,
-                                                                                },
-                                                                            },
-                                                                        },
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                            collection_kind: Optional {
-                                                                                bound: Bounded,
-                                                                                element_type: usize,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                        collection_kind: Optional {
-                                                                            bound: Bounded,
-                                                                            element_type: usize,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Atomic(Tick(15, Cluster(loc1v1))),
-                                                                    collection_kind: Optional {
-                                                                        bound: Unbounded,
-                                                                        element_type: usize,
-                                                                    },
-                                                                },
-                                                            },
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                collection_kind: Optional {
-                                                                    bound: Bounded,
-                                                                    element_type: usize,
-                                                                },
-                                                            },
-                                                        },
-                                                        metadata: HydroIrMetadata {
-                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                            collection_kind: Optional {
-                                                                bound: Bounded,
-                                                                element_type: usize,
-                                                            },
-                                                        },
-                                                    },
-                                                    second: Cast {
-                                                        inner: Cast {
-                                                            inner: ChainFirst {
-                                                                first: DeferTick {
-                                                                    input: CycleSource {
-                                                                        cycle_id: CycleId(
-                                                                            12,
-                                                                        ),
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                            collection_kind: Singleton {
-                                                                                bound: Bounded,
-                                                                                element_type: usize,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                        collection_kind: Optional {
-                                                                            bound: Bounded,
-                                                                            element_type: usize,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                second: Cast {
-                                                                    inner: SingletonSource {
-                                                                        value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_776_58 ! ([] [0]) },
-                                                                        first_tick_only: false,
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                            collection_kind: Singleton {
-                                                                                bound: Bounded,
-                                                                                element_type: usize,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                        collection_kind: Optional {
-                                                                            bound: Bounded,
-                                                                            element_type: usize,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                    collection_kind: Optional {
-                                                                        bound: Bounded,
-                                                                        element_type: usize,
-                                                                    },
-                                                                },
-                                                            },
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                collection_kind: Singleton {
-                                                                    bound: Bounded,
-                                                                    element_type: usize,
-                                                                },
-                                                            },
-                                                        },
-                                                        metadata: HydroIrMetadata {
-                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                            collection_kind: Optional {
-                                                                bound: Bounded,
-                                                                element_type: usize,
-                                                            },
-                                                        },
-                                                    },
-                                                    metadata: HydroIrMetadata {
-                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                        collection_kind: Optional {
-                                                            bound: Bounded,
-                                                            element_type: usize,
-                                                        },
-                                                    },
-                                                },
-                                                metadata: HydroIrMetadata {
-                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                    collection_kind: Singleton {
-                                                        bound: Bounded,
-                                                        element_type: usize,
-                                                    },
-                                                },
-                                            },
-                                            metadata: HydroIrMetadata {
-                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                collection_kind: Singleton {
-                                                    bound: Bounded,
-                                                    element_type: usize,
-                                                },
-                                            },
-                                        },
-                                        metadata: HydroIrMetadata {
-                                            location_id: Tick(15, Cluster(loc1v1)),
-                                            collection_kind: Optional {
-                                                bound: Bounded,
-                                                element_type: usize,
+                                                element_type: (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)),
                                             },
                                         },
                                     },
@@ -4159,7 +3865,7 @@ expression: built.ir()
                                             bound: Bounded,
                                             order: TotalOrder,
                                             retry: ExactlyOnce,
-                                            element_type: ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , usize),
+                                            element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                         },
                                     },
                                 },
@@ -4191,8 +3897,306 @@ expression: built.ir()
                             },
                         },
                     },
-                    right: Tee {
-                        inner: <shared 20>,
+                    right: Reference {
+                        inner: <shared 21>: Cast {
+                            inner: ChainFirst {
+                                first: Map {
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_779_71 ! ([] [| s | s + 1]) }),
+                                    input: Batch {
+                                        inner: YieldConcat {
+                                            inner: Tee {
+                                                inner: <shared 22>: Reduce {
+                                                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
+                                                    input: ObserveNonDet {
+                                                        inner: Map {
+                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
+                                                            input: Cast {
+                                                                inner: Cast {
+                                                                    inner: Tee {
+                                                                        inner: <shared 23>: Map {
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_484_23 ! ([f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_628_16 ! ([] [| (count , entry) | (count , entry . unwrap ())]) }) ,] [{ let orig = f__free ; move | (k , v) | (k , orig (v)) }]) }),
+                                                                            input: FoldKeyed {
+                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_607_67 ! ([] [| | (0 , None)]) }),
+                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_607_85 ! ([] [| curr_entry , new_entry | { if let Some (curr_entry_payload) = & mut curr_entry . 1 { let same_values = new_entry . value == curr_entry_payload . value ; let higher_ballot = new_entry . ballot > curr_entry_payload . ballot ; if same_values { curr_entry . 0 += 1 ; } if higher_ballot { curr_entry_payload . ballot = new_entry . ballot ; if ! same_values { curr_entry . 0 = 1 ; curr_entry_payload . value = new_entry . value ; } } } else { * curr_entry = (1 , Some (new_entry)) ; } }]) }),
+                                                                                input: Cast {
+                                                                                    inner: FlatMap {
+                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_764_35 ! ([] [| d | d]) }),
+                                                                                        input: Map {
+                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_604_16 ! ([] [| (_checkpoint , log) | log]) }),
+                                                                                            input: Tee {
+                                                                                                inner: <shared 24>: FlatMap {
+                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_571_35 ! ([] [| v | v]) }),
+                                                                                                    input: Cast {
+                                                                                                        inner: Tee {
+                                                                                                            inner: <shared 14>,
+                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                collection_kind: Optional {
+                                                                                                                    bound: Bounded,
+                                                                                                                    element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
+                                                                                                                },
+                                                                                                            },
+                                                                                                        },
+                                                                                                        metadata: HydroIrMetadata {
+                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                            collection_kind: Stream {
+                                                                                                                bound: Bounded,
+                                                                                                                order: TotalOrder,
+                                                                                                                retry: ExactlyOnce,
+                                                                                                                element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
+                                                                                                            },
+                                                                                                        },
+                                                                                                    },
+                                                                                                    metadata: HydroIrMetadata {
+                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                        collection_kind: Stream {
+                                                                                                            bound: Bounded,
+                                                                                                            order: NoOrder,
+                                                                                                            retry: ExactlyOnce,
+                                                                                                            element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                                        },
+                                                                                                    },
+                                                                                                },
+                                                                                                metadata: HydroIrMetadata {
+                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                    collection_kind: Stream {
+                                                                                                        bound: Bounded,
+                                                                                                        order: NoOrder,
+                                                                                                        retry: ExactlyOnce,
+                                                                                                        element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                            metadata: HydroIrMetadata {
+                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                collection_kind: Stream {
+                                                                                                    bound: Bounded,
+                                                                                                    order: NoOrder,
+                                                                                                    retry: ExactlyOnce,
+                                                                                                    element_type: std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >,
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                            collection_kind: Stream {
+                                                                                                bound: Bounded,
+                                                                                                order: NoOrder,
+                                                                                                retry: ExactlyOnce,
+                                                                                                element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                    metadata: HydroIrMetadata {
+                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                        collection_kind: KeyedStream {
+                                                                                            bound: Bounded,
+                                                                                            value_order: NoOrder,
+                                                                                            value_retry: ExactlyOnce,
+                                                                                            key_type: usize,
+                                                                                            value_type: hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                    collection_kind: KeyedSingleton {
+                                                                                        bound: Bounded,
+                                                                                        key_type: usize,
+                                                                                        value_type: (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                    },
+                                                                                },
+                                                                            },
+                                                                            metadata: HydroIrMetadata {
+                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                collection_kind: KeyedSingleton {
+                                                                                    bound: Bounded,
+                                                                                    key_type: usize,
+                                                                                    value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        metadata: HydroIrMetadata {
+                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                            collection_kind: KeyedSingleton {
+                                                                                bound: Bounded,
+                                                                                key_type: usize,
+                                                                                value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                    metadata: HydroIrMetadata {
+                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                        collection_kind: KeyedStream {
+                                                                            bound: Bounded,
+                                                                            value_order: TotalOrder,
+                                                                            value_retry: ExactlyOnce,
+                                                                            key_type: usize,
+                                                                            value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                        },
+                                                                    },
+                                                                },
+                                                                metadata: HydroIrMetadata {
+                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                    collection_kind: Stream {
+                                                                        bound: Bounded,
+                                                                        order: NoOrder,
+                                                                        retry: ExactlyOnce,
+                                                                        element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
+                                                                    },
+                                                                },
+                                                            },
+                                                            metadata: HydroIrMetadata {
+                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                collection_kind: Stream {
+                                                                    bound: Bounded,
+                                                                    order: NoOrder,
+                                                                    retry: ExactlyOnce,
+                                                                    element_type: usize,
+                                                                },
+                                                            },
+                                                        },
+                                                        trusted: true,
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                            collection_kind: Stream {
+                                                                bound: Bounded,
+                                                                order: TotalOrder,
+                                                                retry: ExactlyOnce,
+                                                                element_type: usize,
+                                                            },
+                                                        },
+                                                    },
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                        collection_kind: Optional {
+                                                            bound: Bounded,
+                                                            element_type: usize,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                collection_kind: Optional {
+                                                    bound: Unbounded,
+                                                    element_type: usize,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_id: Tick(15, Cluster(loc1v1)),
+                                            collection_kind: Optional {
+                                                bound: Bounded,
+                                                element_type: usize,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_id: Tick(15, Cluster(loc1v1)),
+                                        collection_kind: Optional {
+                                            bound: Bounded,
+                                            element_type: usize,
+                                        },
+                                    },
+                                },
+                                second: Cast {
+                                    inner: Cast {
+                                        inner: ChainFirst {
+                                            first: DeferTick {
+                                                input: CycleSource {
+                                                    cycle_id: CycleId(
+                                                        12,
+                                                    ),
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                        collection_kind: Singleton {
+                                                            bound: Bounded,
+                                                            element_type: usize,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            second: Cast {
+                                                inner: SingletonSource {
+                                                    value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_775_58 ! ([] [0]) },
+                                                    first_tick_only: false,
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                        collection_kind: Singleton {
+                                                            bound: Bounded,
+                                                            element_type: usize,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                    collection_kind: Optional {
+                                                        bound: Bounded,
+                                                        element_type: usize,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                collection_kind: Optional {
+                                                    bound: Bounded,
+                                                    element_type: usize,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_id: Tick(15, Cluster(loc1v1)),
+                                            collection_kind: Singleton {
+                                                bound: Bounded,
+                                                element_type: usize,
+                                            },
+                                        },
+                                    },
+                                    metadata: HydroIrMetadata {
+                                        location_id: Tick(15, Cluster(loc1v1)),
+                                        collection_kind: Optional {
+                                            bound: Bounded,
+                                            element_type: usize,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_id: Tick(15, Cluster(loc1v1)),
+                                    collection_kind: Optional {
+                                        bound: Bounded,
+                                        element_type: usize,
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_id: Tick(15, Cluster(loc1v1)),
+                                collection_kind: Singleton {
+                                    bound: Bounded,
+                                    element_type: usize,
+                                },
+                            },
+                        },
+                        kind: Singleton,
+                        access_counter: Counting(
+                            Cell {
+                                value: 0,
+                            },
+                        ),
                         metadata: HydroIrMetadata {
                             location_id: Tick(15, Cluster(loc1v1)),
                             collection_kind: Singleton {
@@ -4227,13 +4231,41 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: Reference {
+            inner: <shared 25>: Tee {
+                inner: <shared 10>,
+                metadata: HydroIrMetadata {
+                    location_id: Tick(2, Cluster(loc2v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                    },
+                },
+            },
+            kind: Singleton,
+            access_counter: Counting(
+                Cell {
+                    value: 0,
+                },
+            ),
+            metadata: HydroIrMetadata {
+                location_id: Tick(2, Cluster(loc2v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             13,
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 24>: Chain {
+                inner: <shared 26>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -4261,7 +4293,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <shared 25>: Map {
+                            inner: <shared 27>: Map {
                                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
                                 input: Cast {
                                     inner: Network {
@@ -4279,91 +4311,81 @@ expression: built.ir()
                                         input: Cast {
                                             inner: YieldConcat {
                                                 inner: Map {
-                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_874_16 ! ([] [| (p2a , max_ballot) | (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) }))]) }),
-                                                    input: CrossSingleton {
-                                                        left: Tee {
-                                                            inner: <shared 26>: Batch {
-                                                                inner: Map {
-                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
-                                                                    input: Cast {
-                                                                        inner: Network {
-                                                                            name: None,
-                                                                            networking_info: Tcp {
-                                                                                fault: FailStop,
-                                                                            },
-                                                                            serialize_fn: Some(
-                                                                                hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                                            ),
-                                                                            instantiate_fn: <network instantiate>,
-                                                                            deserialize_fn: Some(
-                                                                                | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > (& b) . unwrap ()) },
-                                                                            ),
-                                                                            input: YieldConcat {
-                                                                                inner: Cast {
-                                                                                    inner: CrossProduct {
-                                                                                        left: ObserveNonDet {
-                                                                                            inner: Map {
-                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
-                                                                                                input: Cast {
-                                                                                                    inner: Cast {
-                                                                                                        inner: Filter {
-                                                                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_1187_61 ! ([] [| b | * b]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
-                                                                                                            input: Batch {
-                                                                                                                inner: FoldKeyed {
-                                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_36_11 ! ([] [| | false]) }),
-                                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_37_11 ! ([] [| present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } }]) }),
-                                                                                                                    input: Cast {
-                                                                                                                        inner: Map {
-                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; hydro_lang :: __stageleft_quote_src_location_mod_rs_545_16 ! ([] [| (k , v) | (MemberId :: from_tagless (k) , v)]) }),
-                                                                                                                            input: Source {
-                                                                                                                                source: ClusterMembers(
-                                                                                                                                    Cluster(loc2v1),
-                                                                                                                                    Uninit,
-                                                                                                                                ),
-                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Cluster(loc1v1),
-                                                                                                                                    collection_kind: Stream {
-                                                                                                                                        bound: Unbounded,
-                                                                                                                                        order: TotalOrder,
-                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
-                                                                                                                                    },
-                                                                                                                                },
-                                                                                                                            },
+                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_874_16 ! ([a_max_ballot_ref__free = __hydro_singleton_ref_0 ,] [| p2a | { let max_ballot = a_max_ballot_ref__free . clone () ; (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) } ,) ,) }]) }),
+                                                    input: Tee {
+                                                        inner: <shared 28>: Batch {
+                                                            inner: Map {
+                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
+                                                                input: Cast {
+                                                                    inner: Network {
+                                                                        name: None,
+                                                                        networking_info: Tcp {
+                                                                            fault: FailStop,
+                                                                        },
+                                                                        serialize_fn: Some(
+                                                                            hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                                        ),
+                                                                        instantiate_fn: <network instantiate>,
+                                                                        deserialize_fn: Some(
+                                                                            | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > (& b) . unwrap ()) },
+                                                                        ),
+                                                                        input: YieldConcat {
+                                                                            inner: Cast {
+                                                                                inner: CrossProduct {
+                                                                                    left: ObserveNonDet {
+                                                                                        inner: Map {
+                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
+                                                                                            input: Cast {
+                                                                                                inner: Cast {
+                                                                                                    inner: Filter {
+                                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_1187_61 ! ([] [| b | * b]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
+                                                                                                        input: Batch {
+                                                                                                            inner: FoldKeyed {
+                                                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_36_11 ! ([] [| | false]) }),
+                                                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_37_11 ! ([] [| present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } }]) }),
+                                                                                                                input: Cast {
+                                                                                                                    inner: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; hydro_lang :: __stageleft_quote_src_location_mod_rs_545_16 ! ([] [| (k , v) | (MemberId :: from_tagless (k) , v)]) }),
+                                                                                                                        input: Source {
+                                                                                                                            source: ClusterMembers(
+                                                                                                                                Cluster(loc2v1),
+                                                                                                                                Uninit,
+                                                                                                                            ),
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_id: Cluster(loc1v1),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Unbounded,
                                                                                                                                     order: TotalOrder,
                                                                                                                                     retry: ExactlyOnce,
-                                                                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                                                                                 },
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Cluster(loc1v1),
-                                                                                                                            collection_kind: KeyedStream {
+                                                                                                                            collection_kind: Stream {
                                                                                                                                 bound: Unbounded,
-                                                                                                                                value_order: TotalOrder,
-                                                                                                                                value_retry: ExactlyOnce,
-                                                                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                                value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
+                                                                                                                                order: TotalOrder,
+                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                                                                             },
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_id: Cluster(loc1v1),
-                                                                                                                        collection_kind: KeyedSingleton {
-                                                                                                                            bound: MonotonicKeys,
+                                                                                                                        collection_kind: KeyedStream {
+                                                                                                                            bound: Unbounded,
+                                                                                                                            value_order: TotalOrder,
+                                                                                                                            value_retry: ExactlyOnce,
                                                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                            value_type: bool,
+                                                                                                                            value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
                                                                                                                         },
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                                    location_id: Cluster(loc1v1),
                                                                                                                     collection_kind: KeyedSingleton {
-                                                                                                                        bound: Bounded,
+                                                                                                                        bound: MonotonicKeys,
                                                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                                                         value_type: bool,
                                                                                                                     },
@@ -4380,10 +4402,8 @@ expression: built.ir()
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_id: Tick(13, Cluster(loc1v1)),
-                                                                                                            collection_kind: KeyedStream {
+                                                                                                            collection_kind: KeyedSingleton {
                                                                                                                 bound: Bounded,
-                                                                                                                value_order: TotalOrder,
-                                                                                                                value_retry: ExactlyOnce,
                                                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                                                 value_type: bool,
                                                                                                             },
@@ -4391,11 +4411,12 @@ expression: built.ir()
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Tick(13, Cluster(loc1v1)),
-                                                                                                        collection_kind: Stream {
+                                                                                                        collection_kind: KeyedStream {
                                                                                                             bound: Bounded,
-                                                                                                            order: NoOrder,
-                                                                                                            retry: ExactlyOnce,
-                                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
+                                                                                                            value_order: TotalOrder,
+                                                                                                            value_retry: ExactlyOnce,
+                                                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                            value_type: bool,
                                                                                                         },
                                                                                                     },
                                                                                                 },
@@ -4405,58 +4426,47 @@ expression: built.ir()
                                                                                                         bound: Bounded,
                                                                                                         order: NoOrder,
                                                                                                         retry: ExactlyOnce,
-                                                                                                        element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
                                                                                                     },
                                                                                                 },
                                                                                             },
-                                                                                            trusted: true,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(13, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
-                                                                                                    order: TotalOrder,
+                                                                                                    order: NoOrder,
                                                                                                     retry: ExactlyOnce,
                                                                                                     element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                                 },
                                                                                             },
                                                                                         },
-                                                                                        right: Batch {
-                                                                                            inner: Map {
-                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_735_20 ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ,] [move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free . clone () , ballot , slot , value }]) }),
-                                                                                                input: EndAtomic {
-                                                                                                    inner: Tee {
-                                                                                                        inner: <shared 27>: YieldConcat {
-                                                                                                            inner: Map {
-                                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1054_20 ! ([] [| (d , _) | d]) }),
-                                                                                                                input: CrossSingleton {
-                                                                                                                    left: Chain {
-                                                                                                                        first: Map {
-                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_721_16 ! ([] [| ((slot , payload) , ballot) | ((slot , ballot) , Some (payload))]) }),
-                                                                                                                            input: CrossSingleton {
-                                                                                                                                left: Batch {
-                                                                                                                                    inner: YieldConcat {
-                                                                                                                                        inner: Tee {
-                                                                                                                                            inner: <shared 19>,
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Stream {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    order: TotalOrder,
-                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                    element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Atomic(Tick(15, Cluster(loc1v1))),
-                                                                                                                                            collection_kind: Stream {
-                                                                                                                                                bound: Unbounded,
-                                                                                                                                                order: TotalOrder,
-                                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                                element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
+                                                                                        trusted: true,
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_id: Tick(13, Cluster(loc1v1)),
+                                                                                            collection_kind: Stream {
+                                                                                                bound: Bounded,
+                                                                                                order: TotalOrder,
+                                                                                                retry: ExactlyOnce,
+                                                                                                element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                    right: Batch {
+                                                                                        inner: Map {
+                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_734_20 ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ,] [move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free . clone () , ballot , slot , value }]) }),
+                                                                                            input: EndAtomic {
+                                                                                                inner: Tee {
+                                                                                                    inner: <shared 29>: YieldConcat {
+                                                                                                        inner: Map {
+                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1054_20 ! ([] [| (d , _) | d]) }),
+                                                                                                            input: CrossSingleton {
+                                                                                                                left: Chain {
+                                                                                                                    first: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_720_16 ! ([p_ballot_ref__free = __hydro_singleton_ref_0 ,] [| (slot , payload) | ((slot , p_ballot_ref__free . clone ()) , Some (payload))]) }),
+                                                                                                                        input: Batch {
+                                                                                                                            inner: YieldConcat {
+                                                                                                                                inner: Tee {
+                                                                                                                                    inner: <shared 20>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Stream {
@@ -4467,32 +4477,13 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 },
-                                                                                                                                right: Cast {
-                                                                                                                                    inner: Tee {
-                                                                                                                                        inner: <shared 4>,
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                            collection_kind: Singleton {
-                                                                                                                                                bound: Bounded,
-                                                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                        collection_kind: Optional {
-                                                                                                                                            bound: Bounded,
-                                                                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                    location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                                                                                                                     collection_kind: Stream {
-                                                                                                                                        bound: Bounded,
+                                                                                                                                        bound: Unbounded,
                                                                                                                                         order: TotalOrder,
                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                        element_type: ((usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                                                                        element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                             },
@@ -4502,197 +4493,44 @@ expression: built.ir()
                                                                                                                                     bound: Bounded,
                                                                                                                                     order: TotalOrder,
                                                                                                                                     retry: ExactlyOnce,
-                                                                                                                                    element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                    element_type: (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))),
                                                                                                                                 },
                                                                                                                             },
                                                                                                                         },
-                                                                                                                        second: Chain {
-                                                                                                                            first: FilterMap {
-                                                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < usize >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_634_23 ! ([f__free = 1usize ,] [move | (((slot , (count , entry)) , ballot) , checkpoint) | { if count > f__free { return None ; } else if let Some (checkpoint) = checkpoint && slot <= checkpoint { return None ; } Some (((slot , ballot) , entry . value)) }]) }),
-                                                                                                                                input: CrossSingleton {
-                                                                                                                                    left: CrossSingleton {
-                                                                                                                                        left: Cast {
-                                                                                                                                            inner: Cast {
-                                                                                                                                                inner: Tee {
-                                                                                                                                                    inner: <shared 22>,
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: KeyedSingleton {
-                                                                                                                                                            bound: Bounded,
-                                                                                                                                                            key_type: usize,
-                                                                                                                                                            value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: KeyedStream {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        value_order: TotalOrder,
-                                                                                                                                                        value_retry: ExactlyOnce,
-                                                                                                                                                        key_type: usize,
-                                                                                                                                                        value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Stream {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    order: NoOrder,
-                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                    element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        right: Cast {
-                                                                                                                                            inner: Tee {
-                                                                                                                                                inner: <shared 4>,
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Singleton {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                            collection_kind: Stream {
+                                                                                                                                bound: Bounded,
+                                                                                                                                order: TotalOrder,
+                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    second: Chain {
+                                                                                                                        first: FilterMap {
+                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_634_23 ! ([f__free = 1usize , p_ballot_ref__free = __hydro_singleton_ref_0 , p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1 ,] [move | (slot , (count , entry)) | { if count > f__free { return None ; } else if let Some (checkpoint) = * p_p1b_max_checkpoint_ref__free && slot <= checkpoint { return None ; } Some (((slot , p_ballot_ref__free . clone ()) , entry . value)) }]) }),
+                                                                                                                            input: Cast {
+                                                                                                                                inner: Cast {
+                                                                                                                                    inner: Tee {
+                                                                                                                                        inner: <shared 23>,
                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                            collection_kind: Stream {
+                                                                                                                                            collection_kind: KeyedSingleton {
                                                                                                                                                 bound: Bounded,
-                                                                                                                                                order: NoOrder,
-                                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                                element_type: ((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot),
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    right: Cast {
-                                                                                                                                        inner: Tee {
-                                                                                                                                            inner: <shared 28>: Cast {
-                                                                                                                                                inner: ChainFirst {
-                                                                                                                                                    first: Map {
-                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
-                                                                                                                                                        input: Reduce {
-                                                                                                                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
-                                                                                                                                                            input: ObserveNonDet {
-                                                                                                                                                                inner: FilterMap {
-                                                                                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_600_23 ! ([] [| (checkpoint , _log) | checkpoint]) }),
-                                                                                                                                                                    input: Tee {
-                                                                                                                                                                        inner: <shared 23>,
-                                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                            collection_kind: Stream {
-                                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                                order: NoOrder,
-                                                                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                                                                element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                        collection_kind: Stream {
-                                                                                                                                                                            bound: Bounded,
-                                                                                                                                                                            order: NoOrder,
-                                                                                                                                                                            retry: ExactlyOnce,
-                                                                                                                                                                            element_type: usize,
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                                trusted: true,
-                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                        order: TotalOrder,
-                                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                                        element_type: usize,
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: usize,
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: core :: option :: Option < usize >,
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    second: Cast {
-                                                                                                                                                        inner: SingletonSource {
-                                                                                                                                                            value: :: std :: option :: Option :: None,
-                                                                                                                                                            first_tick_only: false,
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: core :: option :: Option < usize >,
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: core :: option :: Option < usize >,
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: Optional {
-                                                                                                                                                            bound: Bounded,
-                                                                                                                                                            element_type: core :: option :: Option < usize >,
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Singleton {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        element_type: core :: option :: Option < usize >,
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    element_type: core :: option :: Option < usize >,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                bound: Bounded,
-                                                                                                                                                element_type: core :: option :: Option < usize >,
+                                                                                                                                                key_type: usize,
+                                                                                                                                                value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                        collection_kind: Stream {
+                                                                                                                                        collection_kind: KeyedStream {
                                                                                                                                             bound: Bounded,
-                                                                                                                                            order: NoOrder,
-                                                                                                                                            retry: ExactlyOnce,
-                                                                                                                                            element_type: (((usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < usize >),
+                                                                                                                                            value_order: TotalOrder,
+                                                                                                                                            value_retry: ExactlyOnce,
+                                                                                                                                            key_type: usize,
+                                                                                                                                            value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 },
@@ -4702,34 +4540,120 @@ expression: built.ir()
                                                                                                                                         bound: Bounded,
                                                                                                                                         order: NoOrder,
                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                        element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                             },
-                                                                                                                            second: Map {
-                                                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_658_16 ! ([] [move | (slot , ballot) | ((slot , ballot) , None)]) }),
-                                                                                                                                input: CrossSingleton {
-                                                                                                                                    left: Difference {
-                                                                                                                                        pos: FlatMap {
-                                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_649_29 ! ([] [| (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } }]) }),
-                                                                                                                                            input: Cast {
-                                                                                                                                                inner: CrossSingleton {
-                                                                                                                                                    left: Tee {
-                                                                                                                                                        inner: <shared 21>,
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: usize,
-                                                                                                                                                            },
-                                                                                                                                                        },
+                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                collection_kind: Stream {
+                                                                                                                                    bound: Bounded,
+                                                                                                                                    order: NoOrder,
+                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                    element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        second: Map {
+                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < usize , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_657_16 ! ([p_ballot_ref__free = __hydro_singleton_ref_0 ,] [move | slot | ((slot , p_ballot_ref__free . clone ()) , None)]) }),
+                                                                                                                            input: Difference {
+                                                                                                                                pos: FlatMap {
+                                                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_649_29 ! ([] [| (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } }]) }),
+                                                                                                                                    input: Cast {
+                                                                                                                                        inner: CrossSingleton {
+                                                                                                                                            left: Tee {
+                                                                                                                                                inner: <shared 22>,
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    collection_kind: Optional {
+                                                                                                                                                        bound: Bounded,
+                                                                                                                                                        element_type: usize,
                                                                                                                                                     },
-                                                                                                                                                    right: Cast {
-                                                                                                                                                        inner: Tee {
-                                                                                                                                                            inner: <shared 28>,
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            right: Cast {
+                                                                                                                                                inner: Reference {
+                                                                                                                                                    inner: <shared 30>: Cast {
+                                                                                                                                                        inner: ChainFirst {
+                                                                                                                                                            first: Map {
+                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
+                                                                                                                                                                input: Reduce {
+                                                                                                                                                                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
+                                                                                                                                                                    input: ObserveNonDet {
+                                                                                                                                                                        inner: FilterMap {
+                                                                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_600_23 ! ([] [| (checkpoint , _log) | checkpoint]) }),
+                                                                                                                                                                            input: Tee {
+                                                                                                                                                                                inner: <shared 24>,
+                                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                                    collection_kind: Stream {
+                                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                                        order: NoOrder,
+                                                                                                                                                                                        retry: ExactlyOnce,
+                                                                                                                                                                                        element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                                                                                                                    },
+                                                                                                                                                                                },
+                                                                                                                                                                            },
+                                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                                                    bound: Bounded,
+                                                                                                                                                                                    order: NoOrder,
+                                                                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                                                                    element_type: usize,
+                                                                                                                                                                                },
+                                                                                                                                                                            },
+                                                                                                                                                                        },
+                                                                                                                                                                        trusted: true,
+                                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                                                bound: Bounded,
+                                                                                                                                                                                order: TotalOrder,
+                                                                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                                                                element_type: usize,
+                                                                                                                                                                            },
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                        collection_kind: Optional {
+                                                                                                                                                                            bound: Bounded,
+                                                                                                                                                                            element_type: usize,
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                    collection_kind: Optional {
+                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                        element_type: core :: option :: Option < usize >,
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                            second: Cast {
+                                                                                                                                                                inner: SingletonSource {
+                                                                                                                                                                    value: :: std :: option :: Option :: None,
+                                                                                                                                                                    first_tick_only: false,
+                                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                        collection_kind: Singleton {
+                                                                                                                                                                            bound: Bounded,
+                                                                                                                                                                            element_type: core :: option :: Option < usize >,
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                    collection_kind: Optional {
+                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                        element_type: core :: option :: Option < usize >,
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                            },
                                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Singleton {
+                                                                                                                                                                collection_kind: Optional {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: core :: option :: Option < usize >,
                                                                                                                                                                 },
@@ -4737,83 +4661,39 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
+                                                                                                                                                            collection_kind: Singleton {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: core :: option :: Option < usize >,
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                     },
+                                                                                                                                                    kind: Singleton,
+                                                                                                                                                    access_counter: Counting(
+                                                                                                                                                        Cell {
+                                                                                                                                                            value: 0,
+                                                                                                                                                        },
+                                                                                                                                                    ),
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: Optional {
+                                                                                                                                                        collection_kind: Singleton {
                                                                                                                                                             bound: Bounded,
-                                                                                                                                                            element_type: (usize , core :: option :: Option < usize >),
+                                                                                                                                                            element_type: core :: option :: Option < usize >,
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Stream {
+                                                                                                                                                    collection_kind: Optional {
                                                                                                                                                         bound: Bounded,
-                                                                                                                                                        order: TotalOrder,
-                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                        element_type: (usize , core :: option :: Option < usize >),
+                                                                                                                                                        element_type: core :: option :: Option < usize >,
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                collection_kind: Optional {
                                                                                                                                                     bound: Bounded,
-                                                                                                                                                    order: TotalOrder,
-                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                    element_type: usize,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        neg: Map {
-                                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
-                                                                                                                                            input: Cast {
-                                                                                                                                                inner: Cast {
-                                                                                                                                                    inner: Tee {
-                                                                                                                                                        inner: <shared 22>,
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: KeyedSingleton {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                key_type: usize,
-                                                                                                                                                                value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: KeyedStream {
-                                                                                                                                                            bound: Bounded,
-                                                                                                                                                            value_order: TotalOrder,
-                                                                                                                                                            value_retry: ExactlyOnce,
-                                                                                                                                                            key_type: usize,
-                                                                                                                                                            value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        order: NoOrder,
-                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                        element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Stream {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    order: NoOrder,
-                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                    element_type: usize,
+                                                                                                                                                    element_type: (usize , core :: option :: Option < usize >),
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                         },
@@ -4823,26 +4703,7 @@ expression: built.ir()
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 order: TotalOrder,
                                                                                                                                                 retry: ExactlyOnce,
-                                                                                                                                                element_type: usize,
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    right: Cast {
-                                                                                                                                        inner: Tee {
-                                                                                                                                            inner: <shared 4>,
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                bound: Bounded,
-                                                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                                                element_type: (usize , core :: option :: Option < usize >),
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                     },
@@ -4852,7 +4713,53 @@ expression: built.ir()
                                                                                                                                             bound: Bounded,
                                                                                                                                             order: TotalOrder,
                                                                                                                                             retry: ExactlyOnce,
-                                                                                                                                            element_type: (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                                                                            element_type: usize,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                neg: Map {
+                                                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
+                                                                                                                                    input: Cast {
+                                                                                                                                        inner: Cast {
+                                                                                                                                            inner: Tee {
+                                                                                                                                                inner: <shared 23>,
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    collection_kind: KeyedSingleton {
+                                                                                                                                                        bound: Bounded,
+                                                                                                                                                        key_type: usize,
+                                                                                                                                                        value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                collection_kind: KeyedStream {
+                                                                                                                                                    bound: Bounded,
+                                                                                                                                                    value_order: TotalOrder,
+                                                                                                                                                    value_retry: ExactlyOnce,
+                                                                                                                                                    key_type: usize,
+                                                                                                                                                    value_type: (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                bound: Bounded,
+                                                                                                                                                order: NoOrder,
+                                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                                element_type: (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)),
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        collection_kind: Stream {
+                                                                                                                                            bound: Bounded,
+                                                                                                                                            order: NoOrder,
+                                                                                                                                            retry: ExactlyOnce,
+                                                                                                                                            element_type: usize,
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 },
@@ -4862,7 +4769,7 @@ expression: built.ir()
                                                                                                                                         bound: Bounded,
                                                                                                                                         order: TotalOrder,
                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                                        element_type: usize,
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                             },
@@ -4870,7 +4777,7 @@ expression: built.ir()
                                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Bounded,
-                                                                                                                                    order: NoOrder,
+                                                                                                                                    order: TotalOrder,
                                                                                                                                     retry: ExactlyOnce,
                                                                                                                                     element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                                 },
@@ -4886,21 +4793,23 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                     },
-                                                                                                                    right: Filter {
-                                                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1053_46 ! ([] [| b | * b]) }),
-                                                                                                                        input: Tee {
-                                                                                                                            inner: <shared 13>,
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                collection_kind: Singleton {
-                                                                                                                                    bound: Bounded,
-                                                                                                                                    element_type: bool,
-                                                                                                                                },
-                                                                                                                            },
+                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                        collection_kind: Stream {
+                                                                                                                            bound: Bounded,
+                                                                                                                            order: NoOrder,
+                                                                                                                            retry: ExactlyOnce,
+                                                                                                                            element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                                         },
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                right: Filter {
+                                                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1053_46 ! ([] [| b | * b]) }),
+                                                                                                                    input: Tee {
+                                                                                                                        inner: <shared 13>,
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                            collection_kind: Optional {
+                                                                                                                            collection_kind: Singleton {
                                                                                                                                 bound: Bounded,
                                                                                                                                 element_type: bool,
                                                                                                                             },
@@ -4908,11 +4817,9 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                        collection_kind: Stream {
+                                                                                                                        collection_kind: Optional {
                                                                                                                             bound: Bounded,
-                                                                                                                            order: NoOrder,
-                                                                                                                            retry: ExactlyOnce,
-                                                                                                                            element_type: (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool),
+                                                                                                                            element_type: bool,
                                                                                                                         },
                                                                                                                     },
                                                                                                                 },
@@ -4922,14 +4829,14 @@ expression: built.ir()
                                                                                                                         bound: Bounded,
                                                                                                                         order: NoOrder,
                                                                                                                         retry: ExactlyOnce,
-                                                                                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
+                                                                                                                        element_type: (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool),
                                                                                                                     },
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                 collection_kind: Stream {
-                                                                                                                    bound: Unbounded,
+                                                                                                                    bound: Bounded,
                                                                                                                     order: NoOrder,
                                                                                                                     retry: ExactlyOnce,
                                                                                                                     element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
@@ -4947,7 +4854,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Cluster(loc1v1),
+                                                                                                        location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Unbounded,
                                                                                                             order: NoOrder,
@@ -4962,14 +4869,14 @@ expression: built.ir()
                                                                                                         bound: Unbounded,
                                                                                                         order: NoOrder,
                                                                                                         retry: ExactlyOnce,
-                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >),
                                                                                                     },
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                location_id: Cluster(loc1v1),
                                                                                                 collection_kind: Stream {
-                                                                                                    bound: Bounded,
+                                                                                                    bound: Unbounded,
                                                                                                     order: NoOrder,
                                                                                                     retry: ExactlyOnce,
                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -4982,25 +4889,24 @@ expression: built.ir()
                                                                                                 bound: Bounded,
                                                                                                 order: NoOrder,
                                                                                                 retry: ExactlyOnce,
-                                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
+                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                             },
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Tick(13, Cluster(loc1v1)),
-                                                                                        collection_kind: KeyedStream {
+                                                                                        collection_kind: Stream {
                                                                                             bound: Bounded,
-                                                                                            value_order: NoOrder,
-                                                                                            value_retry: ExactlyOnce,
-                                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                            value_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                            order: NoOrder,
+                                                                                            retry: ExactlyOnce,
+                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
                                                                                         },
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Cluster(loc1v1),
+                                                                                    location_id: Tick(13, Cluster(loc1v1)),
                                                                                     collection_kind: KeyedStream {
-                                                                                        bound: Unbounded,
+                                                                                        bound: Bounded,
                                                                                         value_order: NoOrder,
                                                                                         value_retry: ExactlyOnce,
                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -5009,23 +4915,24 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Cluster(loc2v1),
+                                                                                location_id: Cluster(loc1v1),
                                                                                 collection_kind: KeyedStream {
                                                                                     bound: Unbounded,
                                                                                     value_order: NoOrder,
                                                                                     value_retry: ExactlyOnce,
-                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
                                                                                     value_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                 },
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Cluster(loc2v1),
-                                                                            collection_kind: Stream {
+                                                                            collection_kind: KeyedStream {
                                                                                 bound: Unbounded,
-                                                                                order: NoOrder,
-                                                                                retry: ExactlyOnce,
-                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
+                                                                                value_order: NoOrder,
+                                                                                value_retry: ExactlyOnce,
+                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                                value_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                             },
                                                                         },
                                                                     },
@@ -5035,14 +4942,14 @@ expression: built.ir()
                                                                             bound: Unbounded,
                                                                             order: NoOrder,
                                                                             retry: ExactlyOnce,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >),
                                                                         },
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
+                                                                    location_id: Cluster(loc2v1),
                                                                     collection_kind: Stream {
-                                                                        bound: Bounded,
+                                                                        bound: Unbounded,
                                                                         order: NoOrder,
                                                                         retry: ExactlyOnce,
                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -5059,32 +4966,13 @@ expression: built.ir()
                                                                 },
                                                             },
                                                         },
-                                                        right: Cast {
-                                                            inner: Tee {
-                                                                inner: <shared 10>,
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
-                                                                    collection_kind: Singleton {
-                                                                        bound: Bounded,
-                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                    },
-                                                                },
-                                                            },
-                                                            metadata: HydroIrMetadata {
-                                                                location_id: Tick(2, Cluster(loc2v1)),
-                                                                collection_kind: Optional {
-                                                                    bound: Bounded,
-                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                },
-                                                            },
-                                                        },
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(2, Cluster(loc2v1)),
                                                             collection_kind: Stream {
                                                                 bound: Bounded,
                                                                 order: NoOrder,
                                                                 retry: ExactlyOnce,
-                                                                element_type: (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                             },
                                                         },
                                                     },
@@ -5191,19 +5079,19 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 29>: Map {
+                inner: <shared 31>: Map {
                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_134_27 ! ([max__free = 3usize ,] [move | (success , error) | (success + error) >= max__free]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
                                 input: Tee {
-                                    inner: <shared 30>: FoldKeyed {
+                                    inner: <shared 32>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_109_15 ! ([] [move | | (0 , 0)]) }),
                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_110_15 ! ([] [move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } }]) }),
                                         input: Cast {
                                             inner: Tee {
-                                                inner: <shared 24>,
+                                                inner: <shared 26>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(14, Cluster(loc1v1)),
                                                     collection_kind: Stream {
@@ -5311,12 +5199,12 @@ expression: built.ir()
         ),
         input: Difference {
             pos: Tee {
-                inner: <shared 31>: FilterMap {
+                inner: <shared 33>: FilterMap {
                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_122_27 ! ([min__free = 2usize ,] [move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None }]) }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <shared 30>,
+                                inner: <shared 32>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(14, Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
@@ -5368,7 +5256,7 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 29>,
+                inner: <shared 31>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(14, Cluster(loc1v1)),
                     collection_kind: Stream {
@@ -5397,7 +5285,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 32>: Chain {
+                inner: <shared 34>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -5427,7 +5315,7 @@ expression: built.ir()
                         inner: YieldConcat {
                             inner: Batch {
                                 inner: Tee {
-                                    inner: <shared 27>,
+                                    inner: <shared 29>,
                                     metadata: HydroIrMetadata {
                                         location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                         collection_kind: Stream {
@@ -5491,13 +5379,13 @@ expression: built.ir()
             neg: Map {
                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; hydro_std :: __stageleft_quote_src_request_response_rs_39_78 ! ([] [| (key , _) | key]) }),
                 input: Tee {
-                    inner: <shared 33>: Batch {
+                    inner: <shared 35>: Batch {
                         inner: Map {
-                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_751_23 ! ([] [| k | (k , ())]) }),
+                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_750_23 ! ([] [| k | (k , ())]) }),
                             input: YieldConcat {
                                 inner: Difference {
                                     pos: Tee {
-                                        inner: <shared 31>,
+                                        inner: <shared 33>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(14, Cluster(loc1v1)),
                                             collection_kind: Stream {
@@ -5605,6 +5493,34 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: Reference {
+            inner: <shared 36>: Tee {
+                inner: <shared 4>,
+                metadata: HydroIrMetadata {
+                    location_id: Tick(15, Cluster(loc1v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                    },
+                },
+            },
+            kind: Singleton,
+            access_counter: Counting(
+                Cell {
+                    value: 0,
+                },
+            ),
+            metadata: HydroIrMetadata {
+                location_id: Tick(15, Cluster(loc1v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             4,
@@ -5618,7 +5534,7 @@ expression: built.ir()
                                 first: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
                                     input: Tee {
-                                        inner: <shared 34>: Batch {
+                                        inner: <shared 37>: Batch {
                                             inner: CycleSource {
                                                 cycle_id: CycleId(
                                                     2,
@@ -5692,57 +5608,27 @@ expression: built.ir()
                             },
                         },
                         right: Fold {
-                            init: stageleft :: runtime_support :: fn0_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_863_11 ! ([] [| | HashMap :: new ()]) }),
-                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_865_12 ! ([] [| map , (slot , entry) | { map . insert (slot , entry) ; }]) }),
+                            init: stageleft :: runtime_support :: fn0_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_864_11 ! ([] [| | HashMap :: new ()]) }),
+                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_866_12 ! ([] [| map , (slot , entry) | { map . insert (slot , entry) ; }]) }),
                             input: Cast {
                                 inner: Cast {
                                     inner: Batch {
                                         inner: ReduceKeyedWatermark {
-                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_851_15 ! ([] [| prev_entry , entry | { if entry . ballot > prev_entry . ballot { * prev_entry = LogValue { ballot : entry . ballot , value : entry . value , } ; } }]) }),
+                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_852_15 ! ([] [| prev_entry , entry | { if entry . ballot > prev_entry . ballot { * prev_entry = LogValue { ballot : entry . ballot , value : entry . value , } ; } }]) }),
                                             input: ObserveNonDet {
                                                 inner: Cast {
                                                     inner: YieldConcat {
                                                         inner: FilterMap {
-                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_838_23 ! ([] [| (p2a , max_ballot) | if p2a . ballot >= max_ballot { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , })) } else { None }]) }),
-                                                            input: CrossSingleton {
-                                                                left: Tee {
-                                                                    inner: <shared 26>,
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                        collection_kind: Stream {
-                                                                            bound: Bounded,
-                                                                            order: NoOrder,
-                                                                            retry: ExactlyOnce,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                right: Cast {
-                                                                    inner: Tee {
-                                                                        inner: <shared 10>,
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Cluster(loc2v1)),
-                                                                            collection_kind: Singleton {
-                                                                                bound: Bounded,
-                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                        collection_kind: Optional {
-                                                                            bound: Bounded,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                        },
-                                                                    },
-                                                                },
+                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_838_27 ! ([a_max_ballot_ref__free = __hydro_singleton_ref_0 ,] [| p2a | if p2a . ballot >= * a_max_ballot_ref__free { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , } ,)) } else { None }]) }),
+                                                            input: Tee {
+                                                                inner: <shared 28>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(2, Cluster(loc2v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: NoOrder,
                                                                         retry: ExactlyOnce,
-                                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                     },
                                                                 },
                                                             },
@@ -5790,7 +5676,7 @@ expression: built.ir()
                                                 },
                                             },
                                             watermark: Tee {
-                                                inner: <shared 34>,
+                                                inner: <shared 37>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(2, Cluster(loc2v1)),
                                                     collection_kind: Optional {
@@ -5885,11 +5771,11 @@ expression: built.ir()
             3,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_765_21 ! ([] [| (_ , ballot) | ballot]) }),
+            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_764_21 ! ([] [| (_ , ballot) | ballot]) }),
             input: FilterMap {
                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_151_32 ! ([] [move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , }]) }),
                 input: Tee {
-                    inner: <shared 25>,
+                    inner: <shared 27>,
                     metadata: HydroIrMetadata {
                         location_id: Cluster(loc1v1),
                         collection_kind: Stream {
@@ -6006,7 +5892,7 @@ expression: built.ir()
                 f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_49_12 ! ([] [| (sorted_payload , highest_seq) | sorted_payload . seq > * highest_seq]) }),
                 input: CrossSingleton {
                     left: Tee {
-                        inner: <shared 35>: Sort {
+                        inner: <shared 38>: Sort {
                             input: Chain {
                                 first: Batch {
                                     inner: Map {
@@ -6152,13 +6038,13 @@ expression: built.ir()
                                                                     },
                                                                     right: Batch {
                                                                         inner: Map {
-                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_763_29 ! ([] [| ((slot , _ballot) , (value , _)) | (slot , value)]) }),
+                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_762_29 ! ([] [| ((slot , _ballot) , (value , _)) | (slot , value)]) }),
                                                                             input: YieldConcat {
                                                                                 inner: Map {
                                                                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; hydro_std :: __stageleft_quote_src_request_response_rs_37_20 ! ([] [| (key , (meta , resp)) | (key , (meta , resp))]) }),
                                                                                     input: JoinHalf {
                                                                                         left: Tee {
-                                                                                            inner: <shared 32>,
+                                                                                            inner: <shared 34>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
@@ -6170,7 +6056,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         right: Tee {
-                                                                                            inner: <shared 33>,
+                                                                                            inner: <shared 35>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
@@ -6381,12 +6267,12 @@ expression: built.ir()
                     },
                     right: Cast {
                         inner: Tee {
-                            inner: <shared 36>: Fold {
+                            inner: <shared 39>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_31_15 ! ([] [| | 0]) }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_32_15 ! ([] [| new_next_slot , (sorted_payload , next_slot) | { if sorted_payload . seq == std :: cmp :: max (* new_next_slot , next_slot) { * new_next_slot = sorted_payload . seq + 1 ; } }]) }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 35>,
+                                        inner: <shared 38>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(17, Cluster(loc5v1)),
                                             collection_kind: Stream {
@@ -6536,7 +6422,7 @@ expression: built.ir()
             17,
         ),
         input: Tee {
-            inner: <shared 37>: Map {
+            inner: <shared 40>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_78_40 ! ([] [| (_kv_store , next_slot) | next_slot]) }),
                 input: Batch {
                     inner: Fold {
@@ -6544,13 +6430,13 @@ expression: built.ir()
                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_69_15 ! ([] [| (kv_store , next_slot) , payload | { if let Some (kv) = payload . kv { kv_store . insert (kv . key , kv . value) ; } * next_slot = payload . seq + 1 ; }]) }),
                         input: YieldConcat {
                             inner: Tee {
-                                inner: <shared 38>: Map {
+                                inner: <shared 41>: Map {
                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_45_16 ! ([] [| (sorted_payload , _) | { sorted_payload }]) }),
                                     input: Filter {
                                         f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_43_12 ! ([] [| (sorted_payload , highest_seq) | sorted_payload . seq < * highest_seq]) }),
                                         input: CrossSingleton {
                                             left: Tee {
-                                                inner: <shared 35>,
+                                                inner: <shared 38>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(17, Cluster(loc5v1)),
                                                     collection_kind: Stream {
@@ -6563,7 +6449,7 @@ expression: built.ir()
                                             },
                                             right: Cast {
                                                 inner: Tee {
-                                                    inner: <shared 36>,
+                                                    inner: <shared 39>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(17, Cluster(loc5v1)),
                                                         collection_kind: Singleton {
@@ -6669,7 +6555,7 @@ expression: built.ir()
             18,
         ),
         input: Tee {
-            inner: <shared 39>: FilterMap {
+            inner: <shared 42>: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , usize) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_95_12 ! ([checkpoint_frequency__free = 1000usize ,] [move | (max_checkpointed_seq , next_slot) | if max_checkpointed_seq . map (| m | next_slot - m >= checkpoint_frequency__free) . unwrap_or (true) { Some (next_slot) } else { None }]) }),
                 input: Cast {
                     inner: CrossSingleton {
@@ -6788,7 +6674,7 @@ expression: built.ir()
                                 first: DeferTick {
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <shared 37>,
+                                            inner: <shared 40>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(17, Cluster(loc5v1)),
                                                 collection_kind: Singleton {
@@ -6899,7 +6785,7 @@ expression: built.ir()
                                 left: Cast {
                                     inner: Cast {
                                         inner: Tee {
-                                            inner: <shared 40>: Batch {
+                                            inner: <shared 43>: Batch {
                                                 inner: ReduceKeyed {
                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_bench_rs_73_24 ! ([] [| curr_seq , seq | { if seq > * curr_seq { * curr_seq = seq ; } }]) }),
                                                     input: Network {
@@ -7040,7 +6926,7 @@ expression: built.ir()
                                                                         inner: YieldConcat {
                                                                             inner: Cast {
                                                                                 inner: Tee {
-                                                                                    inner: <shared 39>,
+                                                                                    inner: <shared 42>,
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Tick(17, Cluster(loc5v1)),
                                                                                         collection_kind: Optional {
@@ -7181,7 +7067,7 @@ expression: built.ir()
                                                 inner: Cast {
                                                     inner: Cast {
                                                         inner: Tee {
-                                                            inner: <shared 40>,
+                                                            inner: <shared 43>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(19, Cluster(loc2v1)),
                                                                 collection_kind: KeyedSingleton {
@@ -7312,7 +7198,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 41>: Chain {
+                inner: <shared 44>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -7340,7 +7226,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <shared 42>: Map {
+                            inner: <shared 45>: Map {
                                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , i32) , core :: result :: Result < () , () >)) , ((u32 , i32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
                                 input: Cast {
                                     inner: Network {
@@ -7362,7 +7248,7 @@ expression: built.ir()
                                                     inner: FilterMap {
                                                         f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_108_23 ! ([] [| payload | payload . kv]) }),
                                                         input: Tee {
-                                                            inner: <shared 38>,
+                                                            inner: <shared 41>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(17, Cluster(loc5v1)),
                                                                 collection_kind: Stream {
@@ -7486,17 +7372,17 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 43>: FilterMap {
+                inner: <shared 46>: FilterMap {
                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , i32) , (usize , usize)) , core :: option :: Option < (u32 , i32) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_122_27 ! ([min__free = 2usize ,] [move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None }]) }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <shared 44>: FoldKeyed {
+                                inner: <shared 47>: FoldKeyed {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_109_15 ! ([] [move | | (0 , 0)]) }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_110_15 ! ([] [move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } }]) }),
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <shared 41>,
+                                            inner: <shared 44>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(20, Cluster(loc3v1)),
                                                 collection_kind: Stream {
@@ -7624,7 +7510,7 @@ expression: built.ir()
         input: FilterMap {
             f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , i32) , core :: result :: Result < () , () >) , core :: option :: Option < ((u32 , i32) , ()) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_151_32 ! ([] [move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , }]) }),
             input: Tee {
-                inner: <shared 42>,
+                inner: <shared 45>,
                 metadata: HydroIrMetadata {
                     location_id: Cluster(loc3v1),
                     collection_kind: Stream {
@@ -7652,10 +7538,10 @@ expression: built.ir()
             1,
         ),
         input: Tee {
-            inner: <shared 45>: Cast {
+            inner: <shared 48>: Cast {
                 inner: YieldConcat {
                     inner: Tee {
-                        inner: <shared 43>,
+                        inner: <shared 46>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(20, Cluster(loc3v1)),
                             collection_kind: Stream {
@@ -7710,11 +7596,11 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_183_20 ! ([] [| (new , old) | { old . borrow_mut () . add (new) . expect ("Error adding value to histogram") ; old }]) }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 46>: Fold {
+                            inner: <shared 49>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_153_15 ! ([] [move | | Histogram :: < u64 > :: new (3) . unwrap ()]) }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , core :: time :: Duration , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_154_15 ! ([] [move | latencies , latency | { latencies . record (latency . as_nanos () as u64) . unwrap () ; }]) }),
                                 input: Tee {
-                                    inner: <shared 47>: Batch {
+                                    inner: <shared 50>: Batch {
                                         inner: Map {
                                             f: stageleft :: runtime_support :: fnmut1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_bench_rs_118_12 ! ([] [| (_virtual_client_id , (_output , latency)) | latency]) }),
                                             input: Cast {
@@ -7803,7 +7689,7 @@ expression: built.ir()
                                                                                             input: ObserveNonDet {
                                                                                                 inner: Batch {
                                                                                                     inner: Tee {
-                                                                                                        inner: <shared 45>,
+                                                                                                        inner: <shared 48>,
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_id: Cluster(loc3v1),
                                                                                                             collection_kind: KeyedStream {
@@ -8006,11 +7892,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <shared 48>: Map {
+                            inner: <shared 51>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 49>: Cast {
+                                        inner: <shared 52>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -8088,7 +7974,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_935_20 ! ([] [| _ | ()]) }),
                                                             input: Tee {
-                                                                inner: <shared 50>: Reduce {
+                                                                inner: <shared 53>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1589_23 ! ([] [| _ , _ | { }]) }),
                                                                     input: FlatMap {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1955_27 ! ([] [| d | d]) }),
@@ -8268,7 +8154,7 @@ expression: built.ir()
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_187_56 ! ([] [| histogram | Rc :: new (RefCell :: new (histogram))]) }),
                         input: Tee {
-                            inner: <shared 46>,
+                            inner: <shared 49>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(22, Cluster(loc3v1)),
                                 collection_kind: Singleton {
@@ -8321,12 +8207,12 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_174_20 ! ([] [| (new , old) | new + old]) }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 51>: Fold {
+                            inner: <shared 54>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2427_15 ! ([] [| | 0usize]) }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , core :: time :: Duration , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2429_16 ! ([] [| count , _ | * count += 1]) }),
                                 input: ObserveNonDet {
                                     inner: Tee {
-                                        inner: <shared 47>,
+                                        inner: <shared 50>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(22, Cluster(loc3v1)),
                                             collection_kind: Stream {
@@ -8365,11 +8251,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <shared 52>: Map {
+                            inner: <shared 55>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 53>: Cast {
+                                        inner: <shared 56>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -8447,7 +8333,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_935_20 ! ([] [| _ | ()]) }),
                                                             input: Tee {
-                                                                inner: <shared 50>,
+                                                                inner: <shared 53>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                     collection_kind: Optional {
@@ -8566,7 +8452,7 @@ expression: built.ir()
                 },
                 second: Cast {
                     inner: Tee {
-                        inner: <shared 51>,
+                        inner: <shared 54>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(22, Cluster(loc3v1)),
                             collection_kind: Singleton {
@@ -8612,7 +8498,7 @@ expression: built.ir()
                     left: Cast {
                         inner: CrossSingleton {
                             left: Tee {
-                                inner: <shared 54>: Cast {
+                                inner: <shared 57>: Cast {
                                     inner: ChainFirst {
                                         first: DeferTick {
                                             input: CycleSource {
@@ -8713,7 +8599,7 @@ expression: built.ir()
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                                                                         input: CrossSingleton {
                                                                                             left: Tee {
-                                                                                                inner: <shared 49>,
+                                                                                                inner: <shared 52>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                                                     collection_kind: Singleton {
@@ -8733,7 +8619,7 @@ expression: built.ir()
                                                                                                                 input: Map {
                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                                                                                     input: Tee {
-                                                                                                                        inner: <shared 50>,
+                                                                                                                        inner: <shared 53>,
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Tick(22, Cluster(loc3v1)),
                                                                                                                             collection_kind: Optional {
@@ -9002,7 +8888,7 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
                                 input: DeferTick {
                                     input: Tee {
-                                        inner: <shared 55>: Reduce {
+                                        inner: <shared 58>: Reduce {
                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1589_23 ! ([] [| _ , _ | { }]) }),
                                             input: FlatMap {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1955_27 ! ([] [| d | d]) }),
@@ -9179,7 +9065,7 @@ expression: built.ir()
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                                 input: CrossSingleton {
                                                     left: Tee {
-                                                        inner: <shared 53>,
+                                                        inner: <shared 56>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(22, Cluster(loc3v1)),
                                                             collection_kind: Singleton {
@@ -9199,7 +9085,7 @@ expression: built.ir()
                                                                         input: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                                             input: Tee {
-                                                                                inner: <shared 50>,
+                                                                                inner: <shared 53>,
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                                     collection_kind: Optional {
@@ -9368,7 +9254,7 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <shared 56>: Cast {
+                                inner: <shared 59>: Cast {
                                     inner: ChainFirst {
                                         first: DeferTick {
                                             input: CycleSource {
@@ -9446,7 +9332,7 @@ expression: built.ir()
                                                 input: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_935_20 ! ([] [| _ | ()]) }),
                                                     input: Tee {
-                                                        inner: <shared 55>,
+                                                        inner: <shared 58>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(23, Process(loc4v1)),
                                                             collection_kind: Optional {
@@ -9577,7 +9463,7 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 56>,
+                            inner: <shared 59>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(23, Process(loc4v1)),
                                 collection_kind: Singleton {
@@ -9597,7 +9483,7 @@ expression: built.ir()
                                             input: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                 input: Tee {
-                                                    inner: <shared 55>,
+                                                    inner: <shared 58>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(23, Process(loc4v1)),
                                                         collection_kind: Optional {
@@ -9722,7 +9608,7 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <shared 54>,
+                                inner: <shared 57>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(23, Process(loc4v1)),
                                     collection_kind: Singleton {
@@ -9742,7 +9628,7 @@ expression: built.ir()
                                                 input: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                     input: Tee {
-                                                        inner: <shared 55>,
+                                                        inner: <shared 58>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(23, Process(loc4v1)),
                                                             collection_kind: Optional {

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -1112,13 +1112,813 @@ expression: built.ir()
         },
         op_metadata: HydroIrOpMetadata,
     },
+    Null {
+        input: Reference {
+            inner: <shared 7>: Tee {
+                inner: <shared 8>: Cast {
+                    inner: ChainFirst {
+                        first: Batch {
+                            inner: Reduce {
+                                f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
+                                input: ObserveNonDet {
+                                    inner: YieldConcat {
+                                        inner: Inspect {
+                                            f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_486_20 ! ([] [| p1a | println ! ("Acceptor received P1a: {:?}" , p1a)]) }),
+                                            input: Tee {
+                                                inner: <shared 9>: Batch {
+                                                    inner: Map {
+                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
+                                                        input: Cast {
+                                                            inner: Network {
+                                                                name: None,
+                                                                networking_info: Tcp {
+                                                                    fault: FailStop,
+                                                                },
+                                                                serialize_fn: Some(
+                                                                    hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                                ),
+                                                                instantiate_fn: <network instantiate>,
+                                                                deserialize_fn: Some(
+                                                                    | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: Ballot > (& b) . unwrap ()) },
+                                                                ),
+                                                                input: YieldConcat {
+                                                                    inner: Cast {
+                                                                        inner: CrossProduct {
+                                                                            left: ObserveNonDet {
+                                                                                inner: Map {
+                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
+                                                                                    input: Cast {
+                                                                                        inner: Cast {
+                                                                                            inner: Filter {
+                                                                                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_1187_61 ! ([] [| b | * b]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
+                                                                                                input: Batch {
+                                                                                                    inner: FoldKeyed {
+                                                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_36_11 ! ([] [| | false]) }),
+                                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_37_11 ! ([] [| present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } }]) }),
+                                                                                                        input: Cast {
+                                                                                                            inner: Map {
+                                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; hydro_lang :: __stageleft_quote_src_location_mod_rs_545_16 ! ([] [| (k , v) | (MemberId :: from_tagless (k) , v)]) }),
+                                                                                                                input: Source {
+                                                                                                                    source: ClusterMembers(
+                                                                                                                        Cluster(loc2v1),
+                                                                                                                        Uninit,
+                                                                                                                    ),
+                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                        location_id: Cluster(loc1v1),
+                                                                                                                        collection_kind: Stream {
+                                                                                                                            bound: Unbounded,
+                                                                                                                            order: TotalOrder,
+                                                                                                                            retry: ExactlyOnce,
+                                                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                    location_id: Cluster(loc1v1),
+                                                                                                                    collection_kind: Stream {
+                                                                                                                        bound: Unbounded,
+                                                                                                                        order: TotalOrder,
+                                                                                                                        retry: ExactlyOnce,
+                                                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                                                    },
+                                                                                                                },
+                                                                                                            },
+                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                location_id: Cluster(loc1v1),
+                                                                                                                collection_kind: KeyedStream {
+                                                                                                                    bound: Unbounded,
+                                                                                                                    value_order: TotalOrder,
+                                                                                                                    value_retry: ExactlyOnce,
+                                                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                                    value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
+                                                                                                                },
+                                                                                                            },
+                                                                                                        },
+                                                                                                        metadata: HydroIrMetadata {
+                                                                                                            location_id: Cluster(loc1v1),
+                                                                                                            collection_kind: KeyedSingleton {
+                                                                                                                bound: MonotonicKeys,
+                                                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                                value_type: bool,
+                                                                                                            },
+                                                                                                        },
+                                                                                                    },
+                                                                                                    metadata: HydroIrMetadata {
+                                                                                                        location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                        collection_kind: KeyedSingleton {
+                                                                                                            bound: Bounded,
+                                                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                            value_type: bool,
+                                                                                                        },
+                                                                                                    },
+                                                                                                },
+                                                                                                metadata: HydroIrMetadata {
+                                                                                                    location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                    collection_kind: KeyedSingleton {
+                                                                                                        bound: Bounded,
+                                                                                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                        value_type: bool,
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                            metadata: HydroIrMetadata {
+                                                                                                location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                collection_kind: KeyedStream {
+                                                                                                    bound: Bounded,
+                                                                                                    value_order: TotalOrder,
+                                                                                                    value_retry: ExactlyOnce,
+                                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                                    value_type: bool,
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_id: Tick(8, Cluster(loc1v1)),
+                                                                                            collection_kind: Stream {
+                                                                                                bound: Bounded,
+                                                                                                order: NoOrder,
+                                                                                                retry: ExactlyOnce,
+                                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                    metadata: HydroIrMetadata {
+                                                                                        location_id: Tick(8, Cluster(loc1v1)),
+                                                                                        collection_kind: Stream {
+                                                                                            bound: Bounded,
+                                                                                            order: NoOrder,
+                                                                                            retry: ExactlyOnce,
+                                                                                            element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                                trusted: true,
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_id: Tick(8, Cluster(loc1v1)),
+                                                                                    collection_kind: Stream {
+                                                                                        bound: Bounded,
+                                                                                        order: TotalOrder,
+                                                                                        retry: ExactlyOnce,
+                                                                                        element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                    },
+                                                                                },
+                                                                            },
+                                                                            right: Batch {
+                                                                                inner: Inspect {
+                                                                                    f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_317_20 ! ([] [| _ | println ! ("Proposer leader expired, sending P1a")]) }),
+                                                                                    input: YieldConcat {
+                                                                                        inner: Cast {
+                                                                                            inner: Map {
+                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
+                                                                                                input: CrossSingleton {
+                                                                                                    left: Tee {
+                                                                                                        inner: <shared 4>,
+                                                                                                        metadata: HydroIrMetadata {
+                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                            collection_kind: Singleton {
+                                                                                                                bound: Bounded,
+                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                            },
+                                                                                                        },
+                                                                                                    },
+                                                                                                    right: Filter {
+                                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_34 ! ([] [| b | * b]) }),
+                                                                                                        input: Map {
+                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_1144_31 ! ([] [| (a , b) | a && b]) }),
+                                                                                                            input: Cast {
+                                                                                                                inner: CrossSingleton {
+                                                                                                                    left: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_908_20 ! ([] [| o | o . is_some ()]) }),
+                                                                                                                        input: Cast {
+                                                                                                                            inner: ChainFirst {
+                                                                                                                                first: Map {
+                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
+                                                                                                                                    input: Map {
+                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
+                                                                                                                                        input: Map {
+                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (() , bool) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_1105_51 ! ([] [| (d , _) | d]) }),
+                                                                                                                                            input: CrossSingleton {
+                                                                                                                                                left: Batch {
+                                                                                                                                                    inner: YieldConcat {
+                                                                                                                                                        inner: FilterMap {
+                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2027_27 ! ([duration__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_438_15 ! ([i_am_leader_check_timeout__free = 10u64 ,] [Duration :: from_secs (i_am_leader_check_timeout__free)]) } ,] [move | latest_received | { if let Some (latest_received) = latest_received { if Instant :: now () . duration_since (latest_received) > duration__free { Some (()) } else { None } } else { Some (()) } }]) }),
+                                                                                                                                                            input: Batch {
+                                                                                                                                                                inner: Fold {
+                                                                                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2016_15 ! ([] [| | None]) }),
+                                                                                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2018_16 ! ([] [| latest , _ | { * latest = Some (Instant :: now ()) ; }]) }),
+                                                                                                                                                                    input: ObserveNonDet {
+                                                                                                                                                                        inner: Tee {
+                                                                                                                                                                            inner: <shared 3>,
+                                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                                location_id: Cluster(loc1v1),
+                                                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                                                    bound: Unbounded,
+                                                                                                                                                                                    order: NoOrder,
+                                                                                                                                                                                    retry: AtLeastOnce,
+                                                                                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                                                                                },
+                                                                                                                                                                            },
+                                                                                                                                                                        },
+                                                                                                                                                                        trusted: false,
+                                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                                            location_id: Cluster(loc1v1),
+                                                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                                                bound: Unbounded,
+                                                                                                                                                                                order: NoOrder,
+                                                                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                                                                            },
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                                        location_id: Cluster(loc1v1),
+                                                                                                                                                                        collection_kind: Singleton {
+                                                                                                                                                                            bound: Unbounded,
+                                                                                                                                                                            element_type: core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >,
+                                                                                                                                                                        },
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                                    location_id: Tick(7, Cluster(loc1v1)),
+                                                                                                                                                                    collection_kind: Singleton {
+                                                                                                                                                                        bound: Bounded,
+                                                                                                                                                                        element_type: core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >,
+                                                                                                                                                                    },
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                location_id: Tick(7, Cluster(loc1v1)),
+                                                                                                                                                                collection_kind: Optional {
+                                                                                                                                                                    bound: Bounded,
+                                                                                                                                                                    element_type: (),
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                            location_id: Cluster(loc1v1),
+                                                                                                                                                            collection_kind: Optional {
+                                                                                                                                                                bound: Unbounded,
+                                                                                                                                                                element_type: (),
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                        collection_kind: Optional {
+                                                                                                                                                            bound: Bounded,
+                                                                                                                                                            element_type: (),
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                                right: Filter {
+                                                                                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_1105_34 ! ([] [| b | * b]) }),
+                                                                                                                                                    input: Map {
+                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_1078_20 ! ([] [| b | ! b]) }),
+                                                                                                                                                        input: Tee {
+                                                                                                                                                            inner: <shared 6>,
+                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                collection_kind: Singleton {
+                                                                                                                                                                    bound: Bounded,
+                                                                                                                                                                    element_type: bool,
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            collection_kind: Singleton {
+                                                                                                                                                                bound: Bounded,
+                                                                                                                                                                element_type: bool,
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                        collection_kind: Optional {
+                                                                                                                                                            bound: Bounded,
+                                                                                                                                                            element_type: bool,
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    collection_kind: Optional {
+                                                                                                                                                        bound: Bounded,
+                                                                                                                                                        element_type: (() , bool),
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                collection_kind: Optional {
+                                                                                                                                                    bound: Bounded,
+                                                                                                                                                    element_type: (),
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            collection_kind: Optional {
+                                                                                                                                                bound: Bounded,
+                                                                                                                                                element_type: (),
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        collection_kind: Optional {
+                                                                                                                                            bound: Bounded,
+                                                                                                                                            element_type: core :: option :: Option < () >,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                second: Cast {
+                                                                                                                                    inner: SingletonSource {
+                                                                                                                                        value: :: std :: option :: Option :: None,
+                                                                                                                                        first_tick_only: false,
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            collection_kind: Singleton {
+                                                                                                                                                bound: Bounded,
+                                                                                                                                                element_type: core :: option :: Option < () >,
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        collection_kind: Optional {
+                                                                                                                                            bound: Bounded,
+                                                                                                                                            element_type: core :: option :: Option < () >,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                    collection_kind: Optional {
+                                                                                                                                        bound: Bounded,
+                                                                                                                                        element_type: core :: option :: Option < () >,
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                collection_kind: Singleton {
+                                                                                                                                    bound: Bounded,
+                                                                                                                                    element_type: core :: option :: Option < () >,
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                            collection_kind: Singleton {
+                                                                                                                                bound: Bounded,
+                                                                                                                                element_type: bool,
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    right: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_908_20 ! ([] [| o | o . is_some ()]) }),
+                                                                                                                        input: Cast {
+                                                                                                                            inner: ChainFirst {
+                                                                                                                                first: Map {
+                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
+                                                                                                                                    input: Map {
+                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
+                                                                                                                                        input: Reduce {
+                                                                                                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1589_23 ! ([] [| _ , _ | { }]) }),
+                                                                                                                                            input: FlatMap {
+                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1955_27 ! ([] [| d | d]) }),
+                                                                                                                                                input: Scan {
+                                                                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < core :: option :: Option < () > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1915_27 ! ([] [| | None]) }),
+                                                                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < core :: option :: Option < () > > , () , core :: option :: Option < core :: option :: Option < () > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1918_24 ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , hydro_test :: __staged :: __deps :: hydro_lang :: live_collections :: keyed_stream :: Generate < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1588_37 ! ([] [| _ , item | Generate :: Return (item)]) }) , init__free = stageleft :: runtime_support :: fn0_type_hint :: < () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1588_26 ! ([] [| | ()]) }) ,] [move | state : & mut Option < Option < _ > > , v | { if state . is_none () { * state = Some (Some (init__free ())) ; } match state { Some (Some (state_value)) => match f__free (state_value , v) { Generate :: Yield (out) => Some (Some (out)) , Generate :: Return (out) => { * state = Some (None) ; Some (Some (out)) } Generate :: Break => None , Generate :: Continue => Some (None) , } , _ => None , } }]) }),
+                                                                                                                                                    input: Batch {
+                                                                                                                                                        inner: Source {
+                                                                                                                                                            source: Stream(
+                                                                                                                                                                { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; hydro_lang :: __stageleft_quote_src_location_mod_rs_1439_30 ! ([delay__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_453_19 ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) , i_am_leader_check_timeout_delay_multiplier__free = 15usize ,] [Duration :: from_secs ((CLUSTER_SELF_ID__free . get_raw_id () * i_am_leader_check_timeout_delay_multiplier__free as u32) . into ())]) } , interval__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_458_19 ! ([i_am_leader_check_timeout__free = 10u64 ,] [Duration :: from_secs (i_am_leader_check_timeout__free)]) } ,] [tokio_stream :: StreamExt :: map (tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval_at (tokio :: time :: Instant :: now () + delay__free , interval__free ,)) , | _ | ())]) },
+                                                                                                                                                            ),
+                                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                                location_id: Cluster(loc1v1),
+                                                                                                                                                                collection_kind: Stream {
+                                                                                                                                                                    bound: Unbounded,
+                                                                                                                                                                    order: TotalOrder,
+                                                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                                                    element_type: (),
+                                                                                                                                                                },
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            collection_kind: Stream {
+                                                                                                                                                                bound: Bounded,
+                                                                                                                                                                order: TotalOrder,
+                                                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                                                element_type: (),
+                                                                                                                                                            },
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                        collection_kind: Stream {
+                                                                                                                                                            bound: Bounded,
+                                                                                                                                                            order: TotalOrder,
+                                                                                                                                                            retry: ExactlyOnce,
+                                                                                                                                                            element_type: core :: option :: Option < () >,
+                                                                                                                                                        },
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    collection_kind: Stream {
+                                                                                                                                                        bound: Bounded,
+                                                                                                                                                        order: TotalOrder,
+                                                                                                                                                        retry: ExactlyOnce,
+                                                                                                                                                        element_type: (),
+                                                                                                                                                    },
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                collection_kind: Optional {
+                                                                                                                                                    bound: Bounded,
+                                                                                                                                                    element_type: (),
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            collection_kind: Optional {
+                                                                                                                                                bound: Bounded,
+                                                                                                                                                element_type: (),
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        collection_kind: Optional {
+                                                                                                                                            bound: Bounded,
+                                                                                                                                            element_type: core :: option :: Option < () >,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                second: Cast {
+                                                                                                                                    inner: SingletonSource {
+                                                                                                                                        value: :: std :: option :: Option :: None,
+                                                                                                                                        first_tick_only: false,
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            collection_kind: Singleton {
+                                                                                                                                                bound: Bounded,
+                                                                                                                                                element_type: core :: option :: Option < () >,
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        collection_kind: Optional {
+                                                                                                                                            bound: Bounded,
+                                                                                                                                            element_type: core :: option :: Option < () >,
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                    collection_kind: Optional {
+                                                                                                                                        bound: Bounded,
+                                                                                                                                        element_type: core :: option :: Option < () >,
+                                                                                                                                    },
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                collection_kind: Singleton {
+                                                                                                                                    bound: Bounded,
+                                                                                                                                    element_type: core :: option :: Option < () >,
+                                                                                                                                },
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                            collection_kind: Singleton {
+                                                                                                                                bound: Bounded,
+                                                                                                                                element_type: bool,
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                        collection_kind: Optional {
+                                                                                                                            bound: Bounded,
+                                                                                                                            element_type: (bool , bool),
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                metadata: HydroIrMetadata {
+                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                    collection_kind: Singleton {
+                                                                                                                        bound: Bounded,
+                                                                                                                        element_type: (bool , bool),
+                                                                                                                    },
+                                                                                                                },
+                                                                                                            },
+                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                collection_kind: Singleton {
+                                                                                                                    bound: Bounded,
+                                                                                                                    element_type: bool,
+                                                                                                                },
+                                                                                                            },
+                                                                                                        },
+                                                                                                        metadata: HydroIrMetadata {
+                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                            collection_kind: Optional {
+                                                                                                                bound: Bounded,
+                                                                                                                element_type: bool,
+                                                                                                            },
+                                                                                                        },
+                                                                                                    },
+                                                                                                    metadata: HydroIrMetadata {
+                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                        collection_kind: Optional {
+                                                                                                            bound: Bounded,
+                                                                                                            element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool),
+                                                                                                        },
+                                                                                                    },
+                                                                                                },
+                                                                                                metadata: HydroIrMetadata {
+                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                    collection_kind: Optional {
+                                                                                                        bound: Bounded,
+                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                            metadata: HydroIrMetadata {
+                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                collection_kind: Stream {
+                                                                                                    bound: Bounded,
+                                                                                                    order: TotalOrder,
+                                                                                                    retry: ExactlyOnce,
+                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                },
+                                                                                            },
+                                                                                        },
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_id: Cluster(loc1v1),
+                                                                                            collection_kind: Stream {
+                                                                                                bound: Unbounded,
+                                                                                                order: TotalOrder,
+                                                                                                retry: ExactlyOnce,
+                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                    metadata: HydroIrMetadata {
+                                                                                        location_id: Cluster(loc1v1),
+                                                                                        collection_kind: Stream {
+                                                                                            bound: Unbounded,
+                                                                                            order: TotalOrder,
+                                                                                            retry: ExactlyOnce,
+                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                                metadata: HydroIrMetadata {
+                                                                                    location_id: Tick(8, Cluster(loc1v1)),
+                                                                                    collection_kind: Stream {
+                                                                                        bound: Bounded,
+                                                                                        order: TotalOrder,
+                                                                                        retry: ExactlyOnce,
+                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                    },
+                                                                                },
+                                                                            },
+                                                                            metadata: HydroIrMetadata {
+                                                                                location_id: Tick(8, Cluster(loc1v1)),
+                                                                                collection_kind: Stream {
+                                                                                    bound: Bounded,
+                                                                                    order: TotalOrder,
+                                                                                    retry: ExactlyOnce,
+                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                        metadata: HydroIrMetadata {
+                                                                            location_id: Tick(8, Cluster(loc1v1)),
+                                                                            collection_kind: KeyedStream {
+                                                                                bound: Bounded,
+                                                                                value_order: TotalOrder,
+                                                                                value_retry: ExactlyOnce,
+                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                                value_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                    metadata: HydroIrMetadata {
+                                                                        location_id: Cluster(loc1v1),
+                                                                        collection_kind: KeyedStream {
+                                                                            bound: Unbounded,
+                                                                            value_order: TotalOrder,
+                                                                            value_retry: ExactlyOnce,
+                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
+                                                                            value_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                        },
+                                                                    },
+                                                                },
+                                                                metadata: HydroIrMetadata {
+                                                                    location_id: Cluster(loc2v1),
+                                                                    collection_kind: KeyedStream {
+                                                                        bound: Unbounded,
+                                                                        value_order: TotalOrder,
+                                                                        value_retry: ExactlyOnce,
+                                                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
+                                                                        value_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                    },
+                                                                },
+                                                            },
+                                                            metadata: HydroIrMetadata {
+                                                                location_id: Cluster(loc2v1),
+                                                                collection_kind: Stream {
+                                                                    bound: Unbounded,
+                                                                    order: NoOrder,
+                                                                    retry: ExactlyOnce,
+                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                },
+                                                            },
+                                                        },
+                                                        metadata: HydroIrMetadata {
+                                                            location_id: Cluster(loc2v1),
+                                                            collection_kind: Stream {
+                                                                bound: Unbounded,
+                                                                order: NoOrder,
+                                                                retry: ExactlyOnce,
+                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                            },
+                                                        },
+                                                    },
+                                                    metadata: HydroIrMetadata {
+                                                        location_id: Tick(2, Cluster(loc2v1)),
+                                                        collection_kind: Stream {
+                                                            bound: Bounded,
+                                                            order: NoOrder,
+                                                            retry: ExactlyOnce,
+                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                        },
+                                                    },
+                                                },
+                                                metadata: HydroIrMetadata {
+                                                    location_id: Tick(2, Cluster(loc2v1)),
+                                                    collection_kind: Stream {
+                                                        bound: Bounded,
+                                                        order: NoOrder,
+                                                        retry: ExactlyOnce,
+                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                    },
+                                                },
+                                            },
+                                            metadata: HydroIrMetadata {
+                                                location_id: Tick(2, Cluster(loc2v1)),
+                                                collection_kind: Stream {
+                                                    bound: Bounded,
+                                                    order: NoOrder,
+                                                    retry: ExactlyOnce,
+                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                },
+                                            },
+                                        },
+                                        metadata: HydroIrMetadata {
+                                            location_id: Atomic(Tick(2, Cluster(loc2v1))),
+                                            collection_kind: Stream {
+                                                bound: Unbounded,
+                                                order: NoOrder,
+                                                retry: ExactlyOnce,
+                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                            },
+                                        },
+                                    },
+                                    trusted: false,
+                                    metadata: HydroIrMetadata {
+                                        location_id: Atomic(Tick(2, Cluster(loc2v1))),
+                                        collection_kind: Stream {
+                                            bound: Unbounded,
+                                            order: TotalOrder,
+                                            retry: ExactlyOnce,
+                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                        },
+                                    },
+                                },
+                                metadata: HydroIrMetadata {
+                                    location_id: Atomic(Tick(2, Cluster(loc2v1))),
+                                    collection_kind: Optional {
+                                        bound: Unbounded,
+                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_id: Tick(2, Cluster(loc2v1)),
+                                collection_kind: Optional {
+                                    bound: Bounded,
+                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                },
+                            },
+                        },
+                        second: Cast {
+                            inner: SingletonSource {
+                                value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_488_46 ! ([] [Ballot { num : 0 , proposer_id : MemberId :: from_raw_id (0) }]) },
+                                first_tick_only: false,
+                                metadata: HydroIrMetadata {
+                                    location_id: Tick(2, Cluster(loc2v1)),
+                                    collection_kind: Singleton {
+                                        bound: Bounded,
+                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                    },
+                                },
+                            },
+                            metadata: HydroIrMetadata {
+                                location_id: Tick(2, Cluster(loc2v1)),
+                                collection_kind: Optional {
+                                    bound: Bounded,
+                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                },
+                            },
+                        },
+                        metadata: HydroIrMetadata {
+                            location_id: Tick(2, Cluster(loc2v1)),
+                            collection_kind: Optional {
+                                bound: Bounded,
+                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                            },
+                        },
+                    },
+                    metadata: HydroIrMetadata {
+                        location_id: Tick(2, Cluster(loc2v1)),
+                        collection_kind: Singleton {
+                            bound: Bounded,
+                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                        },
+                    },
+                },
+                metadata: HydroIrMetadata {
+                    location_id: Tick(2, Cluster(loc2v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                    },
+                },
+            },
+            kind: Singleton,
+            access_counter: Counting(
+                Cell {
+                    value: 0,
+                },
+            ),
+            metadata: HydroIrMetadata {
+                location_id: Tick(2, Cluster(loc2v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
+    Null {
+        input: Reference {
+            inner: <shared 10>: CycleSource {
+                cycle_id: CycleId(
+                    4,
+                ),
+                metadata: HydroIrMetadata {
+                    location_id: Tick(2, Cluster(loc2v1)),
+                    collection_kind: Singleton {
+                        bound: Bounded,
+                        element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                    },
+                },
+            },
+            kind: Singleton,
+            access_counter: Counting(
+                Cell {
+                    value: 0,
+                },
+            ),
+            metadata: HydroIrMetadata {
+                location_id: Tick(2, Cluster(loc2v1)),
+                collection_kind: Singleton {
+                    bound: Bounded,
+                    element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                },
+            },
+        },
+        op_metadata: HydroIrOpMetadata,
+    },
     CycleSink {
         cycle_id: CycleId(
             9,
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 7>: Chain {
+                inner: <shared 11>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -1146,7 +1946,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <shared 8>: Inspect {
+                            inner: <shared 12>: Inspect {
                                 f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_338_38 ! ([] [| p1b | println ! ("Proposer received P1b: {:?}" , p1b)]) }),
                                 input: Map {
                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
@@ -1166,820 +1966,16 @@ expression: built.ir()
                                             input: Cast {
                                                 inner: YieldConcat {
                                                     inner: Map {
-                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_498_20 ! ([] [| ((ballot , max_ballot) , log) | (ballot . proposer_id . clone () , (ballot . clone () , if ballot == max_ballot { Ok (log) } else { Err (max_ballot) }))]) }),
-                                                        input: CrossSingleton {
-                                                            left: CrossSingleton {
-                                                                left: Tee {
-                                                                    inner: <shared 9>: Batch {
-                                                                        inner: Map {
-                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
-                                                                            input: Cast {
-                                                                                inner: Network {
-                                                                                    name: None,
-                                                                                    networking_info: Tcp {
-                                                                                        fault: FailStop,
-                                                                                    },
-                                                                                    serialize_fn: Some(
-                                                                                        hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                                                    ),
-                                                                                    instantiate_fn: <network instantiate>,
-                                                                                    deserialize_fn: Some(
-                                                                                        | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: Ballot > (& b) . unwrap ()) },
-                                                                                    ),
-                                                                                    input: YieldConcat {
-                                                                                        inner: Cast {
-                                                                                            inner: CrossProduct {
-                                                                                                left: ObserveNonDet {
-                                                                                                    inner: Map {
-                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
-                                                                                                        input: Cast {
-                                                                                                            inner: Cast {
-                                                                                                                inner: Filter {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_1187_61 ! ([] [| b | * b]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
-                                                                                                                    input: Batch {
-                                                                                                                        inner: FoldKeyed {
-                                                                                                                            init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_36_11 ! ([] [| | false]) }),
-                                                                                                                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_37_11 ! ([] [| present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } }]) }),
-                                                                                                                            input: Cast {
-                                                                                                                                inner: Map {
-                                                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; hydro_lang :: __stageleft_quote_src_location_mod_rs_545_16 ! ([] [| (k , v) | (MemberId :: from_tagless (k) , v)]) }),
-                                                                                                                                    input: Source {
-                                                                                                                                        source: ClusterMembers(
-                                                                                                                                            Cluster(loc2v1),
-                                                                                                                                            Uninit,
-                                                                                                                                        ),
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Cluster(loc1v1),
-                                                                                                                                            collection_kind: Stream {
-                                                                                                                                                bound: Unbounded,
-                                                                                                                                                order: TotalOrder,
-                                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Cluster(loc1v1),
-                                                                                                                                        collection_kind: Stream {
-                                                                                                                                            bound: Unbounded,
-                                                                                                                                            order: TotalOrder,
-                                                                                                                                            retry: ExactlyOnce,
-                                                                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                },
-                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Cluster(loc1v1),
-                                                                                                                                    collection_kind: KeyedStream {
-                                                                                                                                        bound: Unbounded,
-                                                                                                                                        value_order: TotalOrder,
-                                                                                                                                        value_retry: ExactlyOnce,
-                                                                                                                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                                        value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
-                                                                                                                                    },
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_id: Cluster(loc1v1),
-                                                                                                                                collection_kind: KeyedSingleton {
-                                                                                                                                    bound: MonotonicKeys,
-                                                                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                                    value_type: bool,
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                                            collection_kind: KeyedSingleton {
-                                                                                                                                bound: Bounded,
-                                                                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                                value_type: bool,
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                                        collection_kind: KeyedSingleton {
-                                                                                                                            bound: Bounded,
-                                                                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                            value_type: bool,
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                                    collection_kind: KeyedStream {
-                                                                                                                        bound: Bounded,
-                                                                                                                        value_order: TotalOrder,
-                                                                                                                        value_retry: ExactlyOnce,
-                                                                                                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                                        value_type: bool,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                            },
-                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                                collection_kind: Stream {
-                                                                                                                    bound: Bounded,
-                                                                                                                    order: NoOrder,
-                                                                                                                    retry: ExactlyOnce,
-                                                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , bool),
-                                                                                                                },
-                                                                                                            },
-                                                                                                        },
-                                                                                                        metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                            collection_kind: Stream {
-                                                                                                                bound: Bounded,
-                                                                                                                order: NoOrder,
-                                                                                                                retry: ExactlyOnce,
-                                                                                                                element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                            },
-                                                                                                        },
-                                                                                                    },
-                                                                                                    trusted: true,
-                                                                                                    metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                        collection_kind: Stream {
-                                                                                                            bound: Bounded,
-                                                                                                            order: TotalOrder,
-                                                                                                            retry: ExactlyOnce,
-                                                                                                            element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                        },
-                                                                                                    },
-                                                                                                },
-                                                                                                right: Batch {
-                                                                                                    inner: Inspect {
-                                                                                                        f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_317_20 ! ([] [| _ | println ! ("Proposer leader expired, sending P1a")]) }),
-                                                                                                        input: YieldConcat {
-                                                                                                            inner: Cast {
-                                                                                                                inner: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
-                                                                                                                    input: CrossSingleton {
-                                                                                                                        left: Tee {
-                                                                                                                            inner: <shared 4>,
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                collection_kind: Singleton {
-                                                                                                                                    bound: Bounded,
-                                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                        right: Filter {
-                                                                                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_34 ! ([] [| b | * b]) }),
-                                                                                                                            input: Map {
-                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_1144_31 ! ([] [| (a , b) | a && b]) }),
-                                                                                                                                input: Cast {
-                                                                                                                                    inner: CrossSingleton {
-                                                                                                                                        left: Map {
-                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_908_20 ! ([] [| o | o . is_some ()]) }),
-                                                                                                                                            input: Cast {
-                                                                                                                                                inner: ChainFirst {
-                                                                                                                                                    first: Map {
-                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
-                                                                                                                                                        input: Map {
-                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
-                                                                                                                                                            input: Map {
-                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < (() , bool) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_1105_51 ! ([] [| (d , _) | d]) }),
-                                                                                                                                                                input: CrossSingleton {
-                                                                                                                                                                    left: Batch {
-                                                                                                                                                                        inner: YieldConcat {
-                                                                                                                                                                            inner: FilterMap {
-                                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2027_27 ! ([duration__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_438_15 ! ([i_am_leader_check_timeout__free = 10u64 ,] [Duration :: from_secs (i_am_leader_check_timeout__free)]) } ,] [move | latest_received | { if let Some (latest_received) = latest_received { if Instant :: now () . duration_since (latest_received) > duration__free { Some (()) } else { None } } else { Some (()) } }]) }),
-                                                                                                                                                                                input: Batch {
-                                                                                                                                                                                    inner: Fold {
-                                                                                                                                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2016_15 ! ([] [| | None]) }),
-                                                                                                                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant > , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2018_16 ! ([] [| latest , _ | { * latest = Some (Instant :: now ()) ; }]) }),
-                                                                                                                                                                                        input: ObserveNonDet {
-                                                                                                                                                                                            inner: Tee {
-                                                                                                                                                                                                inner: <shared 3>,
-                                                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                                                    location_id: Cluster(loc1v1),
-                                                                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                                                                        bound: Unbounded,
-                                                                                                                                                                                                        order: NoOrder,
-                                                                                                                                                                                                        retry: AtLeastOnce,
-                                                                                                                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                                                                    },
-                                                                                                                                                                                                },
-                                                                                                                                                                                            },
-                                                                                                                                                                                            trusted: false,
-                                                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                                                location_id: Cluster(loc1v1),
-                                                                                                                                                                                                collection_kind: Stream {
-                                                                                                                                                                                                    bound: Unbounded,
-                                                                                                                                                                                                    order: NoOrder,
-                                                                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                                                                                },
-                                                                                                                                                                                            },
-                                                                                                                                                                                        },
-                                                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                                                            location_id: Cluster(loc1v1),
-                                                                                                                                                                                            collection_kind: Singleton {
-                                                                                                                                                                                                bound: Unbounded,
-                                                                                                                                                                                                element_type: core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >,
-                                                                                                                                                                                            },
-                                                                                                                                                                                        },
-                                                                                                                                                                                    },
-                                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                                        location_id: Tick(7, Cluster(loc1v1)),
-                                                                                                                                                                                        collection_kind: Singleton {
-                                                                                                                                                                                            bound: Bounded,
-                                                                                                                                                                                            element_type: core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >,
-                                                                                                                                                                                        },
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                                    location_id: Tick(7, Cluster(loc1v1)),
-                                                                                                                                                                                    collection_kind: Optional {
-                                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                                        element_type: (),
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                                location_id: Cluster(loc1v1),
-                                                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                                                    bound: Unbounded,
-                                                                                                                                                                                    element_type: (),
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                                element_type: (),
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                    right: Filter {
-                                                                                                                                                                        f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_1105_34 ! ([] [| b | * b]) }),
-                                                                                                                                                                        input: Map {
-                                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_1078_20 ! ([] [| b | ! b]) }),
-                                                                                                                                                                            input: Tee {
-                                                                                                                                                                                inner: <shared 6>,
-                                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                                    collection_kind: Singleton {
-                                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                                        element_type: bool,
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                                    element_type: bool,
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                                element_type: bool,
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                        collection_kind: Optional {
-                                                                                                                                                                            bound: Bounded,
-                                                                                                                                                                            element_type: (() , bool),
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                    collection_kind: Optional {
-                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                        element_type: (),
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: (),
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: core :: option :: Option < () >,
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    second: Cast {
-                                                                                                                                                        inner: SingletonSource {
-                                                                                                                                                            value: :: std :: option :: Option :: None,
-                                                                                                                                                            first_tick_only: false,
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: core :: option :: Option < () >,
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: core :: option :: Option < () >,
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: Optional {
-                                                                                                                                                            bound: Bounded,
-                                                                                                                                                            element_type: core :: option :: Option < () >,
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Singleton {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        element_type: core :: option :: Option < () >,
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    element_type: bool,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        right: Map {
-                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_908_20 ! ([] [| o | o . is_some ()]) }),
-                                                                                                                                            input: Cast {
-                                                                                                                                                inner: ChainFirst {
-                                                                                                                                                    first: Map {
-                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
-                                                                                                                                                        input: Map {
-                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
-                                                                                                                                                            input: Reduce {
-                                                                                                                                                                f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1589_23 ! ([] [| _ , _ | { }]) }),
-                                                                                                                                                                input: FlatMap {
-                                                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1955_27 ! ([] [| d | d]) }),
-                                                                                                                                                                    input: Scan {
-                                                                                                                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < core :: option :: Option < () > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1915_27 ! ([] [| | None]) }),
-                                                                                                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < core :: option :: Option < () > > , () , core :: option :: Option < core :: option :: Option < () > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1918_24 ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , hydro_test :: __staged :: __deps :: hydro_lang :: live_collections :: keyed_stream :: Generate < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1588_37 ! ([] [| _ , item | Generate :: Return (item)]) }) , init__free = stageleft :: runtime_support :: fn0_type_hint :: < () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1588_26 ! ([] [| | ()]) }) ,] [move | state : & mut Option < Option < _ > > , v | { if state . is_none () { * state = Some (Some (init__free ())) ; } match state { Some (Some (state_value)) => match f__free (state_value , v) { Generate :: Yield (out) => Some (Some (out)) , Generate :: Return (out) => { * state = Some (None) ; Some (Some (out)) } Generate :: Break => None , Generate :: Continue => Some (None) , } , _ => None , } }]) }),
-                                                                                                                                                                        input: Batch {
-                                                                                                                                                                            inner: Source {
-                                                                                                                                                                                source: Stream(
-                                                                                                                                                                                    { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; hydro_lang :: __stageleft_quote_src_location_mod_rs_1439_30 ! ([delay__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_453_19 ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) , i_am_leader_check_timeout_delay_multiplier__free = 15usize ,] [Duration :: from_secs ((CLUSTER_SELF_ID__free . get_raw_id () * i_am_leader_check_timeout_delay_multiplier__free as u32) . into ())]) } , interval__free = { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_458_19 ! ([i_am_leader_check_timeout__free = 10u64 ,] [Duration :: from_secs (i_am_leader_check_timeout__free)]) } ,] [tokio_stream :: StreamExt :: map (tokio_stream :: wrappers :: IntervalStream :: new (tokio :: time :: interval_at (tokio :: time :: Instant :: now () + delay__free , interval__free ,)) , | _ | ())]) },
-                                                                                                                                                                                ),
-                                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                                    location_id: Cluster(loc1v1),
-                                                                                                                                                                                    collection_kind: Stream {
-                                                                                                                                                                                        bound: Unbounded,
-                                                                                                                                                                                        order: TotalOrder,
-                                                                                                                                                                                        retry: ExactlyOnce,
-                                                                                                                                                                                        element_type: (),
-                                                                                                                                                                                    },
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                                collection_kind: Stream {
-                                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                                    order: TotalOrder,
-                                                                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                                                                    element_type: (),
-                                                                                                                                                                                },
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                            collection_kind: Stream {
-                                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                                order: TotalOrder,
-                                                                                                                                                                                retry: ExactlyOnce,
-                                                                                                                                                                                element_type: core :: option :: Option < () >,
-                                                                                                                                                                            },
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                        collection_kind: Stream {
-                                                                                                                                                                            bound: Bounded,
-                                                                                                                                                                            order: TotalOrder,
-                                                                                                                                                                            retry: ExactlyOnce,
-                                                                                                                                                                            element_type: (),
-                                                                                                                                                                        },
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                    collection_kind: Optional {
-                                                                                                                                                                        bound: Bounded,
-                                                                                                                                                                        element_type: (),
-                                                                                                                                                                    },
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Optional {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: (),
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: core :: option :: Option < () >,
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    second: Cast {
-                                                                                                                                                        inner: SingletonSource {
-                                                                                                                                                            value: :: std :: option :: Option :: None,
-                                                                                                                                                            first_tick_only: false,
-                                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                                    bound: Bounded,
-                                                                                                                                                                    element_type: core :: option :: Option < () >,
-                                                                                                                                                                },
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                                bound: Bounded,
-                                                                                                                                                                element_type: core :: option :: Option < () >,
-                                                                                                                                                            },
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: Optional {
-                                                                                                                                                            bound: Bounded,
-                                                                                                                                                            element_type: core :: option :: Option < () >,
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Singleton {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        element_type: core :: option :: Option < () >,
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Singleton {
-                                                                                                                                                    bound: Bounded,
-                                                                                                                                                    element_type: bool,
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                            collection_kind: Optional {
-                                                                                                                                                bound: Bounded,
-                                                                                                                                                element_type: (bool , bool),
-                                                                                                                                            },
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                        collection_kind: Singleton {
-                                                                                                                                            bound: Bounded,
-                                                                                                                                            element_type: (bool , bool),
-                                                                                                                                        },
-                                                                                                                                    },
-                                                                                                                                },
-                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                    collection_kind: Singleton {
-                                                                                                                                        bound: Bounded,
-                                                                                                                                        element_type: bool,
-                                                                                                                                    },
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                collection_kind: Optional {
-                                                                                                                                    bound: Bounded,
-                                                                                                                                    element_type: bool,
-                                                                                                                                },
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                        metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                            collection_kind: Optional {
-                                                                                                                                bound: Bounded,
-                                                                                                                                element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool),
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                        collection_kind: Optional {
-                                                                                                                            bound: Bounded,
-                                                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                    collection_kind: Stream {
-                                                                                                                        bound: Bounded,
-                                                                                                                        order: TotalOrder,
-                                                                                                                        retry: ExactlyOnce,
-                                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                            },
-                                                                                                            metadata: HydroIrMetadata {
-                                                                                                                location_id: Cluster(loc1v1),
-                                                                                                                collection_kind: Stream {
-                                                                                                                    bound: Unbounded,
-                                                                                                                    order: TotalOrder,
-                                                                                                                    retry: ExactlyOnce,
-                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                },
-                                                                                                            },
-                                                                                                        },
-                                                                                                        metadata: HydroIrMetadata {
-                                                                                                            location_id: Cluster(loc1v1),
-                                                                                                            collection_kind: Stream {
-                                                                                                                bound: Unbounded,
-                                                                                                                order: TotalOrder,
-                                                                                                                retry: ExactlyOnce,
-                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                            },
-                                                                                                        },
-                                                                                                    },
-                                                                                                    metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                        collection_kind: Stream {
-                                                                                                            bound: Bounded,
-                                                                                                            order: TotalOrder,
-                                                                                                            retry: ExactlyOnce,
-                                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                        },
-                                                                                                    },
-                                                                                                },
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                    collection_kind: Stream {
-                                                                                                        bound: Bounded,
-                                                                                                        order: TotalOrder,
-                                                                                                        retry: ExactlyOnce,
-                                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
-                                                                                                    },
-                                                                                                },
-                                                                                            },
-                                                                                            metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(8, Cluster(loc1v1)),
-                                                                                                collection_kind: KeyedStream {
-                                                                                                    bound: Bounded,
-                                                                                                    value_order: TotalOrder,
-                                                                                                    value_retry: ExactlyOnce,
-                                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                    value_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                },
-                                                                                            },
-                                                                                        },
-                                                                                        metadata: HydroIrMetadata {
-                                                                                            location_id: Cluster(loc1v1),
-                                                                                            collection_kind: KeyedStream {
-                                                                                                bound: Unbounded,
-                                                                                                value_order: TotalOrder,
-                                                                                                value_retry: ExactlyOnce,
-                                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                                                                value_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                            },
-                                                                                        },
-                                                                                    },
-                                                                                    metadata: HydroIrMetadata {
-                                                                                        location_id: Cluster(loc2v1),
-                                                                                        collection_kind: KeyedStream {
-                                                                                            bound: Unbounded,
-                                                                                            value_order: TotalOrder,
-                                                                                            value_retry: ExactlyOnce,
-                                                                                            key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                                            value_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                        },
-                                                                                    },
-                                                                                },
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_id: Cluster(loc2v1),
-                                                                                    collection_kind: Stream {
-                                                                                        bound: Unbounded,
-                                                                                        order: NoOrder,
-                                                                                        retry: ExactlyOnce,
-                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
-                                                                                    },
-                                                                                },
-                                                                            },
-                                                                            metadata: HydroIrMetadata {
-                                                                                location_id: Cluster(loc2v1),
-                                                                                collection_kind: Stream {
-                                                                                    bound: Unbounded,
-                                                                                    order: NoOrder,
-                                                                                    retry: ExactlyOnce,
-                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                },
-                                                                            },
-                                                                        },
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Cluster(loc2v1)),
-                                                                            collection_kind: Stream {
-                                                                                bound: Bounded,
-                                                                                order: NoOrder,
-                                                                                retry: ExactlyOnce,
-                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                        collection_kind: Stream {
-                                                                            bound: Bounded,
-                                                                            order: NoOrder,
-                                                                            retry: ExactlyOnce,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                right: Cast {
-                                                                    inner: Tee {
-                                                                        inner: <shared 10>: Cast {
-                                                                            inner: ChainFirst {
-                                                                                first: Batch {
-                                                                                    inner: Reduce {
-                                                                                        f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
-                                                                                        input: ObserveNonDet {
-                                                                                            inner: YieldConcat {
-                                                                                                inner: Inspect {
-                                                                                                    f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_486_20 ! ([] [| p1a | println ! ("Acceptor received P1a: {:?}" , p1a)]) }),
-                                                                                                    input: Tee {
-                                                                                                        inner: <shared 9>,
-                                                                                                        metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(2, Cluster(loc2v1)),
-                                                                                                            collection_kind: Stream {
-                                                                                                                bound: Bounded,
-                                                                                                                order: NoOrder,
-                                                                                                                retry: ExactlyOnce,
-                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                            },
-                                                                                                        },
-                                                                                                    },
-                                                                                                    metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                                                        collection_kind: Stream {
-                                                                                                            bound: Bounded,
-                                                                                                            order: NoOrder,
-                                                                                                            retry: ExactlyOnce,
-                                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                        },
-                                                                                                    },
-                                                                                                },
-                                                                                                metadata: HydroIrMetadata {
-                                                                                                    location_id: Atomic(Tick(2, Cluster(loc2v1))),
-                                                                                                    collection_kind: Stream {
-                                                                                                        bound: Unbounded,
-                                                                                                        order: NoOrder,
-                                                                                                        retry: ExactlyOnce,
-                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                    },
-                                                                                                },
-                                                                                            },
-                                                                                            trusted: false,
-                                                                                            metadata: HydroIrMetadata {
-                                                                                                location_id: Atomic(Tick(2, Cluster(loc2v1))),
-                                                                                                collection_kind: Stream {
-                                                                                                    bound: Unbounded,
-                                                                                                    order: TotalOrder,
-                                                                                                    retry: ExactlyOnce,
-                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                },
-                                                                                            },
-                                                                                        },
-                                                                                        metadata: HydroIrMetadata {
-                                                                                            location_id: Atomic(Tick(2, Cluster(loc2v1))),
-                                                                                            collection_kind: Optional {
-                                                                                                bound: Unbounded,
-                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                            },
-                                                                                        },
-                                                                                    },
-                                                                                    metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                                        collection_kind: Optional {
-                                                                                            bound: Bounded,
-                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                        },
-                                                                                    },
-                                                                                },
-                                                                                second: Cast {
-                                                                                    inner: SingletonSource {
-                                                                                        value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_488_46 ! ([] [Ballot { num : 0 , proposer_id : MemberId :: from_raw_id (0) }]) },
-                                                                                        first_tick_only: false,
-                                                                                        metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(2, Cluster(loc2v1)),
-                                                                                            collection_kind: Singleton {
-                                                                                                bound: Bounded,
-                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                            },
-                                                                                        },
-                                                                                    },
-                                                                                    metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                                        collection_kind: Optional {
-                                                                                            bound: Bounded,
-                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                        },
-                                                                                    },
-                                                                                },
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(2, Cluster(loc2v1)),
-                                                                                    collection_kind: Optional {
-                                                                                        bound: Bounded,
-                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                    },
-                                                                                },
-                                                                            },
-                                                                            metadata: HydroIrMetadata {
-                                                                                location_id: Tick(2, Cluster(loc2v1)),
-                                                                                collection_kind: Singleton {
-                                                                                    bound: Bounded,
-                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                },
-                                                                            },
-                                                                        },
-                                                                        metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Cluster(loc2v1)),
-                                                                            collection_kind: Singleton {
-                                                                                bound: Bounded,
-                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                        collection_kind: Optional {
-                                                                            bound: Bounded,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                        },
-                                                                    },
-                                                                },
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
-                                                                    collection_kind: Stream {
-                                                                        bound: Bounded,
-                                                                        order: NoOrder,
-                                                                        retry: ExactlyOnce,
-                                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot),
-                                                                    },
-                                                                },
-                                                            },
-                                                            right: Cast {
-                                                                inner: CycleSource {
-                                                                    cycle_id: CycleId(
-                                                                        4,
-                                                                    ),
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                        collection_kind: Singleton {
-                                                                            bound: Bounded,
-                                                                            element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                        },
-                                                                    },
-                                                                },
-                                                                metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
-                                                                    collection_kind: Optional {
-                                                                        bound: Bounded,
-                                                                        element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
-                                                                    },
-                                                                },
-                                                            },
+                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_498_20 ! ([a_log_ref__free = __hydro_singleton_ref_0 , a_max_ballot_ref__free = __hydro_singleton_ref_1 ,] [| ballot | { let max_ballot = a_max_ballot_ref__free . clone () ; let log = a_log_ref__free . clone () ; (ballot . proposer_id . clone () , (ballot . clone () , if ballot == max_ballot { Ok (log) } else { Err (max_ballot) } ,) ,) }]) }),
+                                                        input: Tee {
+                                                            inner: <shared 9>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(2, Cluster(loc2v1)),
                                                                 collection_kind: Stream {
                                                                     bound: Bounded,
                                                                     order: NoOrder,
                                                                     retry: ExactlyOnce,
-                                                                    element_type: ((hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)),
+                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                 },
                                                             },
                                                         },
@@ -2096,19 +2092,19 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 11>: Map {
+                inner: <shared 13>: Map {
                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_60_27 ! ([max__free = 3usize ,] [move | (success , error) | (success + error) >= max__free]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
                                 input: Tee {
-                                    inner: <shared 12>: FoldKeyed {
+                                    inner: <shared 14>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_34_15 ! ([] [move | | (0 , 0)]) }),
                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_35_15 ! ([] [move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } }]) }),
                                         input: Cast {
                                             inner: Tee {
-                                                inner: <shared 7>,
+                                                inner: <shared 11>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(9, Cluster(loc1v1)),
                                                     collection_kind: Stream {
@@ -2222,7 +2218,7 @@ expression: built.ir()
                         inner: Filter {
                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_51_23 ! ([min__free = 2usize ,] [move | (success , _error) | success >= & min__free]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
                             input: Tee {
-                                inner: <shared 12>,
+                                inner: <shared 14>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(9, Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
@@ -2273,7 +2269,7 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 11>,
+                inner: <shared 13>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(9, Cluster(loc1v1)),
                     collection_kind: Stream {
@@ -2301,7 +2297,7 @@ expression: built.ir()
             7,
         ),
         input: Tee {
-            inner: <shared 13>: Map {
+            inner: <shared 15>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_1144_31 ! ([] [| (a , b) | a && b]) }),
                 input: Cast {
                     inner: CrossSingleton {
@@ -2314,8 +2310,8 @@ expression: built.ir()
                                         input: Map {
                                             f: stageleft :: runtime_support :: fn1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                             input: Tee {
-                                                inner: <shared 14>: FilterMap {
-                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_564_12 ! ([] [move | ((quorum_ballot , quorum_accepted) , my_ballot) | if quorum_ballot == my_ballot { Some (quorum_accepted) } else { None }]) }),
+                                                inner: <shared 16>: FilterMap {
+                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_568_12 ! ([] [move | ((quorum_ballot , quorum_accepted) , my_ballot) | if quorum_ballot == my_ballot { Some (quorum_accepted) } else { None }]) }),
                                                     input: CrossSingleton {
                                                         left: Batch {
                                                             inner: Reduce {
@@ -2328,7 +2324,7 @@ expression: built.ir()
                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) > , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1667_27 ! ([] [| d | d]) }),
                                                                                     input: Scan {
                                                                                         init: stageleft :: runtime_support :: fn0_type_hint :: < std :: collections :: hash_map :: HashMap < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1629_27 ! ([] [| | HashMap :: new ()]) }),
-                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , core :: option :: Option < core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1632_24 ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: __deps :: hydro_lang :: live_collections :: keyed_stream :: Generate < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1737_15 ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_544_15 ! ([quorum_size__free = 2usize ,] [move | logs , log | { logs . push (log) ; logs . len () >= quorum_size__free }]) }) ,] [move | key_state , v | { if let Some (key_state_value) = key_state . as_mut () { if f__free (key_state_value , v) { Generate :: Return (key_state . take () . unwrap ()) } else { Generate :: Continue } } else { unreachable ! () } }]) }) , init__free = stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1736_15 ! ([init__free = stageleft :: runtime_support :: fn0_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_543_15 ! ([] [| | vec ! []]) }) ,] [move | | Some (init__free ())]) }) ,] [move | acc : & mut HashMap < _ , _ > , (k , v) | { let existing_state = acc . entry (Clone :: clone (& k)) . or_insert_with (| | Some (init__free ())) ; if let Some (existing_state_value) = existing_state { match f__free (existing_state_value , v) { Generate :: Yield (out) => Some (Some ((k , out))) , Generate :: Return (out) => { let _ = existing_state . take () ; Some (Some ((k , out))) } Generate :: Break => { let _ = existing_state . take () ; Some (None) } Generate :: Continue => Some (None) , } } else { Some (None) } }]) }),
+                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , core :: option :: Option < core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1632_24 ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: __deps :: hydro_lang :: live_collections :: keyed_stream :: Generate < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1737_15 ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_548_15 ! ([quorum_size__free = 2usize ,] [move | logs , log | { logs . push (log) ; logs . len () >= quorum_size__free }]) }) ,] [move | key_state , v | { if let Some (key_state_value) = key_state . as_mut () { if f__free (key_state_value , v) { Generate :: Return (key_state . take () . unwrap ()) } else { Generate :: Continue } } else { unreachable ! () } }]) }) , init__free = stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_1736_15 ! ([init__free = stageleft :: runtime_support :: fn0_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_547_15 ! ([] [| | vec ! []]) }) ,] [move | | Some (init__free ())]) }) ,] [move | acc : & mut HashMap < _ , _ > , (k , v) | { let existing_state = acc . entry (Clone :: clone (& k)) . or_insert_with (| | Some (init__free ())) ; if let Some (existing_state_value) = existing_state { match f__free (existing_state_value , v) { Generate :: Yield (out) => Some (Some ((k , out))) , Generate :: Return (out) => { let _ = existing_state . take () ; Some (Some ((k , out))) } Generate :: Break => { let _ = existing_state . take () ; Some (None) } Generate :: Continue => Some (None) , } } else { Some (None) } }]) }),
                                                                                         input: ObserveNonDet {
                                                                                             inner: Cast {
                                                                                                 inner: YieldConcat {
@@ -2337,7 +2333,7 @@ expression: built.ir()
                                                                                                         input: AntiJoin {
                                                                                                             pos: AntiJoin {
                                                                                                                 pos: Tee {
-                                                                                                                    inner: <shared 7>,
+                                                                                                                    inner: <shared 11>,
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_id: Tick(9, Cluster(loc1v1)),
                                                                                                                         collection_kind: Stream {
@@ -2355,7 +2351,7 @@ expression: built.ir()
                                                                                                                             inner: Filter {
                                                                                                                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_46_23 ! ([min__free = 2usize ,] [move | (success , _error) | success < & min__free]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
                                                                                                                                 input: Tee {
-                                                                                                                                    inner: <shared 12>,
+                                                                                                                                    inner: <shared 14>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(9, Cluster(loc1v1)),
                                                                                                                                         collection_kind: KeyedSingleton {
@@ -2779,11 +2775,11 @@ expression: built.ir()
             5,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_580_21 ! ([] [| (_ , ballot) | ballot]) }),
+            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_584_21 ! ([] [| (_ , ballot) | ballot]) }),
             input: FilterMap {
                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_82_32 ! ([] [move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , }]) }),
                 input: Tee {
-                    inner: <shared 8>,
+                    inner: <shared 12>,
                     metadata: HydroIrMetadata {
                         location_id: Cluster(loc1v1),
                         collection_kind: Stream {
@@ -2824,7 +2820,7 @@ expression: built.ir()
             f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , bool) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1054_20 ! ([] [| (d , _) | d]) }),
             input: CrossSingleton {
                 left: Tee {
-                    inner: <shared 15>: Chain {
+                    inner: <shared 17>: Chain {
                         first: DeferTick {
                             input: CycleSource {
                                 cycle_id: CycleId(
@@ -2856,7 +2852,7 @@ expression: built.ir()
                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < (u32 , i32) , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_bench_rs_42_28 ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos_bench :: Client > :: from_tagless ((__hydro_lang_cluster_self_id_loc3v1) . clone ()) ,] [move | (virtual_id , payload) | { (virtual_id , (CLUSTER_SELF_ID__free . clone () , payload)) }]) }),
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <shared 16>: Map {
+                                            inner: <shared 18>: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (u32 , core :: option :: Option < i32 >) , (u32 , i32) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_813_23 ! ([f__free = stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < i32 > , i32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_bench_rs_136_33 ! ([] [move | payload | { if let Some (counter) = payload { counter + 1 } else { 0 } }]) }) ,] [{ let orig = f__free ; move | (k , v) | (k , orig (v)) }]) }),
                                                 input: Chain {
                                                     first: YieldConcat {
@@ -3037,7 +3033,7 @@ expression: built.ir()
                                     input: Map {
                                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_935_20 ! ([] [| _ | ()]) }),
                                         input: Tee {
-                                            inner: <shared 17>: Batch {
+                                            inner: <shared 19>: Batch {
                                                 inner: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_94_22 ! ([] [| ballot | ballot . proposer_id]) }),
                                                     input: Reduce {
@@ -3201,12 +3197,12 @@ expression: built.ir()
                                                                                                             right: Filter {
                                                                                                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_34 ! ([] [| b | * b]) }),
                                                                                                                 input: Tee {
-                                                                                                                    inner: <shared 18>: Map {
+                                                                                                                    inner: <shared 20>: Map {
                                                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_1144_31 ! ([] [| (a , b) | a && b]) }),
                                                                                                                         input: Cast {
                                                                                                                             inner: CrossSingleton {
                                                                                                                                 left: Tee {
-                                                                                                                                    inner: <shared 13>,
+                                                                                                                                    inner: <shared 15>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Singleton {
@@ -3229,7 +3225,7 @@ expression: built.ir()
                                                                                                                                                             input: Map {
                                                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_192_16 ! ([] [| is_leader | is_leader . then_some (())]) }),
                                                                                                                                                                 input: Tee {
-                                                                                                                                                                    inner: <shared 13>,
+                                                                                                                                                                    inner: <shared 15>,
                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                                                         collection_kind: Singleton {
@@ -3616,7 +3612,7 @@ expression: built.ir()
     },
     Null {
         input: Reference {
-            inner: <shared 19>: Tee {
+            inner: <shared 21>: Tee {
                 inner: <shared 4>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(15, Cluster(loc1v1)),
@@ -3647,15 +3643,15 @@ expression: built.ir()
             12,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_793_20 ! ([] [| (num_payloads , base_slot) | base_slot + num_payloads]) }),
+            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_797_20 ! ([] [| (num_payloads , base_slot) | base_slot + num_payloads]) }),
             input: Cast {
                 inner: CrossSingleton {
                     left: Fold {
                         init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2427_15 ! ([] [| | 0usize]) }),
                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2429_16 ! ([] [| count , _ | * count += 1]) }),
                         input: Tee {
-                            inner: <shared 20>: Map {
-                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_785_20 ! ([base_slot_ref__free = __hydro_singleton_ref_0 ,] [| (index , payload) | (* base_slot_ref__free + index , payload)]) }),
+                            inner: <shared 22>: Map {
+                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_789_20 ! ([base_slot_ref__free = __hydro_singleton_ref_0 ,] [| (index , payload) | (* base_slot_ref__free + index , payload)]) }),
                                 input: Enumerate {
                                     input: Batch {
                                         inner: YieldConcat {
@@ -3685,7 +3681,7 @@ expression: built.ir()
                                                                                 input: YieldConcat {
                                                                                     inner: CrossSingleton {
                                                                                         left: Tee {
-                                                                                            inner: <shared 15>,
+                                                                                            inner: <shared 17>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(11, Cluster(loc3v1)),
                                                                                                 collection_kind: Stream {
@@ -3697,7 +3693,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         right: Tee {
-                                                                                            inner: <shared 17>,
+                                                                                            inner: <shared 19>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(11, Cluster(loc3v1)),
                                                                                                 collection_kind: Optional {
@@ -3802,7 +3798,7 @@ expression: built.ir()
                                                     right: Filter {
                                                         f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1053_46 ! ([] [| b | * b]) }),
                                                         input: Tee {
-                                                            inner: <shared 13>,
+                                                            inner: <shared 15>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                 collection_kind: Singleton {
@@ -3898,14 +3894,14 @@ expression: built.ir()
                         },
                     },
                     right: Reference {
-                        inner: <shared 21>: Cast {
+                        inner: <shared 23>: Cast {
                             inner: ChainFirst {
                                 first: Map {
-                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_779_71 ! ([] [| s | s + 1]) }),
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < usize , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_783_71 ! ([] [| s | s + 1]) }),
                                     input: Batch {
                                         inner: YieldConcat {
                                             inner: Tee {
-                                                inner: <shared 22>: Reduce {
+                                                inner: <shared 24>: Reduce {
                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
                                                     input: ObserveNonDet {
                                                         inner: Map {
@@ -3913,22 +3909,22 @@ expression: built.ir()
                                                             input: Cast {
                                                                 inner: Cast {
                                                                     inner: Tee {
-                                                                        inner: <shared 23>: Map {
-                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_484_23 ! ([f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_628_16 ! ([] [| (count , entry) | (count , entry . unwrap ())]) }) ,] [{ let orig = f__free ; move | (k , v) | (k , orig (v)) }]) }),
+                                                                        inner: <shared 25>: Map {
+                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_484_23 ! ([f__free = stageleft :: runtime_support :: fn1_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_632_16 ! ([] [| (count , entry) | (count , entry . unwrap ())]) }) ,] [{ let orig = f__free ; move | (k , v) | (k , orig (v)) }]) }),
                                                                             input: FoldKeyed {
-                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_607_67 ! ([] [| | (0 , None)]) }),
-                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_607_85 ! ([] [| curr_entry , new_entry | { if let Some (curr_entry_payload) = & mut curr_entry . 1 { let same_values = new_entry . value == curr_entry_payload . value ; let higher_ballot = new_entry . ballot > curr_entry_payload . ballot ; if same_values { curr_entry . 0 += 1 ; } if higher_ballot { curr_entry_payload . ballot = new_entry . ballot ; if ! same_values { curr_entry . 0 = 1 ; curr_entry_payload . value = new_entry . value ; } } } else { * curr_entry = (1 , Some (new_entry)) ; } }]) }),
+                                                                                init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_611_67 ! ([] [| | (0 , None)]) }),
+                                                                                acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_611_85 ! ([] [| curr_entry , new_entry | { if let Some (curr_entry_payload) = & mut curr_entry . 1 { let same_values = new_entry . value == curr_entry_payload . value ; let higher_ballot = new_entry . ballot > curr_entry_payload . ballot ; if same_values { curr_entry . 0 += 1 ; } if higher_ballot { curr_entry_payload . ballot = new_entry . ballot ; if ! same_values { curr_entry . 0 = 1 ; curr_entry_payload . value = new_entry . value ; } } } else { * curr_entry = (1 , Some (new_entry)) ; } }]) }),
                                                                                 input: Cast {
                                                                                     inner: FlatMap {
                                                                                         f: stageleft :: runtime_support :: fnmut1_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_764_35 ! ([] [| d | d]) }),
                                                                                         input: Map {
-                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_604_16 ! ([] [| (_checkpoint , log) | log]) }),
+                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_608_16 ! ([] [| (_checkpoint , log) | log]) }),
                                                                                             input: Tee {
-                                                                                                inner: <shared 24>: FlatMap {
+                                                                                                inner: <shared 26>: FlatMap {
                                                                                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_571_35 ! ([] [| v | v]) }),
                                                                                                     input: Cast {
                                                                                                         inner: Tee {
-                                                                                                            inner: <shared 14>,
+                                                                                                            inner: <shared 16>,
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                 collection_kind: Optional {
@@ -4133,7 +4129,7 @@ expression: built.ir()
                                             },
                                             second: Cast {
                                                 inner: SingletonSource {
-                                                    value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_775_58 ! ([] [0]) },
+                                                    value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_779_58 ! ([] [0]) },
                                                     first_tick_only: false,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(15, Cluster(loc1v1)),
@@ -4233,8 +4229,8 @@ expression: built.ir()
     },
     Null {
         input: Reference {
-            inner: <shared 25>: Tee {
-                inner: <shared 10>,
+            inner: <shared 27>: Tee {
+                inner: <shared 8>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(2, Cluster(loc2v1)),
                     collection_kind: Singleton {
@@ -4265,7 +4261,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 26>: Chain {
+                inner: <shared 28>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -4293,7 +4289,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <shared 27>: Map {
+                            inner: <shared 29>: Map {
                                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
                                 input: Cast {
                                     inner: Network {
@@ -4311,9 +4307,9 @@ expression: built.ir()
                                         input: Cast {
                                             inner: YieldConcat {
                                                 inner: Map {
-                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_874_16 ! ([a_max_ballot_ref__free = __hydro_singleton_ref_0 ,] [| p2a | { let max_ballot = a_max_ballot_ref__free . clone () ; (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) } ,) ,) }]) }),
+                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_878_16 ! ([a_max_ballot_ref__free = __hydro_singleton_ref_0 ,] [| p2a | { let max_ballot = a_max_ballot_ref__free . clone () ; (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) } ,) ,) }]) }),
                                                     input: Tee {
-                                                        inner: <shared 28>: Batch {
+                                                        inner: <shared 30>: Batch {
                                                             inner: Map {
                                                                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
                                                                 input: Cast {
@@ -4453,20 +4449,20 @@ expression: built.ir()
                                                                                     },
                                                                                     right: Batch {
                                                                                         inner: Map {
-                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_734_20 ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ,] [move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free . clone () , ballot , slot , value }]) }),
+                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_738_20 ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ,] [move | ((slot , ballot) , value) | P2a { sender : CLUSTER_SELF_ID__free . clone () , ballot , slot , value }]) }),
                                                                                             input: EndAtomic {
                                                                                                 inner: Tee {
-                                                                                                    inner: <shared 29>: YieldConcat {
+                                                                                                    inner: <shared 31>: YieldConcat {
                                                                                                         inner: Map {
                                                                                                             f: stageleft :: runtime_support :: fnmut1_type_hint :: < (((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , bool) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1054_20 ! ([] [| (d , _) | d]) }),
                                                                                                             input: CrossSingleton {
                                                                                                                 left: Chain {
                                                                                                                     first: Map {
-                                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_720_16 ! ([p_ballot_ref__free = __hydro_singleton_ref_0 ,] [| (slot , payload) | ((slot , p_ballot_ref__free . clone ()) , Some (payload))]) }),
+                                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32))) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_724_16 ! ([p_ballot_ref__free = __hydro_singleton_ref_0 ,] [| (slot , payload) | ((slot , p_ballot_ref__free . clone ()) , Some (payload))]) }),
                                                                                                                         input: Batch {
                                                                                                                             inner: YieldConcat {
                                                                                                                                 inner: Tee {
-                                                                                                                                    inner: <shared 20>,
+                                                                                                                                    inner: <shared 22>,
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                         collection_kind: Stream {
@@ -4509,11 +4505,11 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                     second: Chain {
                                                                                                                         first: FilterMap {
-                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_634_23 ! ([f__free = 1usize , p_ballot_ref__free = __hydro_singleton_ref_0 , p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1 ,] [move | (slot , (count , entry)) | { if count > f__free { return None ; } else if let Some (checkpoint) = * p_p1b_max_checkpoint_ref__free && slot <= checkpoint { return None ; } Some (((slot , p_ballot_ref__free . clone ()) , entry . value)) }]) }),
+                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >)) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_638_23 ! ([f__free = 1usize , p_ballot_ref__free = __hydro_singleton_ref_0 , p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1 ,] [move | (slot , (count , entry)) | { if count > f__free { return None ; } else if let Some (checkpoint) = * p_p1b_max_checkpoint_ref__free && slot <= checkpoint { return None ; } Some (((slot , p_ballot_ref__free . clone ()) , entry . value)) }]) }),
                                                                                                                             input: Cast {
                                                                                                                                 inner: Cast {
                                                                                                                                     inner: Tee {
-                                                                                                                                        inner: <shared 23>,
+                                                                                                                                        inner: <shared 25>,
                                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                             collection_kind: KeyedSingleton {
@@ -4555,14 +4551,14 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         second: Map {
-                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < usize , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_657_16 ! ([p_ballot_ref__free = __hydro_singleton_ref_0 ,] [move | slot | ((slot , p_ballot_ref__free . clone ()) , None)]) }),
+                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < usize , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_661_16 ! ([p_ballot_ref__free = __hydro_singleton_ref_0 ,] [move | slot | ((slot , p_ballot_ref__free . clone ()) , None)]) }),
                                                                                                                             input: Difference {
                                                                                                                                 pos: FlatMap {
-                                                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_649_29 ! ([] [| (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } }]) }),
+                                                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , core :: option :: Option < usize >) , std :: ops :: Range < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_653_29 ! ([] [| (max_slot , checkpoint) | { if let Some (checkpoint) = checkpoint { (checkpoint + 1) .. max_slot } else { 0 .. max_slot } }]) }),
                                                                                                                                     input: Cast {
                                                                                                                                         inner: CrossSingleton {
                                                                                                                                             left: Tee {
-                                                                                                                                                inner: <shared 22>,
+                                                                                                                                                inner: <shared 24>,
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Optional {
@@ -4573,7 +4569,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                             right: Cast {
                                                                                                                                                 inner: Reference {
-                                                                                                                                                    inner: <shared 30>: Cast {
+                                                                                                                                                    inner: <shared 32>: Cast {
                                                                                                                                                         inner: ChainFirst {
                                                                                                                                                             first: Map {
                                                                                                                                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
@@ -4581,9 +4577,9 @@ expression: built.ir()
                                                                                                                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1519_23 ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
                                                                                                                                                                     input: ObserveNonDet {
                                                                                                                                                                         inner: FilterMap {
-                                                                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_600_23 ! ([] [| (checkpoint , _log) | checkpoint]) }),
+                                                                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_604_23 ! ([] [| (checkpoint , _log) | checkpoint]) }),
                                                                                                                                                                             input: Tee {
-                                                                                                                                                                                inner: <shared 24>,
+                                                                                                                                                                                inner: <shared 26>,
                                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                                     location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                                                                     collection_kind: Stream {
@@ -4722,7 +4718,7 @@ expression: built.ir()
                                                                                                                                     input: Cast {
                                                                                                                                         inner: Cast {
                                                                                                                                             inner: Tee {
-                                                                                                                                                inner: <shared 23>,
+                                                                                                                                                inner: <shared 25>,
                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                     location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                                     collection_kind: KeyedSingleton {
@@ -4806,7 +4802,7 @@ expression: built.ir()
                                                                                                                 right: Filter {
                                                                                                                     f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1053_46 ! ([] [| b | * b]) }),
                                                                                                                     input: Tee {
-                                                                                                                        inner: <shared 13>,
+                                                                                                                        inner: <shared 15>,
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                             collection_kind: Singleton {
@@ -5079,19 +5075,19 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 31>: Map {
+                inner: <shared 33>: Map {
                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30 ! ([] [| (k , _) | k]) }),
                     input: Cast {
                         inner: Cast {
                             inner: Filter {
                                 f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26 ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_134_27 ! ([max__free = 3usize ,] [move | (success , error) | (success + error) >= max__free]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
                                 input: Tee {
-                                    inner: <shared 32>: FoldKeyed {
+                                    inner: <shared 34>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_109_15 ! ([] [move | | (0 , 0)]) }),
                                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_110_15 ! ([] [move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } }]) }),
                                         input: Cast {
                                             inner: Tee {
-                                                inner: <shared 26>,
+                                                inner: <shared 28>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(14, Cluster(loc1v1)),
                                                     collection_kind: Stream {
@@ -5199,12 +5195,12 @@ expression: built.ir()
         ),
         input: Difference {
             pos: Tee {
-                inner: <shared 33>: FilterMap {
+                inner: <shared 35>: FilterMap {
                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (usize , usize)) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_122_27 ! ([min__free = 2usize ,] [move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None }]) }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <shared 32>,
+                                inner: <shared 34>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(14, Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
@@ -5256,7 +5252,7 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 31>,
+                inner: <shared 33>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(14, Cluster(loc1v1)),
                     collection_kind: Stream {
@@ -5285,7 +5281,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 34>: Chain {
+                inner: <shared 36>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -5315,7 +5311,7 @@ expression: built.ir()
                         inner: YieldConcat {
                             inner: Batch {
                                 inner: Tee {
-                                    inner: <shared 29>,
+                                    inner: <shared 31>,
                                     metadata: HydroIrMetadata {
                                         location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                         collection_kind: Stream {
@@ -5379,13 +5375,13 @@ expression: built.ir()
             neg: Map {
                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) , (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; hydro_std :: __stageleft_quote_src_request_response_rs_39_78 ! ([] [| (key , _) | key]) }),
                 input: Tee {
-                    inner: <shared 35>: Batch {
+                    inner: <shared 37>: Batch {
                         inner: Map {
-                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_750_23 ! ([] [| k | (k , ())]) }),
+                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , ()) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_754_23 ! ([] [| k | (k , ())]) }),
                             input: YieldConcat {
                                 inner: Difference {
                                     pos: Tee {
-                                        inner: <shared 33>,
+                                        inner: <shared 35>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(14, Cluster(loc1v1)),
                                             collection_kind: Stream {
@@ -5495,7 +5491,7 @@ expression: built.ir()
     },
     Null {
         input: Reference {
-            inner: <shared 36>: Tee {
+            inner: <shared 38>: Tee {
                 inner: <shared 4>,
                 metadata: HydroIrMetadata {
                     location_id: Tick(15, Cluster(loc1v1)),
@@ -5534,7 +5530,7 @@ expression: built.ir()
                                 first: Map {
                                     f: stageleft :: runtime_support :: fn1_type_hint :: < usize , core :: option :: Option < usize > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
                                     input: Tee {
-                                        inner: <shared 37>: Batch {
+                                        inner: <shared 39>: Batch {
                                             inner: CycleSource {
                                                 cycle_id: CycleId(
                                                     2,
@@ -5608,20 +5604,20 @@ expression: built.ir()
                             },
                         },
                         right: Fold {
-                            init: stageleft :: runtime_support :: fn0_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_864_11 ! ([] [| | HashMap :: new ()]) }),
-                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_866_12 ! ([] [| map , (slot , entry) | { map . insert (slot , entry) ; }]) }),
+                            init: stageleft :: runtime_support :: fn0_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_868_11 ! ([] [| | HashMap :: new ()]) }),
+                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > > , (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_870_12 ! ([] [| map , (slot , entry) | { map . insert (slot , entry) ; }]) }),
                             input: Cast {
                                 inner: Cast {
                                     inner: Batch {
                                         inner: ReduceKeyedWatermark {
-                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_852_15 ! ([] [| prev_entry , entry | { if entry . ballot > prev_entry . ballot { * prev_entry = LogValue { ballot : entry . ballot , value : entry . value , } ; } }]) }),
+                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_856_15 ! ([] [| prev_entry , entry | { if entry . ballot > prev_entry . ballot { * prev_entry = LogValue { ballot : entry . ballot , value : entry . value , } ; } }]) }),
                                             input: ObserveNonDet {
                                                 inner: Cast {
                                                     inner: YieldConcat {
                                                         inner: FilterMap {
-                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_838_27 ! ([a_max_ballot_ref__free = __hydro_singleton_ref_0 ,] [| p2a | if p2a . ballot >= * a_max_ballot_ref__free { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , } ,)) } else { None }]) }),
+                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_842_27 ! ([a_max_ballot_ref__free = __hydro_singleton_ref_0 ,] [| p2a | if p2a . ballot >= * a_max_ballot_ref__free { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , } ,)) } else { None }]) }),
                                                             input: Tee {
-                                                                inner: <shared 28>,
+                                                                inner: <shared 30>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(2, Cluster(loc2v1)),
                                                                     collection_kind: Stream {
@@ -5676,7 +5672,7 @@ expression: built.ir()
                                                 },
                                             },
                                             watermark: Tee {
-                                                inner: <shared 37>,
+                                                inner: <shared 39>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(2, Cluster(loc2v1)),
                                                     collection_kind: Optional {
@@ -5771,11 +5767,11 @@ expression: built.ir()
             3,
         ),
         input: Map {
-            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_764_21 ! ([] [| (_ , ballot) | ballot]) }),
+            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_768_21 ! ([] [| (_ , ballot) | ballot]) }),
             input: FilterMap {
                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_151_32 ! ([] [move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , }]) }),
                 input: Tee {
-                    inner: <shared 27>,
+                    inner: <shared 29>,
                     metadata: HydroIrMetadata {
                         location_id: Cluster(loc1v1),
                         collection_kind: Stream {
@@ -5827,7 +5823,7 @@ expression: built.ir()
                         right: Filter {
                             f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_34 ! ([] [| b | * b]) }),
                             input: Tee {
-                                inner: <shared 18>,
+                                inner: <shared 20>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(15, Cluster(loc1v1)),
                                     collection_kind: Singleton {
@@ -5892,7 +5888,7 @@ expression: built.ir()
                 f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_49_12 ! ([] [| (sorted_payload , highest_seq) | sorted_payload . seq > * highest_seq]) }),
                 input: CrossSingleton {
                     left: Tee {
-                        inner: <shared 38>: Sort {
+                        inner: <shared 40>: Sort {
                             input: Chain {
                                 first: Batch {
                                     inner: Map {
@@ -6038,13 +6034,13 @@ expression: built.ir()
                                                                     },
                                                                     right: Batch {
                                                                         inner: Map {
-                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_762_29 ! ([] [| ((slot , _ballot) , (value , _)) | (slot , value)]) }),
+                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , (usize , core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_rs_766_29 ! ([] [| ((slot , _ballot) , (value , _)) | (slot , value)]) }),
                                                                             input: YieldConcat {
                                                                                 inner: Map {
                                                                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > , ())) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: request_response :: * ; hydro_std :: __stageleft_quote_src_request_response_rs_37_20 ! ([] [| (key , (meta , resp)) | (key , (meta , resp))]) }),
                                                                                     input: JoinHalf {
                                                                                         left: Tee {
-                                                                                            inner: <shared 34>,
+                                                                                            inner: <shared 36>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
@@ -6056,7 +6052,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         right: Tee {
-                                                                                            inner: <shared 35>,
+                                                                                            inner: <shared 37>,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
@@ -6267,12 +6263,12 @@ expression: built.ir()
                     },
                     right: Cast {
                         inner: Tee {
-                            inner: <shared 39>: Fold {
+                            inner: <shared 41>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_31_15 ! ([] [| | 0]) }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_32_15 ! ([] [| new_next_slot , (sorted_payload , next_slot) | { if sorted_payload . seq == std :: cmp :: max (* new_next_slot , next_slot) { * new_next_slot = sorted_payload . seq + 1 ; } }]) }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 38>,
+                                        inner: <shared 40>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(17, Cluster(loc5v1)),
                                             collection_kind: Stream {
@@ -6422,7 +6418,7 @@ expression: built.ir()
             17,
         ),
         input: Tee {
-            inner: <shared 40>: Map {
+            inner: <shared 42>: Map {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , usize > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_78_40 ! ([] [| (_kv_store , next_slot) | next_slot]) }),
                 input: Batch {
                     inner: Fold {
@@ -6430,13 +6426,13 @@ expression: built.ir()
                         acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_69_15 ! ([] [| (kv_store , next_slot) , payload | { if let Some (kv) = payload . kv { kv_store . insert (kv . key , kv . value) ; } * next_slot = payload . seq + 1 ; }]) }),
                         input: YieldConcat {
                             inner: Tee {
-                                inner: <shared 41>: Map {
+                                inner: <shared 43>: Map {
                                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_45_16 ! ([] [| (sorted_payload , _) | { sorted_payload }]) }),
                                     input: Filter {
                                         f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_43_12 ! ([] [| (sorted_payload , highest_seq) | sorted_payload . seq < * highest_seq]) }),
                                         input: CrossSingleton {
                                             left: Tee {
-                                                inner: <shared 38>,
+                                                inner: <shared 40>,
                                                 metadata: HydroIrMetadata {
                                                     location_id: Tick(17, Cluster(loc5v1)),
                                                     collection_kind: Stream {
@@ -6449,7 +6445,7 @@ expression: built.ir()
                                             },
                                             right: Cast {
                                                 inner: Tee {
-                                                    inner: <shared 39>,
+                                                    inner: <shared 41>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(17, Cluster(loc5v1)),
                                                         collection_kind: Singleton {
@@ -6555,7 +6551,7 @@ expression: built.ir()
             18,
         ),
         input: Tee {
-            inner: <shared 42>: FilterMap {
+            inner: <shared 44>: FilterMap {
                 f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < usize > , usize) , core :: option :: Option < usize > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_95_12 ! ([checkpoint_frequency__free = 1000usize ,] [move | (max_checkpointed_seq , next_slot) | if max_checkpointed_seq . map (| m | next_slot - m >= checkpoint_frequency__free) . unwrap_or (true) { Some (next_slot) } else { None }]) }),
                 input: Cast {
                     inner: CrossSingleton {
@@ -6674,7 +6670,7 @@ expression: built.ir()
                                 first: DeferTick {
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <shared 40>,
+                                            inner: <shared 42>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(17, Cluster(loc5v1)),
                                                 collection_kind: Singleton {
@@ -6785,7 +6781,7 @@ expression: built.ir()
                                 left: Cast {
                                     inner: Cast {
                                         inner: Tee {
-                                            inner: <shared 43>: Batch {
+                                            inner: <shared 45>: Batch {
                                                 inner: ReduceKeyed {
                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , usize , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_bench_rs_73_24 ! ([] [| curr_seq , seq | { if seq > * curr_seq { * curr_seq = seq ; } }]) }),
                                                     input: Network {
@@ -6926,7 +6922,7 @@ expression: built.ir()
                                                                         inner: YieldConcat {
                                                                             inner: Cast {
                                                                                 inner: Tee {
-                                                                                    inner: <shared 42>,
+                                                                                    inner: <shared 44>,
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Tick(17, Cluster(loc5v1)),
                                                                                         collection_kind: Optional {
@@ -7067,7 +7063,7 @@ expression: built.ir()
                                                 inner: Cast {
                                                     inner: Cast {
                                                         inner: Tee {
-                                                            inner: <shared 43>,
+                                                            inner: <shared 45>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(19, Cluster(loc2v1)),
                                                                 collection_kind: KeyedSingleton {
@@ -7198,7 +7194,7 @@ expression: built.ir()
         ),
         input: AntiJoin {
             pos: Tee {
-                inner: <shared 44>: Chain {
+                inner: <shared 46>: Chain {
                     first: DeferTick {
                         input: CycleSource {
                             cycle_id: CycleId(
@@ -7226,7 +7222,7 @@ expression: built.ir()
                     },
                     second: Batch {
                         inner: Tee {
-                            inner: <shared 45>: Map {
+                            inner: <shared 47>: Map {
                                 f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica > , ((u32 , i32) , core :: result :: Result < () , () >)) , ((u32 , i32) , core :: result :: Result < () , () >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30 ! ([] [| (_ , v) | v]) }),
                                 input: Cast {
                                     inner: Network {
@@ -7248,7 +7244,7 @@ expression: built.ir()
                                                     inner: FilterMap {
                                                         f: stageleft :: runtime_support :: fnmut1_type_hint :: < hydro_test :: __staged :: cluster :: kv_replica :: SequencedKv < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , core :: option :: Option < hydro_test :: __staged :: cluster :: kv_replica :: KvPayload < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_kv_replica_mod_rs_108_23 ! ([] [| payload | payload . kv]) }),
                                                         input: Tee {
-                                                            inner: <shared 41>,
+                                                            inner: <shared 43>,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Tick(17, Cluster(loc5v1)),
                                                                 collection_kind: Stream {
@@ -7372,17 +7368,17 @@ expression: built.ir()
                 },
             },
             neg: Tee {
-                inner: <shared 46>: FilterMap {
+                inner: <shared 48>: FilterMap {
                     f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , i32) , (usize , usize)) , core :: option :: Option < (u32 , i32) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_122_27 ! ([min__free = 2usize ,] [move | (key , (success , _error)) | if success >= min__free { Some (key) } else { None }]) }),
                     input: Cast {
                         inner: Cast {
                             inner: Tee {
-                                inner: <shared 47>: FoldKeyed {
+                                inner: <shared 49>: FoldKeyed {
                                     init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_109_15 ! ([] [move | | (0 , 0)]) }),
                                     acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , () > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_110_15 ! ([] [move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } }]) }),
                                     input: Cast {
                                         inner: Tee {
-                                            inner: <shared 44>,
+                                            inner: <shared 46>,
                                             metadata: HydroIrMetadata {
                                                 location_id: Tick(20, Cluster(loc3v1)),
                                                 collection_kind: Stream {
@@ -7510,7 +7506,7 @@ expression: built.ir()
         input: FilterMap {
             f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((u32 , i32) , core :: result :: Result < () , () >) , core :: option :: Option < ((u32 , i32) , ()) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_151_32 ! ([] [move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , }]) }),
             input: Tee {
-                inner: <shared 45>,
+                inner: <shared 47>,
                 metadata: HydroIrMetadata {
                     location_id: Cluster(loc3v1),
                     collection_kind: Stream {
@@ -7538,10 +7534,10 @@ expression: built.ir()
             1,
         ),
         input: Tee {
-            inner: <shared 48>: Cast {
+            inner: <shared 50>: Cast {
                 inner: YieldConcat {
                     inner: Tee {
-                        inner: <shared 46>,
+                        inner: <shared 48>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(20, Cluster(loc3v1)),
                             collection_kind: Stream {
@@ -7596,11 +7592,11 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_183_20 ! ([] [| (new , old) | { old . borrow_mut () . add (new) . expect ("Error adding value to histogram") ; old }]) }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 49>: Fold {
+                            inner: <shared 51>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_153_15 ! ([] [move | | Histogram :: < u64 > :: new (3) . unwrap ()]) }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , core :: time :: Duration , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_154_15 ! ([] [move | latencies , latency | { latencies . record (latency . as_nanos () as u64) . unwrap () ; }]) }),
                                 input: Tee {
-                                    inner: <shared 50>: Batch {
+                                    inner: <shared 52>: Batch {
                                         inner: Map {
                                             f: stageleft :: runtime_support :: fnmut1_type_hint :: < (u32 , (i32 , core :: time :: Duration)) , core :: time :: Duration > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_bench :: * ; # [allow (unused_imports)] use crate :: * ; __stageleft_quote_src_cluster_paxos_bench_rs_118_12 ! ([] [| (_virtual_client_id , (_output , latency)) | latency]) }),
                                             input: Cast {
@@ -7620,7 +7616,7 @@ expression: built.ir()
                                                                                                 init: stageleft :: runtime_support :: fn0_type_hint :: < std :: time :: Instant > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_101_11 ! ([] [| | Instant :: now ()]) }),
                                                                                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: time :: Instant , i32 , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_103_12 ! ([] [| curr , _new | { * curr = Instant :: now () ; }]) }),
                                                                                                 input: Tee {
-                                                                                                    inner: <shared 16>,
+                                                                                                    inner: <shared 18>,
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Cluster(loc3v1),
                                                                                                         collection_kind: KeyedStream {
@@ -7689,7 +7685,7 @@ expression: built.ir()
                                                                                             input: ObserveNonDet {
                                                                                                 inner: Batch {
                                                                                                     inner: Tee {
-                                                                                                        inner: <shared 48>,
+                                                                                                        inner: <shared 50>,
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_id: Cluster(loc3v1),
                                                                                                             collection_kind: KeyedStream {
@@ -7892,11 +7888,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <shared 51>: Map {
+                            inner: <shared 53>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 52>: Cast {
+                                        inner: <shared 54>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -7974,7 +7970,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_935_20 ! ([] [| _ | ()]) }),
                                                             input: Tee {
-                                                                inner: <shared 53>: Reduce {
+                                                                inner: <shared 55>: Reduce {
                                                                     f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1589_23 ! ([] [| _ , _ | { }]) }),
                                                                     input: FlatMap {
                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1955_27 ! ([] [| d | d]) }),
@@ -8154,7 +8150,7 @@ expression: built.ir()
                     inner: Map {
                         f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_187_56 ! ([] [| histogram | Rc :: new (RefCell :: new (histogram))]) }),
                         input: Tee {
-                            inner: <shared 49>,
+                            inner: <shared 51>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(22, Cluster(loc3v1)),
                                 collection_kind: Singleton {
@@ -8207,12 +8203,12 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , usize) , usize > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_174_20 ! ([] [| (new , old) | new + old]) }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 54>: Fold {
+                            inner: <shared 56>: Fold {
                                 init: stageleft :: runtime_support :: fn0_type_hint :: < usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2427_15 ! ([] [| | 0usize]) }),
                                 acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < usize , core :: time :: Duration , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_2429_16 ! ([] [| count , _ | * count += 1]) }),
                                 input: ObserveNonDet {
                                     inner: Tee {
-                                        inner: <shared 50>,
+                                        inner: <shared 52>,
                                         metadata: HydroIrMetadata {
                                             location_id: Tick(22, Cluster(loc3v1)),
                                             collection_kind: Stream {
@@ -8251,11 +8247,11 @@ expression: built.ir()
                             },
                         },
                         right: Tee {
-                            inner: <shared 55>: Map {
+                            inner: <shared 57>: Map {
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                 input: CrossSingleton {
                                     left: Tee {
-                                        inner: <shared 56>: Cast {
+                                        inner: <shared 58>: Cast {
                                             inner: ChainFirst {
                                                 first: DeferTick {
                                                     input: CycleSource {
@@ -8333,7 +8329,7 @@ expression: built.ir()
                                                         input: Map {
                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_935_20 ! ([] [| _ | ()]) }),
                                                             input: Tee {
-                                                                inner: <shared 53>,
+                                                                inner: <shared 55>,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                     collection_kind: Optional {
@@ -8452,7 +8448,7 @@ expression: built.ir()
                 },
                 second: Cast {
                     inner: Tee {
-                        inner: <shared 54>,
+                        inner: <shared 56>,
                         metadata: HydroIrMetadata {
                             location_id: Tick(22, Cluster(loc3v1)),
                             collection_kind: Singleton {
@@ -8498,7 +8494,7 @@ expression: built.ir()
                     left: Cast {
                         inner: CrossSingleton {
                             left: Tee {
-                                inner: <shared 57>: Cast {
+                                inner: <shared 59>: Cast {
                                     inner: ChainFirst {
                                         first: DeferTick {
                                             input: CycleSource {
@@ -8599,7 +8595,7 @@ expression: built.ir()
                                                                                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                                                                         input: CrossSingleton {
                                                                                             left: Tee {
-                                                                                                inner: <shared 52>,
+                                                                                                inner: <shared 54>,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                                                     collection_kind: Singleton {
@@ -8619,7 +8615,7 @@ expression: built.ir()
                                                                                                                 input: Map {
                                                                                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                                                                                     input: Tee {
-                                                                                                                        inner: <shared 53>,
+                                                                                                                        inner: <shared 55>,
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Tick(22, Cluster(loc3v1)),
                                                                                                                             collection_kind: Optional {
@@ -8888,7 +8884,7 @@ expression: built.ir()
                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_879_20 ! ([] [| v | Some (v)]) }),
                                 input: DeferTick {
                                     input: Tee {
-                                        inner: <shared 58>: Reduce {
+                                        inner: <shared 60>: Reduce {
                                             f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < () , () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1589_23 ! ([] [| _ , _ | { }]) }),
                                             input: FlatMap {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_1955_27 ! ([] [| d | d]) }),
@@ -9065,7 +9061,7 @@ expression: built.ir()
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                                                 input: CrossSingleton {
                                                     left: Tee {
-                                                        inner: <shared 56>,
+                                                        inner: <shared 58>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(22, Cluster(loc3v1)),
                                                             collection_kind: Singleton {
@@ -9085,7 +9081,7 @@ expression: built.ir()
                                                                         input: Map {
                                                                             f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                                             input: Tee {
-                                                                                inner: <shared 53>,
+                                                                                inner: <shared 55>,
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Tick(22, Cluster(loc3v1)),
                                                                                     collection_kind: Optional {
@@ -9254,7 +9250,7 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <shared 59>: Cast {
+                                inner: <shared 61>: Cast {
                                     inner: ChainFirst {
                                         first: DeferTick {
                                             input: CycleSource {
@@ -9332,7 +9328,7 @@ expression: built.ir()
                                                 input: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_935_20 ! ([] [| _ | ()]) }),
                                                     input: Tee {
-                                                        inner: <shared 58>,
+                                                        inner: <shared 60>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(23, Process(loc4v1)),
                                                             collection_kind: Optional {
@@ -9463,7 +9459,7 @@ expression: built.ir()
                     f: stageleft :: runtime_support :: fn1_type_hint :: < (usize , bool) , usize > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                     input: CrossSingleton {
                         left: Tee {
-                            inner: <shared 59>,
+                            inner: <shared 61>,
                             metadata: HydroIrMetadata {
                                 location_id: Tick(23, Process(loc4v1)),
                                 collection_kind: Singleton {
@@ -9483,7 +9479,7 @@ expression: built.ir()
                                             input: Map {
                                                 f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                 input: Tee {
-                                                    inner: <shared 58>,
+                                                    inner: <shared 60>,
                                                     metadata: HydroIrMetadata {
                                                         location_id: Tick(23, Process(loc4v1)),
                                                         collection_kind: Optional {
@@ -9608,7 +9604,7 @@ expression: built.ir()
                         f: stageleft :: runtime_support :: fn1_type_hint :: < (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool) , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_875_51 ! ([] [| (d , _) | d]) }),
                         input: CrossSingleton {
                             left: Tee {
-                                inner: <shared 57>,
+                                inner: <shared 59>,
                                 metadata: HydroIrMetadata {
                                     location_id: Tick(23, Process(loc4v1)),
                                     collection_kind: Singleton {
@@ -9628,7 +9624,7 @@ expression: built.ir()
                                                 input: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_906_20 ! ([] [| _ | ()]) }),
                                                     input: Tee {
-                                                        inner: <shared 58>,
+                                                        inner: <shared 60>,
                                                         metadata: HydroIrMetadata {
                                                             location_id: Tick(23, Process(loc4v1)),
                                                             collection_kind: Optional {

--- a/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
@@ -25,27 +25,26 @@ linkStyle default stroke:#aaa
 15v1["<div style=text-align:center>(15v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_498_20!(<br>        [] [| ((ballot, max_ballot), log) | (ballot.proposer_id.clone(), (ballot<br>        .clone(), if ballot == max_ballot { Ok(log) } else { Err(max_ballot) }))]<br>    )<br>})</code>"]:::otherClass
 16v1["<div style=text-align:center>(16v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
 17v1["<div style=text-align:center>(17v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-18v1["<div style=text-align:center>(18v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-19v1["<div style=text-align:center>(19v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::P2a&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>                hydro_test::__staged::cluster::paxos::Proposer,<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-20v1["<div style=text-align:center>(20v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
-21v1["<div style=text-align:center>(21v1)</div> <code><br>tee()</code>"]:::otherClass
-22v1["<div style=text-align:center>(22v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-23v1["<div style=text-align:center>(23v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_874_16!(<br>        [] [| (p2a, max_ballot) | (p2a.sender, ((p2a.slot, p2a.ballot.clone()), if<br>        p2a.ballot == max_ballot { Ok(()) } else { Err(max_ballot) }))]<br>    )<br>})</code>"]:::otherClass
-24v1["<div style=text-align:center>(24v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-25v1["<div style=text-align:center>(25v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-26v1["<div style=text-align:center>(26v1)</div> <code><br>tee()</code>"]:::otherClass
-27v1["<div style=text-align:center>(27v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
-28v1["<div style=text-align:center>(28v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-29v1["<div style=text-align:center>(29v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-30v1["<div style=text-align:center>(30v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-31v1["<div style=text-align:center>(31v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-32v1["<div style=text-align:center>(32v1)</div> <code><br>filter_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_838_23!(<br>        [] [| (p2a, max_ballot) | if p2a.ballot &gt;= max_ballot { Some((p2a.slot,<br>        LogValue { ballot : p2a.ballot, value : p2a.value, })) } else { None }]<br>    )<br>})</code>"]:::otherClass
+19v1["<div style=text-align:center>(19v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+20v1["<div style=text-align:center>(20v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+21v1["<div style=text-align:center>(21v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::P2a&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>                hydro_test::__staged::cluster::paxos::Proposer,<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+22v1["<div style=text-align:center>(22v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
+23v1["<div style=text-align:center>(23v1)</div> <code><br>tee()</code>"]:::otherClass
+24v1["<div style=text-align:center>(24v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_389;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_874_16!(<br>            [a_max_ballot_ref__free = __hydro_singleton_ref_0,] [| p2a | { let<br>            max_ballot = a_max_ballot_ref__free.clone(); (p2a.sender, ((p2a.slot, p2a<br>            .ballot.clone()), if p2a.ballot == max_ballot { Ok(()) } else {<br>            Err(max_ballot) },),) }]<br>        )<br>    }<br>})</code>"]:::otherClass
+25v1["<div style=text-align:center>(25v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+26v1["<div style=text-align:center>(26v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+27v1["<div style=text-align:center>(27v1)</div> <code><br>tee()</code>"]:::otherClass
+28v1["<div style=text-align:center>(28v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+29v1["<div style=text-align:center>(29v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+30v1["<div style=text-align:center>(30v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+31v1["<div style=text-align:center>(31v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+32v1["<div style=text-align:center>(32v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_0 = stream_389;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_838_27!(<br>            [a_max_ballot_ref__free = __hydro_singleton_ref_0,] [| p2a | if p2a<br>            .ballot &gt;= * a_max_ballot_ref__free { Some((p2a.slot, LogValue { ballot :<br>            p2a.ballot, value : p2a.value, },)) } else { None }]<br>        )<br>    }<br>})</code>"]:::otherClass
 33v1["<div style=text-align:center>(33v1)</div> <code><br>chain()</code>"]:::otherClass
 34v1["<div style=text-align:center>(34v1)</div> <code><br>map(|x| (Some(x), None))</code>"]:::otherClass
 35v1["<div style=text-align:center>(35v1)</div> <code><br>map(|watermark| (None, Some(watermark)))</code>"]:::otherClass
-36v1["<div style=text-align:center>(36v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    || (::std::collections::HashMap::new(), None),<br>    {<br>        let __reduce_keyed_fn = {<br>            &num;[allow(unused_imports)]<br>            __stageleft_quote_src_cluster_paxos_rs_851_15!(<br>                [] [| prev_entry, entry | { if entry.ballot &gt; prev_entry.ballot { *<br>                prev_entry = LogValue { ballot : entry.ballot, value : entry.value,<br>                }; } }]<br>            )<br>        };<br>        move |(map, opt_curr_watermark), (opt_payload, opt_watermark)| {<br>            if let Some((k, v)) = opt_payload {<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if k &lt; curr_watermark {<br>                        return;<br>                    }<br>                }<br>                match map.entry(k) {<br>                    ::std::collections::hash_map::Entry::Vacant(e) =&gt; {<br>                        e.insert(v);<br>                    }<br>                    ::std::collections::hash_map::Entry::Occupied(mut e) =&gt; {<br>                        __reduce_keyed_fn(e.get_mut(), v);<br>                    }<br>                }<br>            } else {<br>                let watermark = opt_watermark.unwrap();<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if watermark &lt;= curr_watermark {<br>                        return;<br>                    }<br>                }<br>                map.retain(|k, _| *k &gt;= watermark);<br>                *opt_curr_watermark = Some(watermark);<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+36v1["<div style=text-align:center>(36v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    || (::std::collections::HashMap::new(), None),<br>    {<br>        let __reduce_keyed_fn = {<br>            &num;[allow(unused_imports)]<br>            __stageleft_quote_src_cluster_paxos_rs_852_15!(<br>                [] [| prev_entry, entry | { if entry.ballot &gt; prev_entry.ballot { *<br>                prev_entry = LogValue { ballot : entry.ballot, value : entry.value,<br>                }; } }]<br>            )<br>        };<br>        move |(map, opt_curr_watermark), (opt_payload, opt_watermark)| {<br>            if let Some((k, v)) = opt_payload {<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if k &lt; curr_watermark {<br>                        return;<br>                    }<br>                }<br>                match map.entry(k) {<br>                    ::std::collections::hash_map::Entry::Vacant(e) =&gt; {<br>                        e.insert(v);<br>                    }<br>                    ::std::collections::hash_map::Entry::Occupied(mut e) =&gt; {<br>                        __reduce_keyed_fn(e.get_mut(), v);<br>                    }<br>                }<br>            } else {<br>                let watermark = opt_watermark.unwrap();<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if watermark &lt;= curr_watermark {<br>                        return;<br>                    }<br>                }<br>                map.retain(|k, _| *k &gt;= watermark);<br>                *opt_curr_watermark = Some(watermark);<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
 37v1["<div style=text-align:center>(37v1)</div> <code><br>flat_map(|(map, _curr_watermark)| map)</code>"]:::otherClass
-38v1["<div style=text-align:center>(38v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_863_11!([] [| | HashMap::new()])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_865_12!(<br>            [] [| map, (slot, entry) | { map.insert(slot, entry); }]<br>        )<br>    },<br>)</code>"]:::otherClass
+38v1["<div style=text-align:center>(38v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_864_11!([] [| | HashMap::new()])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_866_12!(<br>            [] [| map, (slot, entry) | { map.insert(slot, entry); }]<br>        )<br>    },<br>)</code>"]:::otherClass
 39v1["<div style=text-align:center>(39v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
 40v1["<div style=text-align:center>(40v1)</div> <code><br>identity::&lt;<br>    (<br>        core::option::Option&lt;usize&gt;,<br>        std::collections::hash_map::HashMap&lt;<br>            usize,<br>            hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>            &gt;,<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
 41v1["<div style=text-align:center>(41v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
@@ -77,30 +76,27 @@ linkStyle default stroke:#aaa
 14v1-->15v1
 16v1-->17v1
 15v1-->16v1
-18v1-->19v1
-19v1-->20v1
+12v1-->19v1
 20v1-->21v1
-21v1-->|input|22v1
-12v1-->|single|22v1
+21v1-->22v1
 22v1-->23v1
-24v1-->25v1
 23v1-->24v1
-52v1-->26v1
-26v1-->27v1
-28v1-->29v1
-27v1-->|0|30v1
-29v1-->|1|30v1
-21v1-->|input|31v1
-12v1-->|single|31v1
-31v1-->32v1
+25v1-->26v1
+24v1-->25v1
+52v1-->27v1
+27v1-->28v1
+29v1-->30v1
+28v1-->|0|31v1
+30v1-->|1|31v1
+23v1-->32v1
 34v1-->|0|33v1
 32v1-->34v1
 35v1-->|1|33v1
-26v1-->35v1
+27v1-->35v1
 36v1-->37v1
 33v1-->36v1
 37v1-->38v1
-30v1-->|input|39v1
+31v1-->|input|39v1
 38v1-->|single|39v1
 39v1-->40v1
 41v1-->42v1
@@ -115,13 +111,16 @@ linkStyle default stroke:#aaa
 49v1-->50v1
 50v1-->51v1
 51v1-->52v1
+12v1-->24v1
+12v1-->32v1
 2v1
+25v1
+26v1
+19v1
 35v1
 34v1
 16v1
 17v1
-24v1
-25v1
 subgraph var_cycle_2 ["var <tt>cycle_2</tt>"]
     style var_cycle_2 fill:transparent
     52v1
@@ -130,8 +129,8 @@ subgraph var_cycle_4 ["var <tt>cycle_4</tt>"]
     style var_cycle_4 fill:transparent
     40v1
 end
-subgraph var_reduce_keyed_watermark_chain_524 ["var <tt>reduce_keyed_watermark_chain_524</tt>"]
-    style var_reduce_keyed_watermark_chain_524 fill:transparent
+subgraph var_reduce_keyed_watermark_chain_519 ["var <tt>reduce_keyed_watermark_chain_519</tt>"]
+    style var_reduce_keyed_watermark_chain_519 fill:transparent
     33v1
 end
 subgraph var_stream_162 ["var <tt>stream_162</tt>"]
@@ -184,103 +183,95 @@ subgraph var_stream_24 ["var <tt>stream_24</tt>"]
     style var_stream_24 fill:transparent
     1v1
 end
+subgraph var_stream_452 ["var <tt>stream_452</tt>"]
+    style var_stream_452 fill:transparent
+    20v1
+    21v1
+end
 subgraph var_stream_454 ["var <tt>stream_454</tt>"]
     style var_stream_454 fill:transparent
-    18v1
-    19v1
+    22v1
 end
 subgraph var_stream_456 ["var <tt>stream_456</tt>"]
     style var_stream_456 fill:transparent
-    20v1
-end
-subgraph var_stream_458 ["var <tt>stream_458</tt>"]
-    style var_stream_458 fill:transparent
-    21v1
-end
-subgraph var_stream_461 ["var <tt>stream_461</tt>"]
-    style var_stream_461 fill:transparent
-    22v1
-end
-subgraph var_stream_462 ["var <tt>stream_462</tt>"]
-    style var_stream_462 fill:transparent
     23v1
 end
-subgraph var_stream_509 ["var <tt>stream_509</tt>"]
-    style var_stream_509 fill:transparent
-    26v1
+subgraph var_stream_457 ["var <tt>stream_457</tt>"]
+    style var_stream_457 fill:transparent
+    24v1
+end
+subgraph var_stream_506 ["var <tt>stream_506</tt>"]
+    style var_stream_506 fill:transparent
+    27v1
+end
+subgraph var_stream_507 ["var <tt>stream_507</tt>"]
+    style var_stream_507 fill:transparent
+    28v1
+end
+subgraph var_stream_508 ["var <tt>stream_508</tt>"]
+    style var_stream_508 fill:transparent
+    29v1
+    30v1
 end
 subgraph var_stream_510 ["var <tt>stream_510</tt>"]
     style var_stream_510 fill:transparent
-    27v1
-end
-subgraph var_stream_511 ["var <tt>stream_511</tt>"]
-    style var_stream_511 fill:transparent
-    28v1
-    29v1
-end
-subgraph var_stream_513 ["var <tt>stream_513</tt>"]
-    style var_stream_513 fill:transparent
-    30v1
-end
-subgraph var_stream_518 ["var <tt>stream_518</tt>"]
-    style var_stream_518 fill:transparent
     31v1
+end
+subgraph var_stream_514 ["var <tt>stream_514</tt>"]
+    style var_stream_514 fill:transparent
+    32v1
 end
 subgraph var_stream_519 ["var <tt>stream_519</tt>"]
     style var_stream_519 fill:transparent
-    32v1
-end
-subgraph var_stream_524 ["var <tt>stream_524</tt>"]
-    style var_stream_524 fill:transparent
     36v1
     37v1
 end
-subgraph var_stream_528 ["var <tt>stream_528</tt>"]
-    style var_stream_528 fill:transparent
+subgraph var_stream_523 ["var <tt>stream_523</tt>"]
+    style var_stream_523 fill:transparent
     38v1
 end
-subgraph var_stream_529 ["var <tt>stream_529</tt>"]
-    style var_stream_529 fill:transparent
+subgraph var_stream_524 ["var <tt>stream_524</tt>"]
+    style var_stream_524 fill:transparent
     39v1
 end
-subgraph var_stream_641 ["var <tt>stream_641</tt>"]
-    style var_stream_641 fill:transparent
+subgraph var_stream_636 ["var <tt>stream_636</tt>"]
+    style var_stream_636 fill:transparent
     41v1
     42v1
 end
-subgraph var_stream_642 ["var <tt>stream_642</tt>"]
-    style var_stream_642 fill:transparent
+subgraph var_stream_637 ["var <tt>stream_637</tt>"]
+    style var_stream_637 fill:transparent
     43v1
 end
-subgraph var_stream_644 ["var <tt>stream_644</tt>"]
-    style var_stream_644 fill:transparent
+subgraph var_stream_639 ["var <tt>stream_639</tt>"]
+    style var_stream_639 fill:transparent
     44v1
+end
+subgraph var_stream_646 ["var <tt>stream_646</tt>"]
+    style var_stream_646 fill:transparent
+    45v1
+end
+subgraph var_stream_647 ["var <tt>stream_647</tt>"]
+    style var_stream_647 fill:transparent
+    46v1
+end
+subgraph var_stream_648 ["var <tt>stream_648</tt>"]
+    style var_stream_648 fill:transparent
+    47v1
+end
+subgraph var_stream_649 ["var <tt>stream_649</tt>"]
+    style var_stream_649 fill:transparent
+    48v1
+end
+subgraph var_stream_650 ["var <tt>stream_650</tt>"]
+    style var_stream_650 fill:transparent
+    49v1
 end
 subgraph var_stream_651 ["var <tt>stream_651</tt>"]
     style var_stream_651 fill:transparent
-    45v1
-end
-subgraph var_stream_652 ["var <tt>stream_652</tt>"]
-    style var_stream_652 fill:transparent
-    46v1
+    50v1
 end
 subgraph var_stream_653 ["var <tt>stream_653</tt>"]
     style var_stream_653 fill:transparent
-    47v1
-end
-subgraph var_stream_654 ["var <tt>stream_654</tt>"]
-    style var_stream_654 fill:transparent
-    48v1
-end
-subgraph var_stream_655 ["var <tt>stream_655</tt>"]
-    style var_stream_655 fill:transparent
-    49v1
-end
-subgraph var_stream_656 ["var <tt>stream_656</tt>"]
-    style var_stream_656 fill:transparent
-    50v1
-end
-subgraph var_stream_658 ["var <tt>stream_658</tt>"]
-    style var_stream_658 fill:transparent
     51v1
 end

--- a/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
@@ -20,45 +20,45 @@ linkStyle default stroke:#aaa
 10v1["<div style=text-align:center>(10v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 11v1["<div style=text-align:center>(11v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
 12v1["<div style=text-align:center>(12v1)</div> <code><br>tee()</code>"]:::otherClass
-13v1["<div style=text-align:center>(13v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-14v1["<div style=text-align:center>(14v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-15v1["<div style=text-align:center>(15v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_498_20!(<br>        [] [| ((ballot, max_ballot), log) | (ballot.proposer_id.clone(), (ballot<br>        .clone(), if ballot == max_ballot { Ok(log) } else { Err(max_ballot) }))]<br>    )<br>})</code>"]:::otherClass
-16v1["<div style=text-align:center>(16v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-17v1["<div style=text-align:center>(17v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-19v1["<div style=text-align:center>(19v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
-20v1["<div style=text-align:center>(20v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-21v1["<div style=text-align:center>(21v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::P2a&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>                hydro_test::__staged::cluster::paxos::Proposer,<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-22v1["<div style=text-align:center>(22v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
-23v1["<div style=text-align:center>(23v1)</div> <code><br>tee()</code>"]:::otherClass
-24v1["<div style=text-align:center>(24v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_389;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_874_16!(<br>            [a_max_ballot_ref__free = __hydro_singleton_ref_0,] [| p2a | { let<br>            max_ballot = a_max_ballot_ref__free.clone(); (p2a.sender, ((p2a.slot, p2a<br>            .ballot.clone()), if p2a.ballot == max_ballot { Ok(()) } else {<br>            Err(max_ballot) },),) }]<br>        )<br>    }<br>})</code>"]:::otherClass
-25v1["<div style=text-align:center>(25v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-26v1["<div style=text-align:center>(26v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-27v1["<div style=text-align:center>(27v1)</div> <code><br>tee()</code>"]:::otherClass
-28v1["<div style=text-align:center>(28v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
-29v1["<div style=text-align:center>(29v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-30v1["<div style=text-align:center>(30v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-31v1["<div style=text-align:center>(31v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-32v1["<div style=text-align:center>(32v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_0 = stream_389;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_838_27!(<br>            [a_max_ballot_ref__free = __hydro_singleton_ref_0,] [| p2a | if p2a<br>            .ballot &gt;= * a_max_ballot_ref__free { Some((p2a.slot, LogValue { ballot :<br>            p2a.ballot, value : p2a.value, },)) } else { None }]<br>        )<br>    }<br>})</code>"]:::otherClass
-33v1["<div style=text-align:center>(33v1)</div> <code><br>chain()</code>"]:::otherClass
-34v1["<div style=text-align:center>(34v1)</div> <code><br>map(|x| (Some(x), None))</code>"]:::otherClass
-35v1["<div style=text-align:center>(35v1)</div> <code><br>map(|watermark| (None, Some(watermark)))</code>"]:::otherClass
-36v1["<div style=text-align:center>(36v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    || (::std::collections::HashMap::new(), None),<br>    {<br>        let __reduce_keyed_fn = {<br>            &num;[allow(unused_imports)]<br>            __stageleft_quote_src_cluster_paxos_rs_852_15!(<br>                [] [| prev_entry, entry | { if entry.ballot &gt; prev_entry.ballot { *<br>                prev_entry = LogValue { ballot : entry.ballot, value : entry.value,<br>                }; } }]<br>            )<br>        };<br>        move |(map, opt_curr_watermark), (opt_payload, opt_watermark)| {<br>            if let Some((k, v)) = opt_payload {<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if k &lt; curr_watermark {<br>                        return;<br>                    }<br>                }<br>                match map.entry(k) {<br>                    ::std::collections::hash_map::Entry::Vacant(e) =&gt; {<br>                        e.insert(v);<br>                    }<br>                    ::std::collections::hash_map::Entry::Occupied(mut e) =&gt; {<br>                        __reduce_keyed_fn(e.get_mut(), v);<br>                    }<br>                }<br>            } else {<br>                let watermark = opt_watermark.unwrap();<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if watermark &lt;= curr_watermark {<br>                        return;<br>                    }<br>                }<br>                map.retain(|k, _| *k &gt;= watermark);<br>                *opt_curr_watermark = Some(watermark);<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-37v1["<div style=text-align:center>(37v1)</div> <code><br>flat_map(|(map, _curr_watermark)| map)</code>"]:::otherClass
-38v1["<div style=text-align:center>(38v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_864_11!([] [| | HashMap::new()])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_866_12!(<br>            [] [| map, (slot, entry) | { map.insert(slot, entry); }]<br>        )<br>    },<br>)</code>"]:::otherClass
-39v1["<div style=text-align:center>(39v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-40v1["<div style=text-align:center>(40v1)</div> <code><br>identity::&lt;<br>    (<br>        core::option::Option&lt;usize&gt;,<br>        std::collections::hash_map::HashMap&lt;<br>            usize,<br>            hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>            &gt;,<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
-41v1["<div style=text-align:center>(41v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-42v1["<div style=text-align:center>(42v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::kv_replica::Replica,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;usize&gt;(&amp;b).unwrap(),<br>    )<br>})</code>"]:::otherClass
-43v1["<div style=text-align:center>(43v1)</div> <code><br>reduce_keyed::&lt;<br>    'static,<br>&gt;({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_bench_rs_73_24!(<br>        [] [| curr_seq, seq | { if seq &gt; * curr_seq { * curr_seq = seq; } }]<br>    )<br>})</code>"]:::otherClass
-44v1["<div style=text-align:center>(44v1)</div> <code><br>tee()</code>"]:::otherClass
-45v1["<div style=text-align:center>(45v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2427_15!(<br>            [] [| | 0usize]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2429_16!(<br>            [] [| count, _ | * count += 1]<br>        )<br>    },<br>)</code>"]:::otherClass
-46v1["<div style=text-align:center>(46v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_bench_rs_90_32!(<br>        [f__free = 1usize,] [move | num_received | num_received == f__free + 1]<br>    )<br>})</code>"]:::otherClass
-47v1["<div style=text-align:center>(47v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1053_46!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-48v1["<div style=text-align:center>(48v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-49v1["<div style=text-align:center>(49v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-50v1["<div style=text-align:center>(50v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_bench_rs_96_32!([] [| (_sender, seq) | seq])<br>})</code>"]:::otherClass
-51v1["<div style=text-align:center>(51v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1553_23!(<br>        [] [| curr, new | { if new &lt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
-52v1["<div style=text-align:center>(52v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
+14v1["<div style=text-align:center>(14v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+16v1["<div style=text-align:center>(16v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+17v1["<div style=text-align:center>(17v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_178;<br>    let __hydro_singleton_ref_1 = stream_175;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_498_20!(<br>            [a_log_ref__free = __hydro_singleton_ref_0, a_max_ballot_ref__free =<br>            __hydro_singleton_ref_1,] [| ballot | { let max_ballot =<br>            a_max_ballot_ref__free.clone(); let log = a_log_ref__free.clone();<br>            (ballot.proposer_id.clone(), (ballot.clone(), if ballot == max_ballot {<br>            Ok(log) } else { Err(max_ballot) },),) }]<br>        )<br>    }<br>})</code>"]:::otherClass
+18v1["<div style=text-align:center>(18v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+19v1["<div style=text-align:center>(19v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+21v1["<div style=text-align:center>(21v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+22v1["<div style=text-align:center>(22v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+23v1["<div style=text-align:center>(23v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::P2a&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>                hydro_test::__staged::cluster::paxos::Proposer,<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+24v1["<div style=text-align:center>(24v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
+25v1["<div style=text-align:center>(25v1)</div> <code><br>tee()</code>"]:::otherClass
+26v1["<div style=text-align:center>(26v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_391;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_878_16!(<br>            [a_max_ballot_ref__free = __hydro_singleton_ref_0,] [| p2a | { let<br>            max_ballot = a_max_ballot_ref__free.clone(); (p2a.sender, ((p2a.slot, p2a<br>            .ballot.clone()), if p2a.ballot == max_ballot { Ok(()) } else {<br>            Err(max_ballot) },),) }]<br>        )<br>    }<br>})</code>"]:::otherClass
+27v1["<div style=text-align:center>(27v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+28v1["<div style=text-align:center>(28v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+29v1["<div style=text-align:center>(29v1)</div> <code><br>tee()</code>"]:::otherClass
+30v1["<div style=text-align:center>(30v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+31v1["<div style=text-align:center>(31v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+32v1["<div style=text-align:center>(32v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+33v1["<div style=text-align:center>(33v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+34v1["<div style=text-align:center>(34v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_0 = stream_391;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_842_27!(<br>            [a_max_ballot_ref__free = __hydro_singleton_ref_0,] [| p2a | if p2a<br>            .ballot &gt;= * a_max_ballot_ref__free { Some((p2a.slot, LogValue { ballot :<br>            p2a.ballot, value : p2a.value, },)) } else { None }]<br>        )<br>    }<br>})</code>"]:::otherClass
+35v1["<div style=text-align:center>(35v1)</div> <code><br>chain()</code>"]:::otherClass
+36v1["<div style=text-align:center>(36v1)</div> <code><br>map(|x| (Some(x), None))</code>"]:::otherClass
+37v1["<div style=text-align:center>(37v1)</div> <code><br>map(|watermark| (None, Some(watermark)))</code>"]:::otherClass
+38v1["<div style=text-align:center>(38v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    || (::std::collections::HashMap::new(), None),<br>    {<br>        let __reduce_keyed_fn = {<br>            &num;[allow(unused_imports)]<br>            __stageleft_quote_src_cluster_paxos_rs_856_15!(<br>                [] [| prev_entry, entry | { if entry.ballot &gt; prev_entry.ballot { *<br>                prev_entry = LogValue { ballot : entry.ballot, value : entry.value,<br>                }; } }]<br>            )<br>        };<br>        move |(map, opt_curr_watermark), (opt_payload, opt_watermark)| {<br>            if let Some((k, v)) = opt_payload {<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if k &lt; curr_watermark {<br>                        return;<br>                    }<br>                }<br>                match map.entry(k) {<br>                    ::std::collections::hash_map::Entry::Vacant(e) =&gt; {<br>                        e.insert(v);<br>                    }<br>                    ::std::collections::hash_map::Entry::Occupied(mut e) =&gt; {<br>                        __reduce_keyed_fn(e.get_mut(), v);<br>                    }<br>                }<br>            } else {<br>                let watermark = opt_watermark.unwrap();<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if watermark &lt;= curr_watermark {<br>                        return;<br>                    }<br>                }<br>                map.retain(|k, _| *k &gt;= watermark);<br>                *opt_curr_watermark = Some(watermark);<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+39v1["<div style=text-align:center>(39v1)</div> <code><br>flat_map(|(map, _curr_watermark)| map)</code>"]:::otherClass
+40v1["<div style=text-align:center>(40v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_868_11!([] [| | HashMap::new()])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_870_12!(<br>            [] [| map, (slot, entry) | { map.insert(slot, entry); }]<br>        )<br>    },<br>)</code>"]:::otherClass
+41v1["<div style=text-align:center>(41v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+42v1["<div style=text-align:center>(42v1)</div> <code><br>identity::&lt;<br>    (<br>        core::option::Option&lt;usize&gt;,<br>        std::collections::hash_map::HashMap&lt;<br>            usize,<br>            hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>            &gt;,<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
+43v1["<div style=text-align:center>(43v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+44v1["<div style=text-align:center>(44v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::kv_replica::Replica,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;usize&gt;(&amp;b).unwrap(),<br>    )<br>})</code>"]:::otherClass
+45v1["<div style=text-align:center>(45v1)</div> <code><br>reduce_keyed::&lt;<br>    'static,<br>&gt;({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_bench_rs_73_24!(<br>        [] [| curr_seq, seq | { if seq &gt; * curr_seq { * curr_seq = seq; } }]<br>    )<br>})</code>"]:::otherClass
+46v1["<div style=text-align:center>(46v1)</div> <code><br>tee()</code>"]:::otherClass
+47v1["<div style=text-align:center>(47v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2427_15!(<br>            [] [| | 0usize]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2429_16!(<br>            [] [| count, _ | * count += 1]<br>        )<br>    },<br>)</code>"]:::otherClass
+48v1["<div style=text-align:center>(48v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_bench_rs_90_32!(<br>        [f__free = 1usize,] [move | num_received | num_received == f__free + 1]<br>    )<br>})</code>"]:::otherClass
+49v1["<div style=text-align:center>(49v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1053_46!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+50v1["<div style=text-align:center>(50v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+51v1["<div style=text-align:center>(51v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+52v1["<div style=text-align:center>(52v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_bench_rs_96_32!([] [| (_sender, seq) | seq])<br>})</code>"]:::otherClass
+53v1["<div style=text-align:center>(53v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1553_23!(<br>        [] [| curr, new | { if new &lt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
+54v1["<div style=text-align:center>(54v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
 1v1-->2v1
 3v1-->4v1
 4v1-->5v1
@@ -69,190 +69,176 @@ linkStyle default stroke:#aaa
 8v1-->|0|11v1
 10v1-->|1|11v1
 11v1-->12v1
-6v1-->|input|13v1
-12v1-->|single|13v1
-13v1-->|input|14v1
-40v1-->|single|14v1
-14v1-->15v1
-16v1-->17v1
-15v1-->16v1
-12v1-->19v1
-20v1-->21v1
-21v1-->22v1
+12v1-->14v1
+42v1-->16v1
+6v1-->17v1
+18v1-->19v1
+17v1-->18v1
+12v1-->21v1
 22v1-->23v1
 23v1-->24v1
-25v1-->26v1
 24v1-->25v1
-52v1-->27v1
+25v1-->26v1
 27v1-->28v1
+26v1-->27v1
+54v1-->29v1
 29v1-->30v1
-28v1-->|0|31v1
-30v1-->|1|31v1
-23v1-->32v1
-34v1-->|0|33v1
-32v1-->34v1
-35v1-->|1|33v1
-27v1-->35v1
-36v1-->37v1
-33v1-->36v1
-37v1-->38v1
-31v1-->|input|39v1
-38v1-->|single|39v1
+31v1-->32v1
+30v1-->|0|33v1
+32v1-->|1|33v1
+25v1-->34v1
+36v1-->|0|35v1
+34v1-->36v1
+37v1-->|1|35v1
+29v1-->37v1
+38v1-->39v1
+35v1-->38v1
 39v1-->40v1
+33v1-->|input|41v1
+40v1-->|single|41v1
 41v1-->42v1
-42v1-->43v1
 43v1-->44v1
 44v1-->45v1
 45v1-->46v1
 46v1-->47v1
-44v1-->|input|48v1
-47v1-->|single|48v1
+47v1-->48v1
 48v1-->49v1
-49v1-->50v1
+46v1-->|input|50v1
+49v1-->|single|50v1
 50v1-->51v1
 51v1-->52v1
-12v1-->24v1
-12v1-->32v1
+52v1-->53v1
+53v1-->54v1
+42v1-->17v1
+12v1-->17v1
+12v1-->26v1
+12v1-->34v1
 2v1
-25v1
-26v1
+27v1
+28v1
+37v1
+36v1
+18v1
 19v1
-35v1
-34v1
+14v1
 16v1
-17v1
+21v1
 subgraph var_cycle_2 ["var <tt>cycle_2</tt>"]
     style var_cycle_2 fill:transparent
-    52v1
+    54v1
 end
 subgraph var_cycle_4 ["var <tt>cycle_4</tt>"]
     style var_cycle_4 fill:transparent
-    40v1
+    42v1
 end
-subgraph var_reduce_keyed_watermark_chain_519 ["var <tt>reduce_keyed_watermark_chain_519</tt>"]
-    style var_reduce_keyed_watermark_chain_519 fill:transparent
-    33v1
+subgraph var_reduce_keyed_watermark_chain_521 ["var <tt>reduce_keyed_watermark_chain_521</tt>"]
+    style var_reduce_keyed_watermark_chain_521 fill:transparent
+    35v1
 end
-subgraph var_stream_162 ["var <tt>stream_162</tt>"]
-    style var_stream_162 fill:transparent
+subgraph var_stream_160 ["var <tt>stream_160</tt>"]
+    style var_stream_160 fill:transparent
     3v1
     4v1
 end
-subgraph var_stream_164 ["var <tt>stream_164</tt>"]
-    style var_stream_164 fill:transparent
+subgraph var_stream_162 ["var <tt>stream_162</tt>"]
+    style var_stream_162 fill:transparent
     5v1
 end
-subgraph var_stream_166 ["var <tt>stream_166</tt>"]
-    style var_stream_166 fill:transparent
+subgraph var_stream_164 ["var <tt>stream_164</tt>"]
+    style var_stream_164 fill:transparent
     6v1
+end
+subgraph var_stream_165 ["var <tt>stream_165</tt>"]
+    style var_stream_165 fill:transparent
+    7v1
 end
 subgraph var_stream_168 ["var <tt>stream_168</tt>"]
     style var_stream_168 fill:transparent
-    7v1
-end
-subgraph var_stream_171 ["var <tt>stream_171</tt>"]
-    style var_stream_171 fill:transparent
     8v1
 end
-subgraph var_stream_173 ["var <tt>stream_173</tt>"]
-    style var_stream_173 fill:transparent
+subgraph var_stream_170 ["var <tt>stream_170</tt>"]
+    style var_stream_170 fill:transparent
     9v1
     10v1
 end
-subgraph var_stream_175 ["var <tt>stream_175</tt>"]
-    style var_stream_175 fill:transparent
+subgraph var_stream_172 ["var <tt>stream_172</tt>"]
+    style var_stream_172 fill:transparent
     11v1
 end
-subgraph var_stream_177 ["var <tt>stream_177</tt>"]
-    style var_stream_177 fill:transparent
+subgraph var_stream_174 ["var <tt>stream_174</tt>"]
+    style var_stream_174 fill:transparent
     12v1
 end
-subgraph var_stream_179 ["var <tt>stream_179</tt>"]
-    style var_stream_179 fill:transparent
-    13v1
-end
-subgraph var_stream_182 ["var <tt>stream_182</tt>"]
-    style var_stream_182 fill:transparent
-    14v1
-end
-subgraph var_stream_183 ["var <tt>stream_183</tt>"]
-    style var_stream_183 fill:transparent
-    15v1
+subgraph var_stream_185 ["var <tt>stream_185</tt>"]
+    style var_stream_185 fill:transparent
+    17v1
 end
 subgraph var_stream_24 ["var <tt>stream_24</tt>"]
     style var_stream_24 fill:transparent
     1v1
 end
-subgraph var_stream_452 ["var <tt>stream_452</tt>"]
-    style var_stream_452 fill:transparent
-    20v1
-    21v1
-end
 subgraph var_stream_454 ["var <tt>stream_454</tt>"]
     style var_stream_454 fill:transparent
     22v1
+    23v1
 end
 subgraph var_stream_456 ["var <tt>stream_456</tt>"]
     style var_stream_456 fill:transparent
-    23v1
-end
-subgraph var_stream_457 ["var <tt>stream_457</tt>"]
-    style var_stream_457 fill:transparent
     24v1
 end
-subgraph var_stream_506 ["var <tt>stream_506</tt>"]
-    style var_stream_506 fill:transparent
-    27v1
+subgraph var_stream_458 ["var <tt>stream_458</tt>"]
+    style var_stream_458 fill:transparent
+    25v1
 end
-subgraph var_stream_507 ["var <tt>stream_507</tt>"]
-    style var_stream_507 fill:transparent
-    28v1
+subgraph var_stream_459 ["var <tt>stream_459</tt>"]
+    style var_stream_459 fill:transparent
+    26v1
 end
 subgraph var_stream_508 ["var <tt>stream_508</tt>"]
     style var_stream_508 fill:transparent
     29v1
+end
+subgraph var_stream_509 ["var <tt>stream_509</tt>"]
+    style var_stream_509 fill:transparent
     30v1
 end
 subgraph var_stream_510 ["var <tt>stream_510</tt>"]
     style var_stream_510 fill:transparent
     31v1
-end
-subgraph var_stream_514 ["var <tt>stream_514</tt>"]
-    style var_stream_514 fill:transparent
     32v1
 end
-subgraph var_stream_519 ["var <tt>stream_519</tt>"]
-    style var_stream_519 fill:transparent
-    36v1
-    37v1
+subgraph var_stream_512 ["var <tt>stream_512</tt>"]
+    style var_stream_512 fill:transparent
+    33v1
 end
-subgraph var_stream_523 ["var <tt>stream_523</tt>"]
-    style var_stream_523 fill:transparent
+subgraph var_stream_516 ["var <tt>stream_516</tt>"]
+    style var_stream_516 fill:transparent
+    34v1
+end
+subgraph var_stream_521 ["var <tt>stream_521</tt>"]
+    style var_stream_521 fill:transparent
     38v1
-end
-subgraph var_stream_524 ["var <tt>stream_524</tt>"]
-    style var_stream_524 fill:transparent
     39v1
 end
-subgraph var_stream_636 ["var <tt>stream_636</tt>"]
-    style var_stream_636 fill:transparent
-    41v1
-    42v1
+subgraph var_stream_525 ["var <tt>stream_525</tt>"]
+    style var_stream_525 fill:transparent
+    40v1
 end
-subgraph var_stream_637 ["var <tt>stream_637</tt>"]
-    style var_stream_637 fill:transparent
+subgraph var_stream_526 ["var <tt>stream_526</tt>"]
+    style var_stream_526 fill:transparent
+    41v1
+end
+subgraph var_stream_638 ["var <tt>stream_638</tt>"]
+    style var_stream_638 fill:transparent
     43v1
+    44v1
 end
 subgraph var_stream_639 ["var <tt>stream_639</tt>"]
     style var_stream_639 fill:transparent
-    44v1
-end
-subgraph var_stream_646 ["var <tt>stream_646</tt>"]
-    style var_stream_646 fill:transparent
     45v1
 end
-subgraph var_stream_647 ["var <tt>stream_647</tt>"]
-    style var_stream_647 fill:transparent
+subgraph var_stream_641 ["var <tt>stream_641</tt>"]
+    style var_stream_641 fill:transparent
     46v1
 end
 subgraph var_stream_648 ["var <tt>stream_648</tt>"]
@@ -271,7 +257,15 @@ subgraph var_stream_651 ["var <tt>stream_651</tt>"]
     style var_stream_651 fill:transparent
     50v1
 end
+subgraph var_stream_652 ["var <tt>stream_652</tt>"]
+    style var_stream_652 fill:transparent
+    51v1
+end
 subgraph var_stream_653 ["var <tt>stream_653</tt>"]
     style var_stream_653 fill:transparent
-    51v1
+    52v1
+end
+subgraph var_stream_655 ["var <tt>stream_655</tt>"]
+    style var_stream_655 fill:transparent
+    53v1
 end

--- a/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
@@ -163,119 +163,114 @@ linkStyle default stroke:#aaa
 153v1["<div style=text-align:center>(153v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 154v1["<div style=text-align:center>(154v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
 155v1["<div style=text-align:center>(155v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-156v1["<div style=text-align:center>(156v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-157v1["<div style=text-align:center>(157v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos_bench::Client,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-158v1["<div style=text-align:center>(158v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
-159v1["<div style=text-align:center>(159v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1053_46!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-160v1["<div style=text-align:center>(160v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-161v1["<div style=text-align:center>(161v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-162v1["<div style=text-align:center>(162v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
-163v1["<div style=text-align:center>(163v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_571_35!(<br>        [] [| v | v]<br>    )<br>})</code>"]:::otherClass
+157v1["<div style=text-align:center>(157v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+158v1["<div style=text-align:center>(158v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_571_35!(<br>        [] [| v | v]<br>    )<br>})</code>"]:::otherClass
+159v1["<div style=text-align:center>(159v1)</div> <code><br>tee()</code>"]:::otherClass
+160v1["<div style=text-align:center>(160v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_604_16!([] [| (_checkpoint, log) | log])<br>})</code>"]:::otherClass
+161v1["<div style=text-align:center>(161v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_764_35!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
+162v1["<div style=text-align:center>(162v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_607_67!([] [| | (0, None)])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_607_85!(<br>            [] [| curr_entry, new_entry | { if let Some(curr_entry_payload) = &amp; mut<br>            curr_entry.1 { let same_values = new_entry.value == curr_entry_payload<br>            .value; let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>            if same_values { curr_entry.0 += 1; } if higher_ballot {<br>            curr_entry_payload.ballot = new_entry.ballot; if ! same_values {<br>            curr_entry.0 = 1; curr_entry_payload.value = new_entry.value; } } } else<br>            { * curr_entry = (1, Some(new_entry)); } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+163v1["<div style=text-align:center>(163v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_484_23!(<br>        [f__free = stageleft::runtime_support::fn1_type_hint:: &lt; (usize,<br>        core::option::Option &lt; hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), (usize,<br>        hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt;) &gt; ({ use crate<br>        ::__staged::__deps:: *; use crate ::__staged::cluster::paxos:: *;<br>        &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_628_16!([] [| (count, entry) | (count,<br>        entry.unwrap())]) }),] [{ let orig = f__free; move | (k, v) | (k, orig(v)) }]<br>    )<br>})</code>"]:::otherClass
 164v1["<div style=text-align:center>(164v1)</div> <code><br>tee()</code>"]:::otherClass
-165v1["<div style=text-align:center>(165v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_604_16!([] [| (_checkpoint, log) | log])<br>})</code>"]:::otherClass
-166v1["<div style=text-align:center>(166v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_764_35!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
-167v1["<div style=text-align:center>(167v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_607_67!([] [| | (0, None)])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_607_85!(<br>            [] [| curr_entry, new_entry | { if let Some(curr_entry_payload) = &amp; mut<br>            curr_entry.1 { let same_values = new_entry.value == curr_entry_payload<br>            .value; let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>            if same_values { curr_entry.0 += 1; } if higher_ballot {<br>            curr_entry_payload.ballot = new_entry.ballot; if ! same_values {<br>            curr_entry.0 = 1; curr_entry_payload.value = new_entry.value; } } } else<br>            { * curr_entry = (1, Some(new_entry)); } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-168v1["<div style=text-align:center>(168v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_484_23!(<br>        [f__free = stageleft::runtime_support::fn1_type_hint:: &lt; (usize,<br>        core::option::Option &lt; hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), (usize,<br>        hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt;) &gt; ({ use crate<br>        ::__staged::__deps:: *; use crate ::__staged::cluster::paxos:: *;<br>        &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_628_16!([] [| (count, entry) | (count,<br>        entry.unwrap())]) }),] [{ let orig = f__free; move | (k, v) | (k, orig(v)) }]<br>    )<br>})</code>"]:::otherClass
-169v1["<div style=text-align:center>(169v1)</div> <code><br>tee()</code>"]:::otherClass
-170v1["<div style=text-align:center>(170v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-171v1["<div style=text-align:center>(171v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1519_23!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
-172v1["<div style=text-align:center>(172v1)</div> <code><br>tee()</code>"]:::otherClass
-173v1["<div style=text-align:center>(173v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_780_71!([] [| s | s + 1])<br>})</code>"]:::otherClass
-174v1["<div style=text-align:center>(174v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-175v1["<div style=text-align:center>(175v1)</div> <code><br>source_iter([<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_776_58!([] [0])<br>    },<br>])</code>"]:::otherClass
-176v1["<div style=text-align:center>(176v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-177v1["<div style=text-align:center>(177v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-178v1["<div style=text-align:center>(178v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-179v1["<div style=text-align:center>(179v1)</div> <code><br>tee()</code>"]:::otherClass
-180v1["<div style=text-align:center>(180v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-181v1["<div style=text-align:center>(181v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_786_20!(<br>        [] [| ((index, payload), base_slot) | (base_slot + index, payload)]<br>    )<br>})</code>"]:::otherClass
-182v1["<div style=text-align:center>(182v1)</div> <code><br>tee()</code>"]:::otherClass
-183v1["<div style=text-align:center>(183v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2427_15!(<br>            [] [| | 0usize]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2429_16!(<br>            [] [| count, _ | * count += 1]<br>        )<br>    },<br>)</code>"]:::otherClass
-184v1["<div style=text-align:center>(184v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-185v1["<div style=text-align:center>(185v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_794_20!(<br>        [] [| (num_payloads, base_slot) | base_slot + num_payloads]<br>    )<br>})</code>"]:::otherClass
-186v1["<div style=text-align:center>(186v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
-187v1["<div style=text-align:center>(187v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-188v1["<div style=text-align:center>(188v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-189v1["<div style=text-align:center>(189v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_545_16!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
-190v1["<div style=text-align:center>(190v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_36_11!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_37_11!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-191v1["<div style=text-align:center>(191v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_1187_61!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-192v1["<div style=text-align:center>(192v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-193v1["<div style=text-align:center>(193v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-194v1["<div style=text-align:center>(194v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_721_16!(<br>        [] [| ((slot, payload), ballot) | ((slot, ballot), Some(payload))]<br>    )<br>})</code>"]:::otherClass
-195v1["<div style=text-align:center>(195v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+165v1["<div style=text-align:center>(165v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+166v1["<div style=text-align:center>(166v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1519_23!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
+167v1["<div style=text-align:center>(167v1)</div> <code><br>tee()</code>"]:::otherClass
+168v1["<div style=text-align:center>(168v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_779_71!([] [| s | s + 1])<br>})</code>"]:::otherClass
+169v1["<div style=text-align:center>(169v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+170v1["<div style=text-align:center>(170v1)</div> <code><br>source_iter([<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_775_58!([] [0])<br>    },<br>])</code>"]:::otherClass
+171v1["<div style=text-align:center>(171v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+172v1["<div style=text-align:center>(172v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+173v1["<div style=text-align:center>(173v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+175v1["<div style=text-align:center>(175v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+176v1["<div style=text-align:center>(176v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos_bench::Client,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+177v1["<div style=text-align:center>(177v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
+178v1["<div style=text-align:center>(178v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1053_46!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+179v1["<div style=text-align:center>(179v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+180v1["<div style=text-align:center>(180v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+181v1["<div style=text-align:center>(181v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
+182v1["<div style=text-align:center>(182v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_362;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_785_20!(<br>            [base_slot_ref__free = __hydro_singleton_ref_0,] [| (index, payload) | (*<br>            base_slot_ref__free + index, payload)]<br>        )<br>    }<br>})</code>"]:::otherClass
+183v1["<div style=text-align:center>(183v1)</div> <code><br>tee()</code>"]:::otherClass
+184v1["<div style=text-align:center>(184v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2427_15!(<br>            [] [| | 0usize]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2429_16!(<br>            [] [| count, _ | * count += 1]<br>        )<br>    },<br>)</code>"]:::otherClass
+185v1["<div style=text-align:center>(185v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+186v1["<div style=text-align:center>(186v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_793_20!(<br>        [] [| (num_payloads, base_slot) | base_slot + num_payloads]<br>    )<br>})</code>"]:::otherClass
+187v1["<div style=text-align:center>(187v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
+188v1["<div style=text-align:center>(188v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+189v1["<div style=text-align:center>(189v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+190v1["<div style=text-align:center>(190v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_545_16!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
+191v1["<div style=text-align:center>(191v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_36_11!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_37_11!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+192v1["<div style=text-align:center>(192v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_1187_61!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+193v1["<div style=text-align:center>(193v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+195v1["<div style=text-align:center>(195v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_405;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_720_16!(<br>            [p_ballot_ref__free = __hydro_singleton_ref_0,] [| (slot, payload) |<br>            ((slot, p_ballot_ref__free.clone()), Some(payload))]<br>        )<br>    }<br>})</code>"]:::otherClass
 196v1["<div style=text-align:center>(196v1)</div> <code><br>filter_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_600_23!(<br>        [] [| (checkpoint, _log) | checkpoint]<br>    )<br>})</code>"]:::otherClass
 197v1["<div style=text-align:center>(197v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1519_23!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
 198v1["<div style=text-align:center>(198v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
 199v1["<div style=text-align:center>(199v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
 200v1["<div style=text-align:center>(200v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 201v1["<div style=text-align:center>(201v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-202v1["<div style=text-align:center>(202v1)</div> <code><br>tee()</code>"]:::otherClass
-203v1["<div style=text-align:center>(203v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-204v1["<div style=text-align:center>(204v1)</div> <code><br>filter_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_634_23!(<br>        [f__free = 1usize,] [move | (((slot, (count, entry)), ballot), checkpoint) |<br>        { if count &gt; f__free { return None; } else if let Some(checkpoint) =<br>        checkpoint &amp;&amp; slot &lt;= checkpoint { return None; } Some(((slot, ballot), entry<br>        .value)) }]<br>    )<br>})</code>"]:::otherClass
-205v1["<div style=text-align:center>(205v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-206v1["<div style=text-align:center>(206v1)</div> <code><br>flat_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_649_29!(<br>        [] [| (max_slot, checkpoint) | { if let Some(checkpoint) = checkpoint {<br>        (checkpoint + 1)..max_slot } else { 0..max_slot } }]<br>    )<br>})</code>"]:::otherClass
-207v1["<div style=text-align:center>(207v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-208v1["<div style=text-align:center>(208v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-209v1["<div style=text-align:center>(209v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-210v1["<div style=text-align:center>(210v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_658_16!(<br>        [] [move | (slot, ballot) | ((slot, ballot), None)]<br>    )<br>})</code>"]:::otherClass
-211v1["<div style=text-align:center>(211v1)</div> <code><br>chain()</code>"]:::otherClass
-212v1["<div style=text-align:center>(212v1)</div> <code><br>chain()</code>"]:::otherClass
-213v1["<div style=text-align:center>(213v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1053_46!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-214v1["<div style=text-align:center>(214v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-215v1["<div style=text-align:center>(215v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-216v1["<div style=text-align:center>(216v1)</div> <code><br>tee()</code>"]:::otherClass
-217v1["<div style=text-align:center>(217v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_735_20!(<br>        [CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),] [move |<br>        ((slot, ballot), value) | P2a { sender : CLUSTER_SELF_ID__free.clone(),<br>        ballot, slot, value }]<br>    )<br>})</code>"]:::otherClass
-218v1["<div style=text-align:center>(218v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-219v1["<div style=text-align:center>(219v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-220v1["<div style=text-align:center>(220v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-221v1["<div style=text-align:center>(221v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-222v1["<div style=text-align:center>(222v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>                core::result::Result&lt;<br>                    (),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-223v1["<div style=text-align:center>(223v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
+203v1["<div style=text-align:center>(203v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_0 = stream_332;<br>    let __hydro_singleton_ref_1 = stream_420;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_634_23!(<br>            [f__free = 1usize, p_ballot_ref__free = __hydro_singleton_ref_0,<br>            p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1,] [move | (slot,<br>            (count, entry)) | { if count &gt; f__free { return None; } else if let<br>            Some(checkpoint) = * p_p1b_max_checkpoint_ref__free &amp;&amp; slot &lt;= checkpoint<br>            { return None; } Some(((slot, p_ballot_ref__free.clone()), entry.value))<br>            }]<br>        )<br>    }<br>})</code>"]:::otherClass
+204v1["<div style=text-align:center>(204v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+205v1["<div style=text-align:center>(205v1)</div> <code><br>flat_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_649_29!(<br>        [] [| (max_slot, checkpoint) | { if let Some(checkpoint) = checkpoint {<br>        (checkpoint + 1)..max_slot } else { 0..max_slot } }]<br>    )<br>})</code>"]:::otherClass
+206v1["<div style=text-align:center>(206v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+207v1["<div style=text-align:center>(207v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+208v1["<div style=text-align:center>(208v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_332;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_657_16!(<br>            [p_ballot_ref__free = __hydro_singleton_ref_0,] [move | slot | ((slot,<br>            p_ballot_ref__free.clone()), None)]<br>        )<br>    }<br>})</code>"]:::otherClass
+209v1["<div style=text-align:center>(209v1)</div> <code><br>chain()</code>"]:::otherClass
+210v1["<div style=text-align:center>(210v1)</div> <code><br>chain()</code>"]:::otherClass
+211v1["<div style=text-align:center>(211v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1053_46!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+212v1["<div style=text-align:center>(212v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+213v1["<div style=text-align:center>(213v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+214v1["<div style=text-align:center>(214v1)</div> <code><br>tee()</code>"]:::otherClass
+215v1["<div style=text-align:center>(215v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_734_20!(<br>        [CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),] [move |<br>        ((slot, ballot), value) | P2a { sender : CLUSTER_SELF_ID__free.clone(),<br>        ballot, slot, value }]<br>    )<br>})</code>"]:::otherClass
+216v1["<div style=text-align:center>(216v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+217v1["<div style=text-align:center>(217v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+218v1["<div style=text-align:center>(218v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+219v1["<div style=text-align:center>(219v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+220v1["<div style=text-align:center>(220v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>                core::result::Result&lt;<br>                    (),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+221v1["<div style=text-align:center>(221v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
+222v1["<div style=text-align:center>(222v1)</div> <code><br>tee()</code>"]:::otherClass
+223v1["<div style=text-align:center>(223v1)</div> <code><br>chain()</code>"]:::otherClass
 224v1["<div style=text-align:center>(224v1)</div> <code><br>tee()</code>"]:::otherClass
-225v1["<div style=text-align:center>(225v1)</div> <code><br>chain()</code>"]:::otherClass
+225v1["<div style=text-align:center>(225v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_109_15!([] [move | | (0, 0)])<br>    },<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_110_15!(<br>            [] [move | accum, value | { if value.is_ok() { accum.0 += 1; } else {<br>            accum.1 += 1; } }]<br>        )<br>    },<br>)</code>"]:::otherClass
 226v1["<div style=text-align:center>(226v1)</div> <code><br>tee()</code>"]:::otherClass
-227v1["<div style=text-align:center>(227v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_109_15!([] [move | | (0, 0)])<br>    },<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_110_15!(<br>            [] [move | accum, value | { if value.is_ok() { accum.0 += 1; } else {<br>            accum.1 += 1; } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-228v1["<div style=text-align:center>(228v1)</div> <code><br>tee()</code>"]:::otherClass
-229v1["<div style=text-align:center>(229v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; (usize,<br>        usize), bool &gt; ({ use hydro_std::__staged::__deps:: *; use<br>        hydro_std::__staged::quorum:: *;<br>        hydro_std::__stageleft_quote_src_quorum_rs_134_27!([max__free = 3usize,]<br>        [move | (success, error) | (success + error) &gt;= max__free]) }),] [{ let orig<br>        = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-230v1["<div style=text-align:center>(230v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-231v1["<div style=text-align:center>(231v1)</div> <code><br>tee()</code>"]:::otherClass
-232v1["<div style=text-align:center>(232v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-233v1["<div style=text-align:center>(233v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::result::Result&lt;(), hydro_test::__staged::cluster::paxos::Ballot&gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
-234v1["<div style=text-align:center>(234v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_122_27!(<br>        [min__free = 2usize,] [move | (key, (success, _error)) | if success &gt;=<br>        min__free { Some(key) } else { None }]<br>    )<br>})</code>"]:::otherClass
-235v1["<div style=text-align:center>(235v1)</div> <code><br>tee()</code>"]:::otherClass
-236v1["<div style=text-align:center>(236v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-237v1["<div style=text-align:center>(237v1)</div> <code><br>identity::&lt;(usize, hydro_test::__staged::cluster::paxos::Ballot)&gt;()</code>"]:::otherClass
-238v1["<div style=text-align:center>(238v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-239v1["<div style=text-align:center>(239v1)</div> <code><br>chain()</code>"]:::otherClass
-240v1["<div style=text-align:center>(240v1)</div> <code><br>tee()</code>"]:::otherClass
-241v1["<div style=text-align:center>(241v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-242v1["<div style=text-align:center>(242v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-243v1["<div style=text-align:center>(243v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_751_23!([] [| k | (k, ())])<br>})</code>"]:::otherClass
-244v1["<div style=text-align:center>(244v1)</div> <code><br>tee()</code>"]:::otherClass
-245v1["<div style=text-align:center>(245v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_39_78!(<br>        [] [| (key, _) | key]<br>    )<br>})</code>"]:::otherClass
-246v1["<div style=text-align:center>(246v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-247v1["<div style=text-align:center>(247v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::option::Option&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
-248v1["<div style=text-align:center>(248v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_151_32!(<br>        [] [move | (key, res) | match res { Ok(_) =&gt; None, Err(e) =&gt; Some((key, e)),<br>        }]<br>    )<br>})</code>"]:::otherClass
-249v1["<div style=text-align:center>(249v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_765_21!([] [| (_, ballot) | ballot])<br>})</code>"]:::otherClass
-250v1["<div style=text-align:center>(250v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
-251v1["<div style=text-align:center>(251v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_34!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-252v1["<div style=text-align:center>(252v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-253v1["<div style=text-align:center>(253v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_51!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-254v1["<div style=text-align:center>(254v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
-255v1["<div style=text-align:center>(255v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-256v1["<div style=text-align:center>(256v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_545_16!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
-257v1["<div style=text-align:center>(257v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_36_11!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_37_11!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-258v1["<div style=text-align:center>(258v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_1187_61!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-259v1["<div style=text-align:center>(259v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-260v1["<div style=text-align:center>(260v1)</div> <code><br>join_multiset_half::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-261v1["<div style=text-align:center>(261v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_37_20!(<br>        [] [| (key, (meta, resp)) | (key, (meta, resp))]<br>    )<br>})</code>"]:::otherClass
-262v1["<div style=text-align:center>(262v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_763_29!(<br>        [] [| ((slot, _ballot), (value, _)) | (slot, value)]<br>    )<br>})</code>"]:::otherClass
-263v1["<div style=text-align:center>(263v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-264v1["<div style=text-align:center>(264v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-265v1["<div style=text-align:center>(265v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+227v1["<div style=text-align:center>(227v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; (usize,<br>        usize), bool &gt; ({ use hydro_std::__staged::__deps:: *; use<br>        hydro_std::__staged::quorum:: *;<br>        hydro_std::__stageleft_quote_src_quorum_rs_134_27!([max__free = 3usize,]<br>        [move | (success, error) | (success + error) &gt;= max__free]) }),] [{ let orig<br>        = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+228v1["<div style=text-align:center>(228v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+229v1["<div style=text-align:center>(229v1)</div> <code><br>tee()</code>"]:::otherClass
+230v1["<div style=text-align:center>(230v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+231v1["<div style=text-align:center>(231v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::result::Result&lt;(), hydro_test::__staged::cluster::paxos::Ballot&gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
+232v1["<div style=text-align:center>(232v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_122_27!(<br>        [min__free = 2usize,] [move | (key, (success, _error)) | if success &gt;=<br>        min__free { Some(key) } else { None }]<br>    )<br>})</code>"]:::otherClass
+233v1["<div style=text-align:center>(233v1)</div> <code><br>tee()</code>"]:::otherClass
+234v1["<div style=text-align:center>(234v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+235v1["<div style=text-align:center>(235v1)</div> <code><br>identity::&lt;(usize, hydro_test::__staged::cluster::paxos::Ballot)&gt;()</code>"]:::otherClass
+236v1["<div style=text-align:center>(236v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+237v1["<div style=text-align:center>(237v1)</div> <code><br>chain()</code>"]:::otherClass
+238v1["<div style=text-align:center>(238v1)</div> <code><br>tee()</code>"]:::otherClass
+239v1["<div style=text-align:center>(239v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+240v1["<div style=text-align:center>(240v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+241v1["<div style=text-align:center>(241v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_750_23!([] [| k | (k, ())])<br>})</code>"]:::otherClass
+242v1["<div style=text-align:center>(242v1)</div> <code><br>tee()</code>"]:::otherClass
+243v1["<div style=text-align:center>(243v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_39_78!(<br>        [] [| (key, _) | key]<br>    )<br>})</code>"]:::otherClass
+244v1["<div style=text-align:center>(244v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+245v1["<div style=text-align:center>(245v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::option::Option&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
+246v1["<div style=text-align:center>(246v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+247v1["<div style=text-align:center>(247v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_151_32!(<br>        [] [move | (key, res) | match res { Ok(_) =&gt; None, Err(e) =&gt; Some((key, e)),<br>        }]<br>    )<br>})</code>"]:::otherClass
+248v1["<div style=text-align:center>(248v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_764_21!([] [| (_, ballot) | ballot])<br>})</code>"]:::otherClass
+249v1["<div style=text-align:center>(249v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
+250v1["<div style=text-align:center>(250v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_34!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+251v1["<div style=text-align:center>(251v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+252v1["<div style=text-align:center>(252v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_51!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+253v1["<div style=text-align:center>(253v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+254v1["<div style=text-align:center>(254v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+255v1["<div style=text-align:center>(255v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_545_16!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
+256v1["<div style=text-align:center>(256v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_36_11!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_37_11!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+257v1["<div style=text-align:center>(257v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_1187_61!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+258v1["<div style=text-align:center>(258v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+259v1["<div style=text-align:center>(259v1)</div> <code><br>join_multiset_half::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+260v1["<div style=text-align:center>(260v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_37_20!(<br>        [] [| (key, (meta, resp)) | (key, (meta, resp))]<br>    )<br>})</code>"]:::otherClass
+261v1["<div style=text-align:center>(261v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_762_29!(<br>        [] [| ((slot, _ballot), (value, _)) | (slot, value)]<br>    )<br>})</code>"]:::otherClass
+262v1["<div style=text-align:center>(262v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+263v1["<div style=text-align:center>(263v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+264v1["<div style=text-align:center>(264v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
 1v1-->2v1
 132v1-->|0|3v1
-250v1-->|1|3v1
+249v1-->|1|3v1
 3v1-->|0|4v1
 50v1-->|1|4v1
 4v1-->5v1
@@ -441,135 +436,130 @@ linkStyle default stroke:#aaa
 152v1-->|1|153v1
 154v1-->155v1
 153v1-->154v1
-156v1-->157v1
-157v1-->158v1
-128v1-->159v1
-158v1-->|input|160v1
-159v1-->|single|160v1
+25v1-->157v1
+117v1-->158v1
+158v1-->159v1
+159v1-->160v1
 160v1-->161v1
 161v1-->162v1
-117v1-->163v1
+162v1-->163v1
 163v1-->164v1
 164v1-->165v1
 165v1-->166v1
 166v1-->167v1
 167v1-->168v1
-168v1-->169v1
-169v1-->170v1
+187v1--o169v1; linkStyle 180 stroke:red
 170v1-->171v1
-171v1-->172v1
-172v1-->173v1
-186v1--o174v1; linkStyle 186 stroke:red
+169v1-->|0|172v1
+171v1-->|1|172v1
+168v1-->|0|173v1
+172v1-->|1|173v1
+173v1-->|single|185v1
 175v1-->176v1
-174v1-->|0|177v1
-176v1-->|1|177v1
-173v1-->|0|178v1
-177v1-->|1|178v1
-178v1-->179v1
-162v1-->|input|180v1
-179v1-->|single|180v1
+176v1-->177v1
+128v1-->178v1
+177v1-->|input|179v1
+178v1-->|single|179v1
+179v1-->180v1
 180v1-->181v1
 181v1-->182v1
 182v1-->183v1
-183v1-->|input|184v1
-179v1-->|single|184v1
-184v1-->185v1
+183v1-->184v1
+184v1-->|input|185v1
 185v1-->186v1
-233v1--o187v1; linkStyle 202 stroke:red
-188v1-->189v1
+186v1-->187v1
+231v1--o188v1; linkStyle 200 stroke:red
 189v1-->190v1
 190v1-->191v1
 191v1-->192v1
-182v1-->|input|193v1
-25v1-->|single|193v1
-193v1-->194v1
-169v1-->|input|195v1
-25v1-->|single|195v1
-164v1-->196v1
+192v1-->193v1
+25v1-->246v1
+183v1-->195v1
+159v1-->196v1
 196v1-->197v1
 197v1-->198v1
 199v1-->200v1
 198v1-->|0|201v1
 200v1-->|1|201v1
-201v1-->202v1
-195v1-->|input|203v1
-202v1-->|single|203v1
-203v1-->204v1
-172v1-->|input|205v1
-202v1-->|single|205v1
-205v1-->206v1
-169v1-->207v1
-206v1-->|pos|208v1
-207v1-->|neg|208v1
-208v1-->|input|209v1
-25v1-->|single|209v1
-209v1-->210v1
-204v1-->|0|211v1
-210v1-->|1|211v1
-194v1-->|0|212v1
-211v1-->|1|212v1
-128v1-->213v1
-212v1-->|input|214v1
-213v1-->|single|214v1
+201v1-->|single|204v1
+164v1-->203v1
+167v1-->|input|204v1
+204v1-->205v1
+164v1-->206v1
+205v1-->|pos|207v1
+206v1-->|neg|207v1
+207v1-->208v1
+203v1-->|0|209v1
+208v1-->|1|209v1
+195v1-->|0|210v1
+209v1-->|1|210v1
+128v1-->211v1
+210v1-->|input|212v1
+211v1-->|single|212v1
+212v1-->213v1
+213v1-->214v1
 214v1-->215v1
-215v1-->216v1
+193v1-->|0|216v1
+215v1-->|1|216v1
+217v1-->218v1
 216v1-->217v1
-192v1-->|0|218v1
-217v1-->|1|218v1
 219v1-->220v1
-218v1-->219v1
+220v1-->221v1
 221v1-->222v1
-222v1-->223v1
+188v1-->|0|223v1
+222v1-->|1|223v1
 223v1-->224v1
-187v1-->|0|225v1
-224v1-->|1|225v1
+224v1-->225v1
 225v1-->226v1
 226v1-->227v1
 227v1-->228v1
 228v1-->229v1
-229v1-->230v1
+224v1-->|pos|230v1
+229v1-->|neg|230v1
 230v1-->231v1
-226v1-->|pos|232v1
-231v1-->|neg|232v1
+226v1-->232v1
 232v1-->233v1
-228v1-->234v1
+233v1-->|pos|234v1
+229v1-->|neg|234v1
 234v1-->235v1
-235v1-->|pos|236v1
-231v1-->|neg|236v1
-236v1-->237v1
-247v1--o238v1; linkStyle 264 stroke:red
-238v1-->|0|239v1
-216v1-->|1|239v1
-239v1-->240v1
-237v1--o241v1; linkStyle 268 stroke:red
-235v1-->|pos|242v1
-241v1-->|neg|242v1
+245v1--o236v1; linkStyle 254 stroke:red
+236v1-->|0|237v1
+214v1-->|1|237v1
+237v1-->238v1
+235v1--o239v1; linkStyle 258 stroke:red
+233v1-->|pos|240v1
+239v1-->|neg|240v1
+240v1-->241v1
+241v1-->242v1
 242v1-->243v1
-243v1-->244v1
+238v1-->|pos|244v1
+243v1-->|neg|244v1
 244v1-->245v1
-240v1-->|pos|246v1
-245v1-->|neg|246v1
-246v1-->247v1
-224v1-->248v1
+222v1-->247v1
+247v1-->248v1
 248v1-->249v1
-249v1-->250v1
-149v1-->251v1
-25v1-->|input|252v1
-251v1-->|single|252v1
+149v1-->250v1
+25v1-->|input|251v1
+250v1-->|single|251v1
+251v1-->252v1
 252v1-->253v1
-253v1-->254v1
+254v1-->255v1
 255v1-->256v1
 256v1-->257v1
 257v1-->258v1
-258v1-->259v1
-240v1-->|probe|260v1
-244v1-->|build|260v1
+238v1-->|probe|259v1
+242v1-->|build|259v1
+259v1-->260v1
 260v1-->261v1
-261v1-->262v1
-259v1-->|0|263v1
-262v1-->|1|263v1
-264v1-->265v1
+258v1-->|0|262v1
+261v1-->|1|262v1
 263v1-->264v1
+262v1-->263v1
+173v1-->182v1
+25v1-->195v1
+25v1-->203v1
+201v1-->203v1
+25v1-->208v1
 2v1
 44v1
 45v1
@@ -577,34 +567,36 @@ linkStyle default stroke:#aaa
 87v1
 154v1
 155v1
-219v1
-220v1
-254v1
+157v1
+217v1
+218v1
+246v1
+253v1
+263v1
 264v1
-265v1
 subgraph var_cycle_10 ["var <tt>cycle_10</tt>"]
     style var_cycle_10 fill:transparent
     105v1
 end
 subgraph var_cycle_12 ["var <tt>cycle_12</tt>"]
     style var_cycle_12 fill:transparent
-    186v1
+    187v1
 end
 subgraph var_cycle_13 ["var <tt>cycle_13</tt>"]
     style var_cycle_13 fill:transparent
-    233v1
+    231v1
 end
 subgraph var_cycle_14 ["var <tt>cycle_14</tt>"]
     style var_cycle_14 fill:transparent
-    237v1
+    235v1
 end
 subgraph var_cycle_15 ["var <tt>cycle_15</tt>"]
     style var_cycle_15 fill:transparent
-    247v1
+    245v1
 end
 subgraph var_cycle_3 ["var <tt>cycle_3</tt>"]
     style var_cycle_3 fill:transparent
-    250v1
+    249v1
 end
 subgraph var_cycle_5 ["var <tt>cycle_5</tt>"]
     style var_cycle_5 fill:transparent
@@ -1028,106 +1020,94 @@ subgraph var_stream_33 ["var <tt>stream_33</tt>"]
     style var_stream_33 fill:transparent
     5v1
 end
+subgraph var_stream_336 ["var <tt>stream_336</tt>"]
+    style var_stream_336 fill:transparent
+    158v1
+end
 subgraph var_stream_337 ["var <tt>stream_337</tt>"]
     style var_stream_337 fill:transparent
-    156v1
-    157v1
+    159v1
+end
+subgraph var_stream_338 ["var <tt>stream_338</tt>"]
+    style var_stream_338 fill:transparent
+    160v1
 end
 subgraph var_stream_339 ["var <tt>stream_339</tt>"]
     style var_stream_339 fill:transparent
-    158v1
+    161v1
+end
+subgraph var_stream_341 ["var <tt>stream_341</tt>"]
+    style var_stream_341 fill:transparent
+    162v1
+end
+subgraph var_stream_342 ["var <tt>stream_342</tt>"]
+    style var_stream_342 fill:transparent
+    163v1
 end
 subgraph var_stream_343 ["var <tt>stream_343</tt>"]
     style var_stream_343 fill:transparent
-    159v1
+    164v1
 end
-subgraph var_stream_344 ["var <tt>stream_344</tt>"]
-    style var_stream_344 fill:transparent
-    160v1
-end
-subgraph var_stream_345 ["var <tt>stream_345</tt>"]
-    style var_stream_345 fill:transparent
-    161v1
+subgraph var_stream_346 ["var <tt>stream_346</tt>"]
+    style var_stream_346 fill:transparent
+    165v1
 end
 subgraph var_stream_348 ["var <tt>stream_348</tt>"]
     style var_stream_348 fill:transparent
-    162v1
+    166v1
+end
+subgraph var_stream_349 ["var <tt>stream_349</tt>"]
+    style var_stream_349 fill:transparent
+    167v1
 end
 subgraph var_stream_35 ["var <tt>stream_35</tt>"]
     style var_stream_35 fill:transparent
     6v1
 end
-subgraph var_stream_351 ["var <tt>stream_351</tt>"]
-    style var_stream_351 fill:transparent
-    163v1
-end
 subgraph var_stream_352 ["var <tt>stream_352</tt>"]
     style var_stream_352 fill:transparent
-    164v1
-end
-subgraph var_stream_353 ["var <tt>stream_353</tt>"]
-    style var_stream_353 fill:transparent
-    165v1
+    168v1
 end
 subgraph var_stream_354 ["var <tt>stream_354</tt>"]
     style var_stream_354 fill:transparent
-    166v1
+    169v1
 end
-subgraph var_stream_356 ["var <tt>stream_356</tt>"]
-    style var_stream_356 fill:transparent
-    167v1
+subgraph var_stream_355 ["var <tt>stream_355</tt>"]
+    style var_stream_355 fill:transparent
+    170v1
+    171v1
 end
 subgraph var_stream_357 ["var <tt>stream_357</tt>"]
     style var_stream_357 fill:transparent
-    168v1
-end
-subgraph var_stream_358 ["var <tt>stream_358</tt>"]
-    style var_stream_358 fill:transparent
-    169v1
+    172v1
 end
 subgraph var_stream_36 ["var <tt>stream_36</tt>"]
     style var_stream_36 fill:transparent
     7v1
 end
-subgraph var_stream_361 ["var <tt>stream_361</tt>"]
-    style var_stream_361 fill:transparent
-    170v1
-end
-subgraph var_stream_363 ["var <tt>stream_363</tt>"]
-    style var_stream_363 fill:transparent
-    171v1
-end
-subgraph var_stream_364 ["var <tt>stream_364</tt>"]
-    style var_stream_364 fill:transparent
-    172v1
-end
-subgraph var_stream_367 ["var <tt>stream_367</tt>"]
-    style var_stream_367 fill:transparent
+subgraph var_stream_360 ["var <tt>stream_360</tt>"]
+    style var_stream_360 fill:transparent
     173v1
 end
 subgraph var_stream_369 ["var <tt>stream_369</tt>"]
     style var_stream_369 fill:transparent
-    174v1
-end
-subgraph var_stream_370 ["var <tt>stream_370</tt>"]
-    style var_stream_370 fill:transparent
     175v1
     176v1
 end
-subgraph var_stream_372 ["var <tt>stream_372</tt>"]
-    style var_stream_372 fill:transparent
+subgraph var_stream_371 ["var <tt>stream_371</tt>"]
+    style var_stream_371 fill:transparent
     177v1
 end
 subgraph var_stream_375 ["var <tt>stream_375</tt>"]
     style var_stream_375 fill:transparent
     178v1
 end
-subgraph var_stream_377 ["var <tt>stream_377</tt>"]
-    style var_stream_377 fill:transparent
+subgraph var_stream_376 ["var <tt>stream_376</tt>"]
+    style var_stream_376 fill:transparent
     179v1
 end
-subgraph var_stream_379 ["var <tt>stream_379</tt>"]
-    style var_stream_379 fill:transparent
+subgraph var_stream_377 ["var <tt>stream_377</tt>"]
+    style var_stream_377 fill:transparent
     180v1
 end
 subgraph var_stream_380 ["var <tt>stream_380</tt>"]
@@ -1142,101 +1122,93 @@ subgraph var_stream_382 ["var <tt>stream_382</tt>"]
     style var_stream_382 fill:transparent
     183v1
 end
-subgraph var_stream_384 ["var <tt>stream_384</tt>"]
-    style var_stream_384 fill:transparent
+subgraph var_stream_383 ["var <tt>stream_383</tt>"]
+    style var_stream_383 fill:transparent
     184v1
 end
-subgraph var_stream_386 ["var <tt>stream_386</tt>"]
-    style var_stream_386 fill:transparent
+subgraph var_stream_385 ["var <tt>stream_385</tt>"]
+    style var_stream_385 fill:transparent
     185v1
 end
-subgraph var_stream_388 ["var <tt>stream_388</tt>"]
-    style var_stream_388 fill:transparent
-    187v1
-end
-subgraph var_stream_389 ["var <tt>stream_389</tt>"]
-    style var_stream_389 fill:transparent
-    188v1
+subgraph var_stream_387 ["var <tt>stream_387</tt>"]
+    style var_stream_387 fill:transparent
+    186v1
 end
 subgraph var_stream_39 ["var <tt>stream_39</tt>"]
     style var_stream_39 fill:transparent
     8v1
 end
-subgraph var_stream_390 ["var <tt>stream_390</tt>"]
-    style var_stream_390 fill:transparent
-    189v1
-end
 subgraph var_stream_392 ["var <tt>stream_392</tt>"]
     style var_stream_392 fill:transparent
-    190v1
+    188v1
 end
 subgraph var_stream_394 ["var <tt>stream_394</tt>"]
     style var_stream_394 fill:transparent
-    191v1
+    189v1
+end
+subgraph var_stream_395 ["var <tt>stream_395</tt>"]
+    style var_stream_395 fill:transparent
+    190v1
 end
 subgraph var_stream_397 ["var <tt>stream_397</tt>"]
     style var_stream_397 fill:transparent
+    191v1
+end
+subgraph var_stream_399 ["var <tt>stream_399</tt>"]
+    style var_stream_399 fill:transparent
     192v1
 end
-subgraph var_stream_404 ["var <tt>stream_404</tt>"]
-    style var_stream_404 fill:transparent
+subgraph var_stream_402 ["var <tt>stream_402</tt>"]
+    style var_stream_402 fill:transparent
     193v1
 end
-subgraph var_stream_405 ["var <tt>stream_405</tt>"]
-    style var_stream_405 fill:transparent
-    194v1
-end
-subgraph var_stream_411 ["var <tt>stream_411</tt>"]
-    style var_stream_411 fill:transparent
+subgraph var_stream_409 ["var <tt>stream_409</tt>"]
+    style var_stream_409 fill:transparent
     195v1
 end
-subgraph var_stream_413 ["var <tt>stream_413</tt>"]
-    style var_stream_413 fill:transparent
+subgraph var_stream_412 ["var <tt>stream_412</tt>"]
+    style var_stream_412 fill:transparent
     196v1
+end
+subgraph var_stream_414 ["var <tt>stream_414</tt>"]
+    style var_stream_414 fill:transparent
+    197v1
 end
 subgraph var_stream_415 ["var <tt>stream_415</tt>"]
     style var_stream_415 fill:transparent
-    197v1
+    198v1
 end
 subgraph var_stream_416 ["var <tt>stream_416</tt>"]
     style var_stream_416 fill:transparent
-    198v1
-end
-subgraph var_stream_417 ["var <tt>stream_417</tt>"]
-    style var_stream_417 fill:transparent
     199v1
     200v1
 end
-subgraph var_stream_419 ["var <tt>stream_419</tt>"]
-    style var_stream_419 fill:transparent
+subgraph var_stream_418 ["var <tt>stream_418</tt>"]
+    style var_stream_418 fill:transparent
     201v1
-end
-subgraph var_stream_421 ["var <tt>stream_421</tt>"]
-    style var_stream_421 fill:transparent
-    202v1
-end
-subgraph var_stream_423 ["var <tt>stream_423</tt>"]
-    style var_stream_423 fill:transparent
-    203v1
 end
 subgraph var_stream_424 ["var <tt>stream_424</tt>"]
     style var_stream_424 fill:transparent
+    203v1
+end
+subgraph var_stream_429 ["var <tt>stream_429</tt>"]
+    style var_stream_429 fill:transparent
     204v1
 end
-subgraph var_stream_428 ["var <tt>stream_428</tt>"]
-    style var_stream_428 fill:transparent
+subgraph var_stream_431 ["var <tt>stream_431</tt>"]
+    style var_stream_431 fill:transparent
     205v1
-end
-subgraph var_stream_430 ["var <tt>stream_430</tt>"]
-    style var_stream_430 fill:transparent
-    206v1
-end
-subgraph var_stream_434 ["var <tt>stream_434</tt>"]
-    style var_stream_434 fill:transparent
-    207v1
 end
 subgraph var_stream_435 ["var <tt>stream_435</tt>"]
     style var_stream_435 fill:transparent
+    206v1
+end
+subgraph var_stream_436 ["var <tt>stream_436</tt>"]
+    style var_stream_436 fill:transparent
+    207v1
+end
+subgraph var_stream_437 ["var <tt>stream_437</tt>"]
+    style var_stream_437 fill:transparent
     208v1
 end
 subgraph var_stream_438 ["var <tt>stream_438</tt>"]
@@ -1247,54 +1219,58 @@ subgraph var_stream_439 ["var <tt>stream_439</tt>"]
     style var_stream_439 fill:transparent
     210v1
 end
-subgraph var_stream_440 ["var <tt>stream_440</tt>"]
-    style var_stream_440 fill:transparent
-    211v1
-end
 subgraph var_stream_441 ["var <tt>stream_441</tt>"]
     style var_stream_441 fill:transparent
+    211v1
+end
+subgraph var_stream_442 ["var <tt>stream_442</tt>"]
+    style var_stream_442 fill:transparent
     212v1
 end
 subgraph var_stream_443 ["var <tt>stream_443</tt>"]
     style var_stream_443 fill:transparent
     213v1
 end
-subgraph var_stream_444 ["var <tt>stream_444</tt>"]
-    style var_stream_444 fill:transparent
-    214v1
-end
 subgraph var_stream_445 ["var <tt>stream_445</tt>"]
     style var_stream_445 fill:transparent
-    215v1
+    214v1
 end
 subgraph var_stream_447 ["var <tt>stream_447</tt>"]
     style var_stream_447 fill:transparent
-    216v1
+    215v1
 end
 subgraph var_stream_449 ["var <tt>stream_449</tt>"]
     style var_stream_449 fill:transparent
-    217v1
+    216v1
 end
 subgraph var_stream_45 ["var <tt>stream_45</tt>"]
     style var_stream_45 fill:transparent
     9v1
 end
-subgraph var_stream_451 ["var <tt>stream_451</tt>"]
-    style var_stream_451 fill:transparent
-    218v1
+subgraph var_stream_460 ["var <tt>stream_460</tt>"]
+    style var_stream_460 fill:transparent
+    219v1
+    220v1
+end
+subgraph var_stream_462 ["var <tt>stream_462</tt>"]
+    style var_stream_462 fill:transparent
+    221v1
+end
+subgraph var_stream_463 ["var <tt>stream_463</tt>"]
+    style var_stream_463 fill:transparent
+    222v1
 end
 subgraph var_stream_465 ["var <tt>stream_465</tt>"]
     style var_stream_465 fill:transparent
-    221v1
-    222v1
-end
-subgraph var_stream_467 ["var <tt>stream_467</tt>"]
-    style var_stream_467 fill:transparent
     223v1
 end
-subgraph var_stream_468 ["var <tt>stream_468</tt>"]
-    style var_stream_468 fill:transparent
+subgraph var_stream_466 ["var <tt>stream_466</tt>"]
+    style var_stream_466 fill:transparent
     224v1
+end
+subgraph var_stream_469 ["var <tt>stream_469</tt>"]
+    style var_stream_469 fill:transparent
+    225v1
 end
 subgraph var_stream_47 ["var <tt>stream_47</tt>"]
     style var_stream_47 fill:transparent
@@ -1302,26 +1278,22 @@ subgraph var_stream_47 ["var <tt>stream_47</tt>"]
 end
 subgraph var_stream_470 ["var <tt>stream_470</tt>"]
     style var_stream_470 fill:transparent
-    225v1
+    226v1
 end
 subgraph var_stream_471 ["var <tt>stream_471</tt>"]
     style var_stream_471 fill:transparent
-    226v1
+    227v1
 end
 subgraph var_stream_474 ["var <tt>stream_474</tt>"]
     style var_stream_474 fill:transparent
-    227v1
+    228v1
 end
 subgraph var_stream_475 ["var <tt>stream_475</tt>"]
     style var_stream_475 fill:transparent
-    228v1
+    229v1
 end
 subgraph var_stream_476 ["var <tt>stream_476</tt>"]
     style var_stream_476 fill:transparent
-    229v1
-end
-subgraph var_stream_479 ["var <tt>stream_479</tt>"]
-    style var_stream_479 fill:transparent
     230v1
 end
 subgraph var_stream_48 ["var <tt>stream_48</tt>"]
@@ -1331,39 +1303,43 @@ subgraph var_stream_48 ["var <tt>stream_48</tt>"]
 end
 subgraph var_stream_480 ["var <tt>stream_480</tt>"]
     style var_stream_480 fill:transparent
-    231v1
+    232v1
 end
 subgraph var_stream_481 ["var <tt>stream_481</tt>"]
     style var_stream_481 fill:transparent
-    232v1
+    233v1
+end
+subgraph var_stream_483 ["var <tt>stream_483</tt>"]
+    style var_stream_483 fill:transparent
+    234v1
 end
 subgraph var_stream_485 ["var <tt>stream_485</tt>"]
     style var_stream_485 fill:transparent
-    234v1
-end
-subgraph var_stream_486 ["var <tt>stream_486</tt>"]
-    style var_stream_486 fill:transparent
-    235v1
-end
-subgraph var_stream_488 ["var <tt>stream_488</tt>"]
-    style var_stream_488 fill:transparent
     236v1
 end
 subgraph var_stream_490 ["var <tt>stream_490</tt>"]
     style var_stream_490 fill:transparent
+    237v1
+end
+subgraph var_stream_491 ["var <tt>stream_491</tt>"]
+    style var_stream_491 fill:transparent
     238v1
+end
+subgraph var_stream_494 ["var <tt>stream_494</tt>"]
+    style var_stream_494 fill:transparent
+    239v1
 end
 subgraph var_stream_495 ["var <tt>stream_495</tt>"]
     style var_stream_495 fill:transparent
-    239v1
-end
-subgraph var_stream_496 ["var <tt>stream_496</tt>"]
-    style var_stream_496 fill:transparent
     240v1
+end
+subgraph var_stream_497 ["var <tt>stream_497</tt>"]
+    style var_stream_497 fill:transparent
+    241v1
 end
 subgraph var_stream_499 ["var <tt>stream_499</tt>"]
     style var_stream_499 fill:transparent
-    241v1
+    242v1
 end
 subgraph var_stream_50 ["var <tt>stream_50</tt>"]
     style var_stream_50 fill:transparent
@@ -1371,43 +1347,39 @@ subgraph var_stream_50 ["var <tt>stream_50</tt>"]
 end
 subgraph var_stream_500 ["var <tt>stream_500</tt>"]
     style var_stream_500 fill:transparent
-    242v1
-end
-subgraph var_stream_502 ["var <tt>stream_502</tt>"]
-    style var_stream_502 fill:transparent
     243v1
 end
-subgraph var_stream_504 ["var <tt>stream_504</tt>"]
-    style var_stream_504 fill:transparent
+subgraph var_stream_501 ["var <tt>stream_501</tt>"]
+    style var_stream_501 fill:transparent
     244v1
-end
-subgraph var_stream_505 ["var <tt>stream_505</tt>"]
-    style var_stream_505 fill:transparent
-    245v1
-end
-subgraph var_stream_506 ["var <tt>stream_506</tt>"]
-    style var_stream_506 fill:transparent
-    246v1
 end
 subgraph var_stream_52 ["var <tt>stream_52</tt>"]
     style var_stream_52 fill:transparent
     14v1
 end
+subgraph var_stream_529 ["var <tt>stream_529</tt>"]
+    style var_stream_529 fill:transparent
+    247v1
+end
+subgraph var_stream_530 ["var <tt>stream_530</tt>"]
+    style var_stream_530 fill:transparent
+    248v1
+end
+subgraph var_stream_533 ["var <tt>stream_533</tt>"]
+    style var_stream_533 fill:transparent
+    250v1
+end
 subgraph var_stream_534 ["var <tt>stream_534</tt>"]
     style var_stream_534 fill:transparent
-    248v1
+    251v1
 end
 subgraph var_stream_535 ["var <tt>stream_535</tt>"]
     style var_stream_535 fill:transparent
-    249v1
-end
-subgraph var_stream_538 ["var <tt>stream_538</tt>"]
-    style var_stream_538 fill:transparent
-    251v1
+    252v1
 end
 subgraph var_stream_539 ["var <tt>stream_539</tt>"]
     style var_stream_539 fill:transparent
-    252v1
+    254v1
 end
 subgraph var_stream_54 ["var <tt>stream_54</tt>"]
     style var_stream_54 fill:transparent
@@ -1415,51 +1387,43 @@ subgraph var_stream_54 ["var <tt>stream_54</tt>"]
 end
 subgraph var_stream_540 ["var <tt>stream_540</tt>"]
     style var_stream_540 fill:transparent
-    253v1
+    255v1
+end
+subgraph var_stream_542 ["var <tt>stream_542</tt>"]
+    style var_stream_542 fill:transparent
+    256v1
 end
 subgraph var_stream_544 ["var <tt>stream_544</tt>"]
     style var_stream_544 fill:transparent
-    255v1
-end
-subgraph var_stream_545 ["var <tt>stream_545</tt>"]
-    style var_stream_545 fill:transparent
-    256v1
+    257v1
 end
 subgraph var_stream_547 ["var <tt>stream_547</tt>"]
     style var_stream_547 fill:transparent
-    257v1
-end
-subgraph var_stream_549 ["var <tt>stream_549</tt>"]
-    style var_stream_549 fill:transparent
     258v1
 end
 subgraph var_stream_55 ["var <tt>stream_55</tt>"]
     style var_stream_55 fill:transparent
     16v1
 end
+subgraph var_stream_551 ["var <tt>stream_551</tt>"]
+    style var_stream_551 fill:transparent
+    259v1
+end
 subgraph var_stream_552 ["var <tt>stream_552</tt>"]
     style var_stream_552 fill:transparent
-    259v1
+    260v1
+end
+subgraph var_stream_554 ["var <tt>stream_554</tt>"]
+    style var_stream_554 fill:transparent
+    261v1
 end
 subgraph var_stream_556 ["var <tt>stream_556</tt>"]
     style var_stream_556 fill:transparent
-    260v1
-end
-subgraph var_stream_557 ["var <tt>stream_557</tt>"]
-    style var_stream_557 fill:transparent
-    261v1
-end
-subgraph var_stream_559 ["var <tt>stream_559</tt>"]
-    style var_stream_559 fill:transparent
     262v1
 end
 subgraph var_stream_56 ["var <tt>stream_56</tt>"]
     style var_stream_56 fill:transparent
     18v1
-end
-subgraph var_stream_561 ["var <tt>stream_561</tt>"]
-    style var_stream_561 fill:transparent
-    263v1
 end
 subgraph var_stream_57 ["var <tt>stream_57</tt>"]
     style var_stream_57 fill:transparent

--- a/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
@@ -58,43 +58,43 @@ linkStyle default stroke:#aaa
 48v1["<div style=text-align:center>(48v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
 49v1["<div style=text-align:center>(49v1)</div> <code><br>tee()</code>"]:::otherClass
 50v1["<div style=text-align:center>(50v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
-51v1["<div style=text-align:center>(51v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-52v1["<div style=text-align:center>(52v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-53v1["<div style=text-align:center>(53v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_545_16!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
-54v1["<div style=text-align:center>(54v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_36_11!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_37_11!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-55v1["<div style=text-align:center>(55v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_1187_61!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-56v1["<div style=text-align:center>(56v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-57v1["<div style=text-align:center>(57v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2016_15!(<br>            [] [| | None]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2018_16!(<br>            [] [| latest, _ | { * latest = Some(Instant::now()); }]<br>        )<br>    },<br>)</code>"]:::otherClass
-58v1["<div style=text-align:center>(58v1)</div> <code><br>filter_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2027_27!(<br>        [duration__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_438_15!([i_am_leader_check_timeout__free<br>        = 10u64,] [Duration::from_secs(i_am_leader_check_timeout__free)]) },] [move |<br>        latest_received | { if let Some(latest_received) = latest_received { if<br>        Instant::now().duration_since(latest_received) &gt; duration__free { Some(()) }<br>        else { None } } else { Some(()) } }]<br>    )<br>})</code>"]:::otherClass
-59v1["<div style=text-align:center>(59v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_1078_20!(<br>        [] [| b | ! b]<br>    )<br>})</code>"]:::otherClass
-60v1["<div style=text-align:center>(60v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_1105_34!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-61v1["<div style=text-align:center>(61v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-62v1["<div style=text-align:center>(62v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_1105_51!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-63v1["<div style=text-align:center>(63v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_906_20!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
-64v1["<div style=text-align:center>(64v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
-65v1["<div style=text-align:center>(65v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-66v1["<div style=text-align:center>(66v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-67v1["<div style=text-align:center>(67v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-68v1["<div style=text-align:center>(68v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_908_20!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
-69v1["<div style=text-align:center>(69v1)</div> <code><br>source_stream({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_1439_30!(<br>        [delay__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_453_19!([CLUSTER_SELF_ID__free =<br>        hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),<br>        i_am_leader_check_timeout_delay_multiplier__free = 15usize,]<br>        [Duration::from_secs((CLUSTER_SELF_ID__free.get_raw_id() *<br>        i_am_leader_check_timeout_delay_multiplier__free as u32).into())]) },<br>        interval__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_458_19!([i_am_leader_check_timeout__free<br>        = 10u64,] [Duration::from_secs(i_am_leader_check_timeout__free)]) },]<br>        [tokio_stream::StreamExt::map(tokio_stream::wrappers::IntervalStream::new(tokio::time::interval_at(tokio::time::Instant::now()<br>        + delay__free, interval__free,)), | _ | ())]<br>    )<br>})</code>"]:::otherClass
-70v1["<div style=text-align:center>(70v1)</div> <code><br>scan::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1915_27!(<br>            [] [| | None]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1918_24!(<br>            [f__free = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt; (),<br>            (),<br>            hydro_test::__staged::__deps::hydro_lang::live_collections::keyed_stream::Generate<br>            &lt; () &gt; &gt; ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1588_37!([]<br>            [| _, item | Generate::Return(item)]) }), init__free =<br>            stageleft::runtime_support::fn0_type_hint:: &lt; () &gt; ({ use<br>            hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1588_26!([]<br>            [| | ()]) }),] [move | state : &amp; mut Option &lt; Option &lt; _ &gt; &gt;, v | { if<br>            state.is_none() { * state = Some(Some(init__free())); } match state {<br>            Some(Some(state_value)) =&gt; match f__free(state_value, v) {<br>            Generate::Yield(out) =&gt; Some(Some(out)), Generate::Return(out) =&gt; { *<br>            state = Some(None); Some(Some(out)) } Generate::Break =&gt; None,<br>            Generate::Continue =&gt; Some(None), }, _ =&gt; None, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-71v1["<div style=text-align:center>(71v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1955_27!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
-72v1["<div style=text-align:center>(72v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1589_23!(<br>        [] [| _, _ | {}]<br>    )<br>})</code>"]:::otherClass
-73v1["<div style=text-align:center>(73v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_906_20!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
-74v1["<div style=text-align:center>(74v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
-75v1["<div style=text-align:center>(75v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-76v1["<div style=text-align:center>(76v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-77v1["<div style=text-align:center>(77v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-78v1["<div style=text-align:center>(78v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_908_20!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
-79v1["<div style=text-align:center>(79v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-80v1["<div style=text-align:center>(80v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_1144_31!(<br>        [] [| (a, b) | a &amp;&amp; b]<br>    )<br>})</code>"]:::otherClass
-81v1["<div style=text-align:center>(81v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_34!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-82v1["<div style=text-align:center>(82v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-83v1["<div style=text-align:center>(83v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_51!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-84v1["<div style=text-align:center>(84v1)</div> <code><br>inspect({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_317_20!(<br>        [] [| _ | println!(&quot;Proposer leader expired, sending P1a&quot;)]<br>    )<br>})</code>"]:::otherClass
-85v1["<div style=text-align:center>(85v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-86v1["<div style=text-align:center>(86v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-87v1["<div style=text-align:center>(87v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+51v1["<div style=text-align:center>(51v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+52v1["<div style=text-align:center>(52v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_545_16!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
+53v1["<div style=text-align:center>(53v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_36_11!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_37_11!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+54v1["<div style=text-align:center>(54v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_1187_61!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+55v1["<div style=text-align:center>(55v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+56v1["<div style=text-align:center>(56v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2016_15!(<br>            [] [| | None]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2018_16!(<br>            [] [| latest, _ | { * latest = Some(Instant::now()); }]<br>        )<br>    },<br>)</code>"]:::otherClass
+57v1["<div style=text-align:center>(57v1)</div> <code><br>filter_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2027_27!(<br>        [duration__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_438_15!([i_am_leader_check_timeout__free<br>        = 10u64,] [Duration::from_secs(i_am_leader_check_timeout__free)]) },] [move |<br>        latest_received | { if let Some(latest_received) = latest_received { if<br>        Instant::now().duration_since(latest_received) &gt; duration__free { Some(()) }<br>        else { None } } else { Some(()) } }]<br>    )<br>})</code>"]:::otherClass
+58v1["<div style=text-align:center>(58v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_1078_20!(<br>        [] [| b | ! b]<br>    )<br>})</code>"]:::otherClass
+59v1["<div style=text-align:center>(59v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_1105_34!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+60v1["<div style=text-align:center>(60v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+61v1["<div style=text-align:center>(61v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_1105_51!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+62v1["<div style=text-align:center>(62v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_906_20!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
+63v1["<div style=text-align:center>(63v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+64v1["<div style=text-align:center>(64v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+65v1["<div style=text-align:center>(65v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+66v1["<div style=text-align:center>(66v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+67v1["<div style=text-align:center>(67v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_908_20!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
+68v1["<div style=text-align:center>(68v1)</div> <code><br>source_stream({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_1439_30!(<br>        [delay__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_453_19!([CLUSTER_SELF_ID__free =<br>        hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),<br>        i_am_leader_check_timeout_delay_multiplier__free = 15usize,]<br>        [Duration::from_secs((CLUSTER_SELF_ID__free.get_raw_id() *<br>        i_am_leader_check_timeout_delay_multiplier__free as u32).into())]) },<br>        interval__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_458_19!([i_am_leader_check_timeout__free<br>        = 10u64,] [Duration::from_secs(i_am_leader_check_timeout__free)]) },]<br>        [tokio_stream::StreamExt::map(tokio_stream::wrappers::IntervalStream::new(tokio::time::interval_at(tokio::time::Instant::now()<br>        + delay__free, interval__free,)), | _ | ())]<br>    )<br>})</code>"]:::otherClass
+69v1["<div style=text-align:center>(69v1)</div> <code><br>scan::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1915_27!(<br>            [] [| | None]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1918_24!(<br>            [f__free = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt; (),<br>            (),<br>            hydro_test::__staged::__deps::hydro_lang::live_collections::keyed_stream::Generate<br>            &lt; () &gt; &gt; ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1588_37!([]<br>            [| _, item | Generate::Return(item)]) }), init__free =<br>            stageleft::runtime_support::fn0_type_hint:: &lt; () &gt; ({ use<br>            hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1588_26!([]<br>            [| | ()]) }),] [move | state : &amp; mut Option &lt; Option &lt; _ &gt; &gt;, v | { if<br>            state.is_none() { * state = Some(Some(init__free())); } match state {<br>            Some(Some(state_value)) =&gt; match f__free(state_value, v) {<br>            Generate::Yield(out) =&gt; Some(Some(out)), Generate::Return(out) =&gt; { *<br>            state = Some(None); Some(Some(out)) } Generate::Break =&gt; None,<br>            Generate::Continue =&gt; Some(None), }, _ =&gt; None, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+70v1["<div style=text-align:center>(70v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1955_27!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
+71v1["<div style=text-align:center>(71v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1589_23!(<br>        [] [| _, _ | {}]<br>    )<br>})</code>"]:::otherClass
+72v1["<div style=text-align:center>(72v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_906_20!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
+73v1["<div style=text-align:center>(73v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+74v1["<div style=text-align:center>(74v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+75v1["<div style=text-align:center>(75v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+76v1["<div style=text-align:center>(76v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+77v1["<div style=text-align:center>(77v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_908_20!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
+78v1["<div style=text-align:center>(78v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+79v1["<div style=text-align:center>(79v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_1144_31!(<br>        [] [| (a, b) | a &amp;&amp; b]<br>    )<br>})</code>"]:::otherClass
+80v1["<div style=text-align:center>(80v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_34!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+81v1["<div style=text-align:center>(81v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+82v1["<div style=text-align:center>(82v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_51!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+83v1["<div style=text-align:center>(83v1)</div> <code><br>inspect({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_317_20!(<br>        [] [| _ | println!(&quot;Proposer leader expired, sending P1a&quot;)]<br>    )<br>})</code>"]:::otherClass
+84v1["<div style=text-align:center>(84v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+85v1["<div style=text-align:center>(85v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+86v1["<div style=text-align:center>(86v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+87v1["<div style=text-align:center>(87v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
 88v1["<div style=text-align:center>(88v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
 89v1["<div style=text-align:center>(89v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                hydro_test::__staged::cluster::paxos::Ballot,<br>                core::result::Result&lt;<br>                    (<br>                        core::option::Option&lt;usize&gt;,<br>                        std::collections::hash_map::HashMap&lt;<br>                            usize,<br>                            hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                                (<br>                                    u32,<br>                                    (<br>                                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                                        &gt;,<br>                                        i32,<br>                                    ),<br>                                ),<br>                            &gt;,<br>                        &gt;,<br>                    ),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
 90v1["<div style=text-align:center>(90v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_747_30!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
@@ -119,11 +119,11 @@ linkStyle default stroke:#aaa
 109v1["<div style=text-align:center>(109v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
 110v1["<div style=text-align:center>(110v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 111v1["<div style=text-align:center>(111v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_74_42!(<br>        [] [move | (key, res) | match res { Ok(v) =&gt; Some((key, v)), Err(_) =&gt; None,<br>        }]<br>    )<br>})</code>"]:::otherClass
-112v1["<div style=text-align:center>(112v1)</div> <code><br>scan::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1629_27!(<br>            [] [| | HashMap::new()]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1632_24!(<br>            [f__free = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt;<br>            core::option::Option &lt; std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt;,<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;),<br>            hydro_test::__staged::__deps::hydro_lang::live_collections::keyed_stream::Generate<br>            &lt; std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; &gt;<br>            ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::keyed_stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1737_15!([f__free<br>            = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt; std::vec::Vec<br>            &lt; (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt;,<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), bool<br>            &gt; ({ use crate ::__staged::__deps:: *; use crate<br>            ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>            __stageleft_quote_src_cluster_paxos_rs_544_15!([quorum_size__free =<br>            2usize,] [move | logs, log | { logs.push(log); logs.len() &gt;=<br>            quorum_size__free }]) }),] [move | key_state, v | { if let<br>            Some(key_state_value) = key_state.as_mut() { if f__free(key_state_value,<br>            v) { Generate::Return(key_state.take().unwrap()) } else {<br>            Generate::Continue } } else { unreachable!() } }]) }), init__free =<br>            stageleft::runtime_support::fn0_type_hint:: &lt; core::option::Option &lt;<br>            std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; &gt;<br>            ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::keyed_stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1736_15!([init__free<br>            = stageleft::runtime_support::fn0_type_hint:: &lt; std::vec::Vec &lt;<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; ({<br>            *; &num;[allow(unused_imports)] use crate :: *;<br>            __stageleft_quote_src_cluster_paxos_rs_543_15!([] [| | vec![]]) }),]<br>            [move | | Some(init__free())]) }),] [move | acc : &amp; mut HashMap &lt; _, _ &gt;,<br>            (k, v) | { let existing_state = acc.entry(Clone::clone(&amp; k))<br>            .or_insert_with(| | Some(init__free())); if let<br>            Some(existing_state_value) = existing_state { match<br>            f__free(existing_state_value, v) { Generate::Yield(out) =&gt; Some(Some((k,<br>            out))), Generate::Return(out) =&gt; { let _ = existing_state.take();<br>            Some(Some((k, out))) } Generate::Break =&gt; { let _ = existing_state<br>            .take(); Some(None) } Generate::Continue =&gt; Some(None), } } else {<br>            Some(None) } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+112v1["<div style=text-align:center>(112v1)</div> <code><br>scan::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1629_27!(<br>            [] [| | HashMap::new()]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1632_24!(<br>            [f__free = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt;<br>            core::option::Option &lt; std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt;,<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;),<br>            hydro_test::__staged::__deps::hydro_lang::live_collections::keyed_stream::Generate<br>            &lt; std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; &gt;<br>            ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::keyed_stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1737_15!([f__free<br>            = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt; std::vec::Vec<br>            &lt; (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt;,<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), bool<br>            &gt; ({ use crate ::__staged::__deps:: *; use crate<br>            ::__staged::cluster::paxos:: *; &num;[allow(unused_imports)] use crate :: *;<br>            __stageleft_quote_src_cluster_paxos_rs_548_15!([quorum_size__free =<br>            2usize,] [move | logs, log | { logs.push(log); logs.len() &gt;=<br>            quorum_size__free }]) }),] [move | key_state, v | { if let<br>            Some(key_state_value) = key_state.as_mut() { if f__free(key_state_value,<br>            v) { Generate::Return(key_state.take().unwrap()) } else {<br>            Generate::Continue } } else { unreachable!() } }]) }), init__free =<br>            stageleft::runtime_support::fn0_type_hint:: &lt; core::option::Option &lt;<br>            std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; &gt;<br>            ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::keyed_stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1736_15!([init__free<br>            = stageleft::runtime_support::fn0_type_hint:: &lt; std::vec::Vec &lt;<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; ({<br>            *; &num;[allow(unused_imports)] use crate :: *;<br>            __stageleft_quote_src_cluster_paxos_rs_547_15!([] [| | vec![]]) }),]<br>            [move | | Some(init__free())]) }),] [move | acc : &amp; mut HashMap &lt; _, _ &gt;,<br>            (k, v) | { let existing_state = acc.entry(Clone::clone(&amp; k))<br>            .or_insert_with(| | Some(init__free())); if let<br>            Some(existing_state_value) = existing_state { match<br>            f__free(existing_state_value, v) { Generate::Yield(out) =&gt; Some(Some((k,<br>            out))), Generate::Return(out) =&gt; { let _ = existing_state.take();<br>            Some(Some((k, out))) } Generate::Break =&gt; { let _ = existing_state<br>            .take(); Some(None) } Generate::Continue =&gt; Some(None), } } else {<br>            Some(None) } }]<br>        )<br>    },<br>)</code>"]:::otherClass
 113v1["<div style=text-align:center>(113v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_1667_27!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
 114v1["<div style=text-align:center>(114v1)</div> <code><br>reduce::&lt;<br>    'static,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1549_16!(<br>        [] [move | curr, new | { if new.0 &gt; curr.0 { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
 115v1["<div style=text-align:center>(115v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-116v1["<div style=text-align:center>(116v1)</div> <code><br>filter_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_564_12!(<br>        [] [move | ((quorum_ballot, quorum_accepted), my_ballot) | if quorum_ballot<br>        == my_ballot { Some(quorum_accepted) } else { None }]<br>    )<br>})</code>"]:::otherClass
+116v1["<div style=text-align:center>(116v1)</div> <code><br>filter_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_568_12!(<br>        [] [move | ((quorum_ballot, quorum_accepted), my_ballot) | if quorum_ballot<br>        == my_ballot { Some(quorum_accepted) } else { None }]<br>    )<br>})</code>"]:::otherClass
 117v1["<div style=text-align:center>(117v1)</div> <code><br>tee()</code>"]:::otherClass
 118v1["<div style=text-align:center>(118v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_906_20!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
 119v1["<div style=text-align:center>(119v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
@@ -138,7 +138,7 @@ linkStyle default stroke:#aaa
 128v1["<div style=text-align:center>(128v1)</div> <code><br>tee()</code>"]:::otherClass
 129v1["<div style=text-align:center>(129v1)</div> <code><br>identity::&lt;bool&gt;()</code>"]:::otherClass
 130v1["<div style=text-align:center>(130v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_82_32!(<br>        [] [move | (key, res) | match res { Ok(_) =&gt; None, Err(e) =&gt; Some((key, e)),<br>        }]<br>    )<br>})</code>"]:::otherClass
-131v1["<div style=text-align:center>(131v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_580_21!([] [| (_, ballot) | ballot])<br>})</code>"]:::otherClass
+131v1["<div style=text-align:center>(131v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_584_21!([] [| (_, ballot) | ballot])<br>})</code>"]:::otherClass
 132v1["<div style=text-align:center>(132v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
 133v1["<div style=text-align:center>(133v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
 134v1["<div style=text-align:center>(134v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_545_16!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
@@ -166,17 +166,17 @@ linkStyle default stroke:#aaa
 157v1["<div style=text-align:center>(157v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
 158v1["<div style=text-align:center>(158v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_571_35!(<br>        [] [| v | v]<br>    )<br>})</code>"]:::otherClass
 159v1["<div style=text-align:center>(159v1)</div> <code><br>tee()</code>"]:::otherClass
-160v1["<div style=text-align:center>(160v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_604_16!([] [| (_checkpoint, log) | log])<br>})</code>"]:::otherClass
+160v1["<div style=text-align:center>(160v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_608_16!([] [| (_checkpoint, log) | log])<br>})</code>"]:::otherClass
 161v1["<div style=text-align:center>(161v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_764_35!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
-162v1["<div style=text-align:center>(162v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_607_67!([] [| | (0, None)])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_607_85!(<br>            [] [| curr_entry, new_entry | { if let Some(curr_entry_payload) = &amp; mut<br>            curr_entry.1 { let same_values = new_entry.value == curr_entry_payload<br>            .value; let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>            if same_values { curr_entry.0 += 1; } if higher_ballot {<br>            curr_entry_payload.ballot = new_entry.ballot; if ! same_values {<br>            curr_entry.0 = 1; curr_entry_payload.value = new_entry.value; } } } else<br>            { * curr_entry = (1, Some(new_entry)); } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-163v1["<div style=text-align:center>(163v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_484_23!(<br>        [f__free = stageleft::runtime_support::fn1_type_hint:: &lt; (usize,<br>        core::option::Option &lt; hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), (usize,<br>        hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt;) &gt; ({ use crate<br>        ::__staged::__deps:: *; use crate ::__staged::cluster::paxos:: *;<br>        &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_628_16!([] [| (count, entry) | (count,<br>        entry.unwrap())]) }),] [{ let orig = f__free; move | (k, v) | (k, orig(v)) }]<br>    )<br>})</code>"]:::otherClass
+162v1["<div style=text-align:center>(162v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_611_67!([] [| | (0, None)])<br>    },<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_611_85!(<br>            [] [| curr_entry, new_entry | { if let Some(curr_entry_payload) = &amp; mut<br>            curr_entry.1 { let same_values = new_entry.value == curr_entry_payload<br>            .value; let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>            if same_values { curr_entry.0 += 1; } if higher_ballot {<br>            curr_entry_payload.ballot = new_entry.ballot; if ! same_values {<br>            curr_entry.0 = 1; curr_entry_payload.value = new_entry.value; } } } else<br>            { * curr_entry = (1, Some(new_entry)); } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+163v1["<div style=text-align:center>(163v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_484_23!(<br>        [f__free = stageleft::runtime_support::fn1_type_hint:: &lt; (usize,<br>        core::option::Option &lt; hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), (usize,<br>        hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt;) &gt; ({ use crate<br>        ::__staged::__deps:: *; use crate ::__staged::cluster::paxos:: *;<br>        &num;[allow(unused_imports)] use crate :: *;<br>        __stageleft_quote_src_cluster_paxos_rs_632_16!([] [| (count, entry) | (count,<br>        entry.unwrap())]) }),] [{ let orig = f__free; move | (k, v) | (k, orig(v)) }]<br>    )<br>})</code>"]:::otherClass
 164v1["<div style=text-align:center>(164v1)</div> <code><br>tee()</code>"]:::otherClass
 165v1["<div style=text-align:center>(165v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
 166v1["<div style=text-align:center>(166v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1519_23!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
 167v1["<div style=text-align:center>(167v1)</div> <code><br>tee()</code>"]:::otherClass
-168v1["<div style=text-align:center>(168v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_779_71!([] [| s | s + 1])<br>})</code>"]:::otherClass
+168v1["<div style=text-align:center>(168v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_783_71!([] [| s | s + 1])<br>})</code>"]:::otherClass
 169v1["<div style=text-align:center>(169v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-170v1["<div style=text-align:center>(170v1)</div> <code><br>source_iter([<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_775_58!([] [0])<br>    },<br>])</code>"]:::otherClass
+170v1["<div style=text-align:center>(170v1)</div> <code><br>source_iter([<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_779_58!([] [0])<br>    },<br>])</code>"]:::otherClass
 171v1["<div style=text-align:center>(171v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 172v1["<div style=text-align:center>(172v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
 173v1["<div style=text-align:center>(173v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
@@ -187,11 +187,11 @@ linkStyle default stroke:#aaa
 179v1["<div style=text-align:center>(179v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
 180v1["<div style=text-align:center>(180v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
 181v1["<div style=text-align:center>(181v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
-182v1["<div style=text-align:center>(182v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_362;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_785_20!(<br>            [base_slot_ref__free = __hydro_singleton_ref_0,] [| (index, payload) | (*<br>            base_slot_ref__free + index, payload)]<br>        )<br>    }<br>})</code>"]:::otherClass
+182v1["<div style=text-align:center>(182v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_364;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_789_20!(<br>            [base_slot_ref__free = __hydro_singleton_ref_0,] [| (index, payload) | (*<br>            base_slot_ref__free + index, payload)]<br>        )<br>    }<br>})</code>"]:::otherClass
 183v1["<div style=text-align:center>(183v1)</div> <code><br>tee()</code>"]:::otherClass
 184v1["<div style=text-align:center>(184v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2427_15!(<br>            [] [| | 0usize]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_2429_16!(<br>            [] [| count, _ | * count += 1]<br>        )<br>    },<br>)</code>"]:::otherClass
 185v1["<div style=text-align:center>(185v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-186v1["<div style=text-align:center>(186v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_793_20!(<br>        [] [| (num_payloads, base_slot) | base_slot + num_payloads]<br>    )<br>})</code>"]:::otherClass
+186v1["<div style=text-align:center>(186v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_797_20!(<br>        [] [| (num_payloads, base_slot) | base_slot + num_payloads]<br>    )<br>})</code>"]:::otherClass
 187v1["<div style=text-align:center>(187v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
 188v1["<div style=text-align:center>(188v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
 189v1["<div style=text-align:center>(189v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
@@ -199,26 +199,26 @@ linkStyle default stroke:#aaa
 191v1["<div style=text-align:center>(191v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_36_11!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_37_11!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
 192v1["<div style=text-align:center>(192v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1807_26!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_1187_61!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
 193v1["<div style=text-align:center>(193v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-195v1["<div style=text-align:center>(195v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_405;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_720_16!(<br>            [p_ballot_ref__free = __hydro_singleton_ref_0,] [| (slot, payload) |<br>            ((slot, p_ballot_ref__free.clone()), Some(payload))]<br>        )<br>    }<br>})</code>"]:::otherClass
-196v1["<div style=text-align:center>(196v1)</div> <code><br>filter_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_600_23!(<br>        [] [| (checkpoint, _log) | checkpoint]<br>    )<br>})</code>"]:::otherClass
+195v1["<div style=text-align:center>(195v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_407;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_724_16!(<br>            [p_ballot_ref__free = __hydro_singleton_ref_0,] [| (slot, payload) |<br>            ((slot, p_ballot_ref__free.clone()), Some(payload))]<br>        )<br>    }<br>})</code>"]:::otherClass
+196v1["<div style=text-align:center>(196v1)</div> <code><br>filter_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_604_23!(<br>        [] [| (checkpoint, _log) | checkpoint]<br>    )<br>})</code>"]:::otherClass
 197v1["<div style=text-align:center>(197v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1519_23!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
 198v1["<div style=text-align:center>(198v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_879_20!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
 199v1["<div style=text-align:center>(199v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
 200v1["<div style=text-align:center>(200v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 201v1["<div style=text-align:center>(201v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-203v1["<div style=text-align:center>(203v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_0 = stream_332;<br>    let __hydro_singleton_ref_1 = stream_420;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_634_23!(<br>            [f__free = 1usize, p_ballot_ref__free = __hydro_singleton_ref_0,<br>            p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1,] [move | (slot,<br>            (count, entry)) | { if count &gt; f__free { return None; } else if let<br>            Some(checkpoint) = * p_p1b_max_checkpoint_ref__free &amp;&amp; slot &lt;= checkpoint<br>            { return None; } Some(((slot, p_ballot_ref__free.clone()), entry.value))<br>            }]<br>        )<br>    }<br>})</code>"]:::otherClass
+203v1["<div style=text-align:center>(203v1)</div> <code><br>filter_map({<br>    let __hydro_singleton_ref_0 = stream_334;<br>    let __hydro_singleton_ref_1 = stream_422;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_638_23!(<br>            [f__free = 1usize, p_ballot_ref__free = __hydro_singleton_ref_0,<br>            p_p1b_max_checkpoint_ref__free = __hydro_singleton_ref_1,] [move | (slot,<br>            (count, entry)) | { if count &gt; f__free { return None; } else if let<br>            Some(checkpoint) = * p_p1b_max_checkpoint_ref__free &amp;&amp; slot &lt;= checkpoint<br>            { return None; } Some(((slot, p_ballot_ref__free.clone()), entry.value))<br>            }]<br>        )<br>    }<br>})</code>"]:::otherClass
 204v1["<div style=text-align:center>(204v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-205v1["<div style=text-align:center>(205v1)</div> <code><br>flat_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_649_29!(<br>        [] [| (max_slot, checkpoint) | { if let Some(checkpoint) = checkpoint {<br>        (checkpoint + 1)..max_slot } else { 0..max_slot } }]<br>    )<br>})</code>"]:::otherClass
+205v1["<div style=text-align:center>(205v1)</div> <code><br>flat_map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_653_29!(<br>        [] [| (max_slot, checkpoint) | { if let Some(checkpoint) = checkpoint {<br>        (checkpoint + 1)..max_slot } else { 0..max_slot } }]<br>    )<br>})</code>"]:::otherClass
 206v1["<div style=text-align:center>(206v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
 207v1["<div style=text-align:center>(207v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-208v1["<div style=text-align:center>(208v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_332;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_657_16!(<br>            [p_ballot_ref__free = __hydro_singleton_ref_0,] [move | slot | ((slot,<br>            p_ballot_ref__free.clone()), None)]<br>        )<br>    }<br>})</code>"]:::otherClass
+208v1["<div style=text-align:center>(208v1)</div> <code><br>map({<br>    let __hydro_singleton_ref_0 = stream_334;<br>    {<br>        &num;[allow(unused_imports)]<br>        __stageleft_quote_src_cluster_paxos_rs_661_16!(<br>            [p_ballot_ref__free = __hydro_singleton_ref_0,] [move | slot | ((slot,<br>            p_ballot_ref__free.clone()), None)]<br>        )<br>    }<br>})</code>"]:::otherClass
 209v1["<div style=text-align:center>(209v1)</div> <code><br>chain()</code>"]:::otherClass
 210v1["<div style=text-align:center>(210v1)</div> <code><br>chain()</code>"]:::otherClass
 211v1["<div style=text-align:center>(211v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1053_46!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
 212v1["<div style=text-align:center>(212v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
 213v1["<div style=text-align:center>(213v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_1054_20!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
 214v1["<div style=text-align:center>(214v1)</div> <code><br>tee()</code>"]:::otherClass
-215v1["<div style=text-align:center>(215v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_734_20!(<br>        [CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),] [move |<br>        ((slot, ballot), value) | P2a { sender : CLUSTER_SELF_ID__free.clone(),<br>        ballot, slot, value }]<br>    )<br>})</code>"]:::otherClass
+215v1["<div style=text-align:center>(215v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_738_20!(<br>        [CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),] [move |<br>        ((slot, ballot), value) | P2a { sender : CLUSTER_SELF_ID__free.clone(),<br>        ballot, slot, value }]<br>    )<br>})</code>"]:::otherClass
 216v1["<div style=text-align:center>(216v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 217v1["<div style=text-align:center>(217v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
 218v1["<div style=text-align:center>(218v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
@@ -244,14 +244,14 @@ linkStyle default stroke:#aaa
 238v1["<div style=text-align:center>(238v1)</div> <code><br>tee()</code>"]:::otherClass
 239v1["<div style=text-align:center>(239v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
 240v1["<div style=text-align:center>(240v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-241v1["<div style=text-align:center>(241v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_750_23!([] [| k | (k, ())])<br>})</code>"]:::otherClass
+241v1["<div style=text-align:center>(241v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_754_23!([] [| k | (k, ())])<br>})</code>"]:::otherClass
 242v1["<div style=text-align:center>(242v1)</div> <code><br>tee()</code>"]:::otherClass
 243v1["<div style=text-align:center>(243v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_39_78!(<br>        [] [| (key, _) | key]<br>    )<br>})</code>"]:::otherClass
 244v1["<div style=text-align:center>(244v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 245v1["<div style=text-align:center>(245v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::option::Option&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
 246v1["<div style=text-align:center>(246v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
 247v1["<div style=text-align:center>(247v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_151_32!(<br>        [] [move | (key, res) | match res { Ok(_) =&gt; None, Err(e) =&gt; Some((key, e)),<br>        }]<br>    )<br>})</code>"]:::otherClass
-248v1["<div style=text-align:center>(248v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_764_21!([] [| (_, ballot) | ballot])<br>})</code>"]:::otherClass
+248v1["<div style=text-align:center>(248v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_768_21!([] [| (_, ballot) | ballot])<br>})</code>"]:::otherClass
 249v1["<div style=text-align:center>(249v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
 250v1["<div style=text-align:center>(250v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_875_34!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
 251v1["<div style=text-align:center>(251v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
@@ -264,7 +264,7 @@ linkStyle default stroke:#aaa
 258v1["<div style=text-align:center>(258v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_1369_30!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
 259v1["<div style=text-align:center>(259v1)</div> <code><br>join_multiset_half::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 260v1["<div style=text-align:center>(260v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_37_20!(<br>        [] [| (key, (meta, resp)) | (key, (meta, resp))]<br>    )<br>})</code>"]:::otherClass
-261v1["<div style=text-align:center>(261v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_762_29!(<br>        [] [| ((slot, _ballot), (value, _)) | (slot, value)]<br>    )<br>})</code>"]:::otherClass
+261v1["<div style=text-align:center>(261v1)</div> <code><br>map({<br>    &num;[allow(unused_imports)]<br>    __stageleft_quote_src_cluster_paxos_rs_766_29!(<br>        [] [| ((slot, _ballot), (value, _)) | (slot, value)]<br>    )<br>})</code>"]:::otherClass
 262v1["<div style=text-align:center>(262v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
 263v1["<div style=text-align:center>(263v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
 264v1["<div style=text-align:center>(264v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
@@ -320,50 +320,50 @@ linkStyle default stroke:#aaa
 47v1-->48v1
 48v1-->49v1
 49v1-->50v1
-101v1--o51v1; linkStyle 52 stroke:red
+51v1-->52v1
 52v1-->53v1
 53v1-->54v1
 54v1-->55v1
-55v1-->56v1
-49v1-->57v1
-57v1-->58v1
-26v1-->59v1
-59v1-->60v1
-58v1-->|input|61v1
-60v1-->|single|61v1
+49v1-->56v1
+56v1-->57v1
+26v1-->58v1
+58v1-->59v1
+57v1-->|input|60v1
+59v1-->|single|60v1
+60v1-->61v1
 61v1-->62v1
 62v1-->63v1
-63v1-->64v1
-65v1-->66v1
-64v1-->|0|67v1
-66v1-->|1|67v1
-67v1-->68v1
+64v1-->65v1
+63v1-->|0|66v1
+65v1-->|1|66v1
+66v1-->67v1
+68v1-->69v1
 69v1-->70v1
 70v1-->71v1
 71v1-->72v1
 72v1-->73v1
-73v1-->74v1
-75v1-->76v1
-74v1-->|0|77v1
-76v1-->|1|77v1
-77v1-->78v1
-68v1-->|input|79v1
-78v1-->|single|79v1
+74v1-->75v1
+73v1-->|0|76v1
+75v1-->|1|76v1
+76v1-->77v1
+67v1-->|input|78v1
+77v1-->|single|78v1
+78v1-->79v1
 79v1-->80v1
-80v1-->81v1
-25v1-->|input|82v1
-81v1-->|single|82v1
+25v1-->|input|81v1
+80v1-->|single|81v1
+81v1-->82v1
 82v1-->83v1
-83v1-->84v1
-56v1-->|0|85v1
-84v1-->|1|85v1
-86v1-->87v1
+55v1-->|0|84v1
+83v1-->|1|84v1
 85v1-->86v1
+84v1-->85v1
+101v1--o87v1; linkStyle 90 stroke:red
 88v1-->89v1
 89v1-->90v1
 90v1-->91v1
 91v1-->92v1
-51v1-->|0|93v1
+87v1-->|0|93v1
 92v1-->|1|93v1
 93v1-->94v1
 94v1-->95v1
@@ -563,8 +563,8 @@ linkStyle default stroke:#aaa
 2v1
 44v1
 45v1
+85v1
 86v1
-87v1
 154v1
 155v1
 157v1
@@ -631,12 +631,12 @@ subgraph var_stream_104 ["var <tt>stream_104</tt>"]
     style var_stream_104 fill:transparent
     49v1
 end
-subgraph var_stream_106 ["var <tt>stream_106</tt>"]
-    style var_stream_106 fill:transparent
+subgraph var_stream_105 ["var <tt>stream_105</tt>"]
+    style var_stream_105 fill:transparent
     51v1
 end
-subgraph var_stream_107 ["var <tt>stream_107</tt>"]
-    style var_stream_107 fill:transparent
+subgraph var_stream_106 ["var <tt>stream_106</tt>"]
+    style var_stream_106 fill:transparent
     52v1
 end
 subgraph var_stream_108 ["var <tt>stream_108</tt>"]
@@ -647,297 +647,293 @@ subgraph var_stream_110 ["var <tt>stream_110</tt>"]
     style var_stream_110 fill:transparent
     54v1
 end
-subgraph var_stream_112 ["var <tt>stream_112</tt>"]
-    style var_stream_112 fill:transparent
+subgraph var_stream_113 ["var <tt>stream_113</tt>"]
+    style var_stream_113 fill:transparent
     55v1
 end
-subgraph var_stream_115 ["var <tt>stream_115</tt>"]
-    style var_stream_115 fill:transparent
+subgraph var_stream_118 ["var <tt>stream_118</tt>"]
+    style var_stream_118 fill:transparent
     56v1
 end
 subgraph var_stream_120 ["var <tt>stream_120</tt>"]
     style var_stream_120 fill:transparent
     57v1
 end
-subgraph var_stream_122 ["var <tt>stream_122</tt>"]
-    style var_stream_122 fill:transparent
+subgraph var_stream_124 ["var <tt>stream_124</tt>"]
+    style var_stream_124 fill:transparent
     58v1
+end
+subgraph var_stream_125 ["var <tt>stream_125</tt>"]
+    style var_stream_125 fill:transparent
+    59v1
 end
 subgraph var_stream_126 ["var <tt>stream_126</tt>"]
     style var_stream_126 fill:transparent
-    59v1
+    60v1
 end
 subgraph var_stream_127 ["var <tt>stream_127</tt>"]
     style var_stream_127 fill:transparent
-    60v1
+    61v1
 end
 subgraph var_stream_128 ["var <tt>stream_128</tt>"]
     style var_stream_128 fill:transparent
-    61v1
+    62v1
 end
 subgraph var_stream_129 ["var <tt>stream_129</tt>"]
     style var_stream_129 fill:transparent
-    62v1
+    63v1
 end
 subgraph var_stream_130 ["var <tt>stream_130</tt>"]
     style var_stream_130 fill:transparent
-    63v1
-end
-subgraph var_stream_131 ["var <tt>stream_131</tt>"]
-    style var_stream_131 fill:transparent
     64v1
+    65v1
 end
 subgraph var_stream_132 ["var <tt>stream_132</tt>"]
     style var_stream_132 fill:transparent
-    65v1
     66v1
 end
 subgraph var_stream_134 ["var <tt>stream_134</tt>"]
     style var_stream_134 fill:transparent
     67v1
 end
-subgraph var_stream_136 ["var <tt>stream_136</tt>"]
-    style var_stream_136 fill:transparent
+subgraph var_stream_135 ["var <tt>stream_135</tt>"]
+    style var_stream_135 fill:transparent
     68v1
 end
 subgraph var_stream_137 ["var <tt>stream_137</tt>"]
     style var_stream_137 fill:transparent
     69v1
 end
+subgraph var_stream_138 ["var <tt>stream_138</tt>"]
+    style var_stream_138 fill:transparent
+    70v1
+end
 subgraph var_stream_139 ["var <tt>stream_139</tt>"]
     style var_stream_139 fill:transparent
-    70v1
+    71v1
 end
 subgraph var_stream_140 ["var <tt>stream_140</tt>"]
     style var_stream_140 fill:transparent
-    71v1
+    72v1
 end
 subgraph var_stream_141 ["var <tt>stream_141</tt>"]
     style var_stream_141 fill:transparent
-    72v1
+    73v1
 end
 subgraph var_stream_142 ["var <tt>stream_142</tt>"]
     style var_stream_142 fill:transparent
-    73v1
-end
-subgraph var_stream_143 ["var <tt>stream_143</tt>"]
-    style var_stream_143 fill:transparent
     74v1
+    75v1
 end
 subgraph var_stream_144 ["var <tt>stream_144</tt>"]
     style var_stream_144 fill:transparent
-    75v1
     76v1
 end
 subgraph var_stream_146 ["var <tt>stream_146</tt>"]
     style var_stream_146 fill:transparent
     77v1
 end
-subgraph var_stream_148 ["var <tt>stream_148</tt>"]
-    style var_stream_148 fill:transparent
+subgraph var_stream_147 ["var <tt>stream_147</tt>"]
+    style var_stream_147 fill:transparent
     78v1
 end
 subgraph var_stream_149 ["var <tt>stream_149</tt>"]
     style var_stream_149 fill:transparent
     79v1
 end
+subgraph var_stream_150 ["var <tt>stream_150</tt>"]
+    style var_stream_150 fill:transparent
+    80v1
+end
 subgraph var_stream_151 ["var <tt>stream_151</tt>"]
     style var_stream_151 fill:transparent
-    80v1
+    81v1
 end
 subgraph var_stream_152 ["var <tt>stream_152</tt>"]
     style var_stream_152 fill:transparent
-    81v1
-end
-subgraph var_stream_153 ["var <tt>stream_153</tt>"]
-    style var_stream_153 fill:transparent
     82v1
 end
-subgraph var_stream_154 ["var <tt>stream_154</tt>"]
-    style var_stream_154 fill:transparent
+subgraph var_stream_155 ["var <tt>stream_155</tt>"]
+    style var_stream_155 fill:transparent
     83v1
 end
 subgraph var_stream_157 ["var <tt>stream_157</tt>"]
     style var_stream_157 fill:transparent
     84v1
 end
-subgraph var_stream_159 ["var <tt>stream_159</tt>"]
-    style var_stream_159 fill:transparent
-    85v1
-end
-subgraph var_stream_186 ["var <tt>stream_186</tt>"]
-    style var_stream_186 fill:transparent
-    88v1
-    89v1
+subgraph var_stream_181 ["var <tt>stream_181</tt>"]
+    style var_stream_181 fill:transparent
+    87v1
 end
 subgraph var_stream_188 ["var <tt>stream_188</tt>"]
     style var_stream_188 fill:transparent
-    90v1
-end
-subgraph var_stream_189 ["var <tt>stream_189</tt>"]
-    style var_stream_189 fill:transparent
-    91v1
+    88v1
+    89v1
 end
 subgraph var_stream_190 ["var <tt>stream_190</tt>"]
     style var_stream_190 fill:transparent
-    92v1
+    90v1
+end
+subgraph var_stream_191 ["var <tt>stream_191</tt>"]
+    style var_stream_191 fill:transparent
+    91v1
 end
 subgraph var_stream_192 ["var <tt>stream_192</tt>"]
     style var_stream_192 fill:transparent
+    92v1
+end
+subgraph var_stream_194 ["var <tt>stream_194</tt>"]
+    style var_stream_194 fill:transparent
     93v1
 end
-subgraph var_stream_193 ["var <tt>stream_193</tt>"]
-    style var_stream_193 fill:transparent
+subgraph var_stream_195 ["var <tt>stream_195</tt>"]
+    style var_stream_195 fill:transparent
     94v1
-end
-subgraph var_stream_196 ["var <tt>stream_196</tt>"]
-    style var_stream_196 fill:transparent
-    95v1
-end
-subgraph var_stream_197 ["var <tt>stream_197</tt>"]
-    style var_stream_197 fill:transparent
-    96v1
 end
 subgraph var_stream_198 ["var <tt>stream_198</tt>"]
     style var_stream_198 fill:transparent
+    95v1
+end
+subgraph var_stream_199 ["var <tt>stream_199</tt>"]
+    style var_stream_199 fill:transparent
+    96v1
+end
+subgraph var_stream_200 ["var <tt>stream_200</tt>"]
+    style var_stream_200 fill:transparent
     97v1
-end
-subgraph var_stream_201 ["var <tt>stream_201</tt>"]
-    style var_stream_201 fill:transparent
-    98v1
-end
-subgraph var_stream_202 ["var <tt>stream_202</tt>"]
-    style var_stream_202 fill:transparent
-    99v1
 end
 subgraph var_stream_203 ["var <tt>stream_203</tt>"]
     style var_stream_203 fill:transparent
-    100v1
+    98v1
+end
+subgraph var_stream_204 ["var <tt>stream_204</tt>"]
+    style var_stream_204 fill:transparent
+    99v1
 end
 subgraph var_stream_205 ["var <tt>stream_205</tt>"]
     style var_stream_205 fill:transparent
-    102v1
+    100v1
 end
-subgraph var_stream_208 ["var <tt>stream_208</tt>"]
-    style var_stream_208 fill:transparent
-    103v1
+subgraph var_stream_207 ["var <tt>stream_207</tt>"]
+    style var_stream_207 fill:transparent
+    102v1
 end
 subgraph var_stream_210 ["var <tt>stream_210</tt>"]
     style var_stream_210 fill:transparent
+    103v1
+end
+subgraph var_stream_212 ["var <tt>stream_212</tt>"]
+    style var_stream_212 fill:transparent
     104v1
 end
-subgraph var_stream_213 ["var <tt>stream_213</tt>"]
-    style var_stream_213 fill:transparent
+subgraph var_stream_215 ["var <tt>stream_215</tt>"]
+    style var_stream_215 fill:transparent
     106v1
 end
-subgraph var_stream_216 ["var <tt>stream_216</tt>"]
-    style var_stream_216 fill:transparent
+subgraph var_stream_218 ["var <tt>stream_218</tt>"]
+    style var_stream_218 fill:transparent
     107v1
-end
-subgraph var_stream_217 ["var <tt>stream_217</tt>"]
-    style var_stream_217 fill:transparent
-    108v1
 end
 subgraph var_stream_219 ["var <tt>stream_219</tt>"]
     style var_stream_219 fill:transparent
-    109v1
+    108v1
 end
 subgraph var_stream_22 ["var <tt>stream_22</tt>"]
     style var_stream_22 fill:transparent
     1v1
 end
-subgraph var_stream_220 ["var <tt>stream_220</tt>"]
-    style var_stream_220 fill:transparent
-    110v1
-end
 subgraph var_stream_221 ["var <tt>stream_221</tt>"]
     style var_stream_221 fill:transparent
+    109v1
+end
+subgraph var_stream_222 ["var <tt>stream_222</tt>"]
+    style var_stream_222 fill:transparent
+    110v1
+end
+subgraph var_stream_223 ["var <tt>stream_223</tt>"]
+    style var_stream_223 fill:transparent
     111v1
 end
-subgraph var_stream_225 ["var <tt>stream_225</tt>"]
-    style var_stream_225 fill:transparent
+subgraph var_stream_227 ["var <tt>stream_227</tt>"]
+    style var_stream_227 fill:transparent
     112v1
 end
-subgraph var_stream_226 ["var <tt>stream_226</tt>"]
-    style var_stream_226 fill:transparent
+subgraph var_stream_228 ["var <tt>stream_228</tt>"]
+    style var_stream_228 fill:transparent
     113v1
 end
-subgraph var_stream_231 ["var <tt>stream_231</tt>"]
-    style var_stream_231 fill:transparent
+subgraph var_stream_233 ["var <tt>stream_233</tt>"]
+    style var_stream_233 fill:transparent
     114v1
-end
-subgraph var_stream_235 ["var <tt>stream_235</tt>"]
-    style var_stream_235 fill:transparent
-    115v1
-end
-subgraph var_stream_236 ["var <tt>stream_236</tt>"]
-    style var_stream_236 fill:transparent
-    116v1
 end
 subgraph var_stream_237 ["var <tt>stream_237</tt>"]
     style var_stream_237 fill:transparent
-    117v1
+    115v1
 end
 subgraph var_stream_238 ["var <tt>stream_238</tt>"]
     style var_stream_238 fill:transparent
-    118v1
+    116v1
 end
 subgraph var_stream_239 ["var <tt>stream_239</tt>"]
     style var_stream_239 fill:transparent
-    119v1
+    117v1
 end
 subgraph var_stream_240 ["var <tt>stream_240</tt>"]
     style var_stream_240 fill:transparent
-    120v1
-    121v1
+    118v1
+end
+subgraph var_stream_241 ["var <tt>stream_241</tt>"]
+    style var_stream_241 fill:transparent
+    119v1
 end
 subgraph var_stream_242 ["var <tt>stream_242</tt>"]
     style var_stream_242 fill:transparent
-    122v1
+    120v1
+    121v1
 end
 subgraph var_stream_244 ["var <tt>stream_244</tt>"]
     style var_stream_244 fill:transparent
-    123v1
+    122v1
 end
-subgraph var_stream_247 ["var <tt>stream_247</tt>"]
-    style var_stream_247 fill:transparent
-    124v1
+subgraph var_stream_246 ["var <tt>stream_246</tt>"]
+    style var_stream_246 fill:transparent
+    123v1
 end
 subgraph var_stream_249 ["var <tt>stream_249</tt>"]
     style var_stream_249 fill:transparent
-    125v1
+    124v1
 end
-subgraph var_stream_252 ["var <tt>stream_252</tt>"]
-    style var_stream_252 fill:transparent
-    126v1
+subgraph var_stream_251 ["var <tt>stream_251</tt>"]
+    style var_stream_251 fill:transparent
+    125v1
 end
 subgraph var_stream_254 ["var <tt>stream_254</tt>"]
     style var_stream_254 fill:transparent
-    127v1
+    126v1
 end
-subgraph var_stream_255 ["var <tt>stream_255</tt>"]
-    style var_stream_255 fill:transparent
-    128v1
+subgraph var_stream_256 ["var <tt>stream_256</tt>"]
+    style var_stream_256 fill:transparent
+    127v1
 end
 subgraph var_stream_257 ["var <tt>stream_257</tt>"]
     style var_stream_257 fill:transparent
+    128v1
+end
+subgraph var_stream_259 ["var <tt>stream_259</tt>"]
+    style var_stream_259 fill:transparent
     130v1
 end
-subgraph var_stream_258 ["var <tt>stream_258</tt>"]
-    style var_stream_258 fill:transparent
+subgraph var_stream_260 ["var <tt>stream_260</tt>"]
+    style var_stream_260 fill:transparent
     131v1
 end
-subgraph var_stream_276 ["var <tt>stream_276</tt>"]
-    style var_stream_276 fill:transparent
+subgraph var_stream_278 ["var <tt>stream_278</tt>"]
+    style var_stream_278 fill:transparent
     133v1
-end
-subgraph var_stream_277 ["var <tt>stream_277</tt>"]
-    style var_stream_277 fill:transparent
-    134v1
 end
 subgraph var_stream_279 ["var <tt>stream_279</tt>"]
     style var_stream_279 fill:transparent
-    135v1
+    134v1
 end
 subgraph var_stream_28 ["var <tt>stream_28</tt>"]
     style var_stream_28 fill:transparent
@@ -945,355 +941,359 @@ subgraph var_stream_28 ["var <tt>stream_28</tt>"]
 end
 subgraph var_stream_281 ["var <tt>stream_281</tt>"]
     style var_stream_281 fill:transparent
+    135v1
+end
+subgraph var_stream_283 ["var <tt>stream_283</tt>"]
+    style var_stream_283 fill:transparent
     136v1
 end
-subgraph var_stream_284 ["var <tt>stream_284</tt>"]
-    style var_stream_284 fill:transparent
+subgraph var_stream_286 ["var <tt>stream_286</tt>"]
+    style var_stream_286 fill:transparent
     137v1
-end
-subgraph var_stream_289 ["var <tt>stream_289</tt>"]
-    style var_stream_289 fill:transparent
-    138v1
-end
-subgraph var_stream_290 ["var <tt>stream_290</tt>"]
-    style var_stream_290 fill:transparent
-    139v1
 end
 subgraph var_stream_291 ["var <tt>stream_291</tt>"]
     style var_stream_291 fill:transparent
-    140v1
+    138v1
 end
 subgraph var_stream_292 ["var <tt>stream_292</tt>"]
     style var_stream_292 fill:transparent
-    141v1
+    139v1
 end
 subgraph var_stream_293 ["var <tt>stream_293</tt>"]
     style var_stream_293 fill:transparent
-    142v1
+    140v1
 end
 subgraph var_stream_294 ["var <tt>stream_294</tt>"]
     style var_stream_294 fill:transparent
-    143v1
-    144v1
+    141v1
+end
+subgraph var_stream_295 ["var <tt>stream_295</tt>"]
+    style var_stream_295 fill:transparent
+    142v1
 end
 subgraph var_stream_296 ["var <tt>stream_296</tt>"]
     style var_stream_296 fill:transparent
-    145v1
+    143v1
+    144v1
 end
 subgraph var_stream_298 ["var <tt>stream_298</tt>"]
     style var_stream_298 fill:transparent
-    146v1
-end
-subgraph var_stream_299 ["var <tt>stream_299</tt>"]
-    style var_stream_299 fill:transparent
-    147v1
+    145v1
 end
 subgraph var_stream_30 ["var <tt>stream_30</tt>"]
     style var_stream_30 fill:transparent
     4v1
 end
+subgraph var_stream_300 ["var <tt>stream_300</tt>"]
+    style var_stream_300 fill:transparent
+    146v1
+end
 subgraph var_stream_301 ["var <tt>stream_301</tt>"]
     style var_stream_301 fill:transparent
-    148v1
-end
-subgraph var_stream_302 ["var <tt>stream_302</tt>"]
-    style var_stream_302 fill:transparent
-    149v1
+    147v1
 end
 subgraph var_stream_303 ["var <tt>stream_303</tt>"]
     style var_stream_303 fill:transparent
-    150v1
+    148v1
 end
 subgraph var_stream_304 ["var <tt>stream_304</tt>"]
     style var_stream_304 fill:transparent
-    151v1
+    149v1
 end
 subgraph var_stream_305 ["var <tt>stream_305</tt>"]
     style var_stream_305 fill:transparent
+    150v1
+end
+subgraph var_stream_306 ["var <tt>stream_306</tt>"]
+    style var_stream_306 fill:transparent
+    151v1
+end
+subgraph var_stream_307 ["var <tt>stream_307</tt>"]
+    style var_stream_307 fill:transparent
     152v1
 end
-subgraph var_stream_309 ["var <tt>stream_309</tt>"]
-    style var_stream_309 fill:transparent
+subgraph var_stream_311 ["var <tt>stream_311</tt>"]
+    style var_stream_311 fill:transparent
     153v1
 end
 subgraph var_stream_33 ["var <tt>stream_33</tt>"]
     style var_stream_33 fill:transparent
     5v1
 end
-subgraph var_stream_336 ["var <tt>stream_336</tt>"]
-    style var_stream_336 fill:transparent
-    158v1
-end
-subgraph var_stream_337 ["var <tt>stream_337</tt>"]
-    style var_stream_337 fill:transparent
-    159v1
-end
 subgraph var_stream_338 ["var <tt>stream_338</tt>"]
     style var_stream_338 fill:transparent
-    160v1
+    158v1
 end
 subgraph var_stream_339 ["var <tt>stream_339</tt>"]
     style var_stream_339 fill:transparent
-    161v1
+    159v1
+end
+subgraph var_stream_340 ["var <tt>stream_340</tt>"]
+    style var_stream_340 fill:transparent
+    160v1
 end
 subgraph var_stream_341 ["var <tt>stream_341</tt>"]
     style var_stream_341 fill:transparent
-    162v1
-end
-subgraph var_stream_342 ["var <tt>stream_342</tt>"]
-    style var_stream_342 fill:transparent
-    163v1
+    161v1
 end
 subgraph var_stream_343 ["var <tt>stream_343</tt>"]
     style var_stream_343 fill:transparent
-    164v1
+    162v1
 end
-subgraph var_stream_346 ["var <tt>stream_346</tt>"]
-    style var_stream_346 fill:transparent
-    165v1
+subgraph var_stream_344 ["var <tt>stream_344</tt>"]
+    style var_stream_344 fill:transparent
+    163v1
+end
+subgraph var_stream_345 ["var <tt>stream_345</tt>"]
+    style var_stream_345 fill:transparent
+    164v1
 end
 subgraph var_stream_348 ["var <tt>stream_348</tt>"]
     style var_stream_348 fill:transparent
-    166v1
-end
-subgraph var_stream_349 ["var <tt>stream_349</tt>"]
-    style var_stream_349 fill:transparent
-    167v1
+    165v1
 end
 subgraph var_stream_35 ["var <tt>stream_35</tt>"]
     style var_stream_35 fill:transparent
     6v1
 end
-subgraph var_stream_352 ["var <tt>stream_352</tt>"]
-    style var_stream_352 fill:transparent
-    168v1
+subgraph var_stream_350 ["var <tt>stream_350</tt>"]
+    style var_stream_350 fill:transparent
+    166v1
+end
+subgraph var_stream_351 ["var <tt>stream_351</tt>"]
+    style var_stream_351 fill:transparent
+    167v1
 end
 subgraph var_stream_354 ["var <tt>stream_354</tt>"]
     style var_stream_354 fill:transparent
-    169v1
+    168v1
 end
-subgraph var_stream_355 ["var <tt>stream_355</tt>"]
-    style var_stream_355 fill:transparent
-    170v1
-    171v1
+subgraph var_stream_356 ["var <tt>stream_356</tt>"]
+    style var_stream_356 fill:transparent
+    169v1
 end
 subgraph var_stream_357 ["var <tt>stream_357</tt>"]
     style var_stream_357 fill:transparent
+    170v1
+    171v1
+end
+subgraph var_stream_359 ["var <tt>stream_359</tt>"]
+    style var_stream_359 fill:transparent
     172v1
 end
 subgraph var_stream_36 ["var <tt>stream_36</tt>"]
     style var_stream_36 fill:transparent
     7v1
 end
-subgraph var_stream_360 ["var <tt>stream_360</tt>"]
-    style var_stream_360 fill:transparent
+subgraph var_stream_362 ["var <tt>stream_362</tt>"]
+    style var_stream_362 fill:transparent
     173v1
-end
-subgraph var_stream_369 ["var <tt>stream_369</tt>"]
-    style var_stream_369 fill:transparent
-    175v1
-    176v1
 end
 subgraph var_stream_371 ["var <tt>stream_371</tt>"]
     style var_stream_371 fill:transparent
+    175v1
+    176v1
+end
+subgraph var_stream_373 ["var <tt>stream_373</tt>"]
+    style var_stream_373 fill:transparent
     177v1
-end
-subgraph var_stream_375 ["var <tt>stream_375</tt>"]
-    style var_stream_375 fill:transparent
-    178v1
-end
-subgraph var_stream_376 ["var <tt>stream_376</tt>"]
-    style var_stream_376 fill:transparent
-    179v1
 end
 subgraph var_stream_377 ["var <tt>stream_377</tt>"]
     style var_stream_377 fill:transparent
+    178v1
+end
+subgraph var_stream_378 ["var <tt>stream_378</tt>"]
+    style var_stream_378 fill:transparent
+    179v1
+end
+subgraph var_stream_379 ["var <tt>stream_379</tt>"]
+    style var_stream_379 fill:transparent
     180v1
-end
-subgraph var_stream_380 ["var <tt>stream_380</tt>"]
-    style var_stream_380 fill:transparent
-    181v1
-end
-subgraph var_stream_381 ["var <tt>stream_381</tt>"]
-    style var_stream_381 fill:transparent
-    182v1
 end
 subgraph var_stream_382 ["var <tt>stream_382</tt>"]
     style var_stream_382 fill:transparent
-    183v1
+    181v1
 end
 subgraph var_stream_383 ["var <tt>stream_383</tt>"]
     style var_stream_383 fill:transparent
-    184v1
+    182v1
+end
+subgraph var_stream_384 ["var <tt>stream_384</tt>"]
+    style var_stream_384 fill:transparent
+    183v1
 end
 subgraph var_stream_385 ["var <tt>stream_385</tt>"]
     style var_stream_385 fill:transparent
-    185v1
+    184v1
 end
 subgraph var_stream_387 ["var <tt>stream_387</tt>"]
     style var_stream_387 fill:transparent
+    185v1
+end
+subgraph var_stream_389 ["var <tt>stream_389</tt>"]
+    style var_stream_389 fill:transparent
     186v1
 end
 subgraph var_stream_39 ["var <tt>stream_39</tt>"]
     style var_stream_39 fill:transparent
     8v1
 end
-subgraph var_stream_392 ["var <tt>stream_392</tt>"]
-    style var_stream_392 fill:transparent
-    188v1
-end
 subgraph var_stream_394 ["var <tt>stream_394</tt>"]
     style var_stream_394 fill:transparent
-    189v1
+    188v1
 end
-subgraph var_stream_395 ["var <tt>stream_395</tt>"]
-    style var_stream_395 fill:transparent
-    190v1
+subgraph var_stream_396 ["var <tt>stream_396</tt>"]
+    style var_stream_396 fill:transparent
+    189v1
 end
 subgraph var_stream_397 ["var <tt>stream_397</tt>"]
     style var_stream_397 fill:transparent
-    191v1
+    190v1
 end
 subgraph var_stream_399 ["var <tt>stream_399</tt>"]
     style var_stream_399 fill:transparent
+    191v1
+end
+subgraph var_stream_401 ["var <tt>stream_401</tt>"]
+    style var_stream_401 fill:transparent
     192v1
 end
-subgraph var_stream_402 ["var <tt>stream_402</tt>"]
-    style var_stream_402 fill:transparent
+subgraph var_stream_404 ["var <tt>stream_404</tt>"]
+    style var_stream_404 fill:transparent
     193v1
 end
-subgraph var_stream_409 ["var <tt>stream_409</tt>"]
-    style var_stream_409 fill:transparent
+subgraph var_stream_411 ["var <tt>stream_411</tt>"]
+    style var_stream_411 fill:transparent
     195v1
-end
-subgraph var_stream_412 ["var <tt>stream_412</tt>"]
-    style var_stream_412 fill:transparent
-    196v1
 end
 subgraph var_stream_414 ["var <tt>stream_414</tt>"]
     style var_stream_414 fill:transparent
-    197v1
-end
-subgraph var_stream_415 ["var <tt>stream_415</tt>"]
-    style var_stream_415 fill:transparent
-    198v1
+    196v1
 end
 subgraph var_stream_416 ["var <tt>stream_416</tt>"]
     style var_stream_416 fill:transparent
-    199v1
-    200v1
+    197v1
+end
+subgraph var_stream_417 ["var <tt>stream_417</tt>"]
+    style var_stream_417 fill:transparent
+    198v1
 end
 subgraph var_stream_418 ["var <tt>stream_418</tt>"]
     style var_stream_418 fill:transparent
+    199v1
+    200v1
+end
+subgraph var_stream_420 ["var <tt>stream_420</tt>"]
+    style var_stream_420 fill:transparent
     201v1
 end
-subgraph var_stream_424 ["var <tt>stream_424</tt>"]
-    style var_stream_424 fill:transparent
+subgraph var_stream_426 ["var <tt>stream_426</tt>"]
+    style var_stream_426 fill:transparent
     203v1
-end
-subgraph var_stream_429 ["var <tt>stream_429</tt>"]
-    style var_stream_429 fill:transparent
-    204v1
 end
 subgraph var_stream_431 ["var <tt>stream_431</tt>"]
     style var_stream_431 fill:transparent
+    204v1
+end
+subgraph var_stream_433 ["var <tt>stream_433</tt>"]
+    style var_stream_433 fill:transparent
     205v1
-end
-subgraph var_stream_435 ["var <tt>stream_435</tt>"]
-    style var_stream_435 fill:transparent
-    206v1
-end
-subgraph var_stream_436 ["var <tt>stream_436</tt>"]
-    style var_stream_436 fill:transparent
-    207v1
 end
 subgraph var_stream_437 ["var <tt>stream_437</tt>"]
     style var_stream_437 fill:transparent
-    208v1
+    206v1
 end
 subgraph var_stream_438 ["var <tt>stream_438</tt>"]
     style var_stream_438 fill:transparent
-    209v1
+    207v1
 end
 subgraph var_stream_439 ["var <tt>stream_439</tt>"]
     style var_stream_439 fill:transparent
-    210v1
+    208v1
+end
+subgraph var_stream_440 ["var <tt>stream_440</tt>"]
+    style var_stream_440 fill:transparent
+    209v1
 end
 subgraph var_stream_441 ["var <tt>stream_441</tt>"]
     style var_stream_441 fill:transparent
-    211v1
-end
-subgraph var_stream_442 ["var <tt>stream_442</tt>"]
-    style var_stream_442 fill:transparent
-    212v1
+    210v1
 end
 subgraph var_stream_443 ["var <tt>stream_443</tt>"]
     style var_stream_443 fill:transparent
-    213v1
+    211v1
+end
+subgraph var_stream_444 ["var <tt>stream_444</tt>"]
+    style var_stream_444 fill:transparent
+    212v1
 end
 subgraph var_stream_445 ["var <tt>stream_445</tt>"]
     style var_stream_445 fill:transparent
-    214v1
+    213v1
 end
 subgraph var_stream_447 ["var <tt>stream_447</tt>"]
     style var_stream_447 fill:transparent
-    215v1
+    214v1
 end
 subgraph var_stream_449 ["var <tt>stream_449</tt>"]
     style var_stream_449 fill:transparent
-    216v1
+    215v1
 end
 subgraph var_stream_45 ["var <tt>stream_45</tt>"]
     style var_stream_45 fill:transparent
     9v1
 end
-subgraph var_stream_460 ["var <tt>stream_460</tt>"]
-    style var_stream_460 fill:transparent
-    219v1
-    220v1
+subgraph var_stream_451 ["var <tt>stream_451</tt>"]
+    style var_stream_451 fill:transparent
+    216v1
 end
 subgraph var_stream_462 ["var <tt>stream_462</tt>"]
     style var_stream_462 fill:transparent
-    221v1
+    219v1
+    220v1
 end
-subgraph var_stream_463 ["var <tt>stream_463</tt>"]
-    style var_stream_463 fill:transparent
-    222v1
+subgraph var_stream_464 ["var <tt>stream_464</tt>"]
+    style var_stream_464 fill:transparent
+    221v1
 end
 subgraph var_stream_465 ["var <tt>stream_465</tt>"]
     style var_stream_465 fill:transparent
+    222v1
+end
+subgraph var_stream_467 ["var <tt>stream_467</tt>"]
+    style var_stream_467 fill:transparent
     223v1
 end
-subgraph var_stream_466 ["var <tt>stream_466</tt>"]
-    style var_stream_466 fill:transparent
+subgraph var_stream_468 ["var <tt>stream_468</tt>"]
+    style var_stream_468 fill:transparent
     224v1
-end
-subgraph var_stream_469 ["var <tt>stream_469</tt>"]
-    style var_stream_469 fill:transparent
-    225v1
 end
 subgraph var_stream_47 ["var <tt>stream_47</tt>"]
     style var_stream_47 fill:transparent
     10v1
 end
-subgraph var_stream_470 ["var <tt>stream_470</tt>"]
-    style var_stream_470 fill:transparent
-    226v1
-end
 subgraph var_stream_471 ["var <tt>stream_471</tt>"]
     style var_stream_471 fill:transparent
+    225v1
+end
+subgraph var_stream_472 ["var <tt>stream_472</tt>"]
+    style var_stream_472 fill:transparent
+    226v1
+end
+subgraph var_stream_473 ["var <tt>stream_473</tt>"]
+    style var_stream_473 fill:transparent
     227v1
-end
-subgraph var_stream_474 ["var <tt>stream_474</tt>"]
-    style var_stream_474 fill:transparent
-    228v1
-end
-subgraph var_stream_475 ["var <tt>stream_475</tt>"]
-    style var_stream_475 fill:transparent
-    229v1
 end
 subgraph var_stream_476 ["var <tt>stream_476</tt>"]
     style var_stream_476 fill:transparent
+    228v1
+end
+subgraph var_stream_477 ["var <tt>stream_477</tt>"]
+    style var_stream_477 fill:transparent
+    229v1
+end
+subgraph var_stream_478 ["var <tt>stream_478</tt>"]
+    style var_stream_478 fill:transparent
     230v1
 end
 subgraph var_stream_48 ["var <tt>stream_48</tt>"]
@@ -1301,124 +1301,124 @@ subgraph var_stream_48 ["var <tt>stream_48</tt>"]
     11v1
     12v1
 end
-subgraph var_stream_480 ["var <tt>stream_480</tt>"]
-    style var_stream_480 fill:transparent
+subgraph var_stream_482 ["var <tt>stream_482</tt>"]
+    style var_stream_482 fill:transparent
     232v1
-end
-subgraph var_stream_481 ["var <tt>stream_481</tt>"]
-    style var_stream_481 fill:transparent
-    233v1
 end
 subgraph var_stream_483 ["var <tt>stream_483</tt>"]
     style var_stream_483 fill:transparent
-    234v1
+    233v1
 end
 subgraph var_stream_485 ["var <tt>stream_485</tt>"]
     style var_stream_485 fill:transparent
+    234v1
+end
+subgraph var_stream_487 ["var <tt>stream_487</tt>"]
+    style var_stream_487 fill:transparent
     236v1
 end
-subgraph var_stream_490 ["var <tt>stream_490</tt>"]
-    style var_stream_490 fill:transparent
+subgraph var_stream_492 ["var <tt>stream_492</tt>"]
+    style var_stream_492 fill:transparent
     237v1
 end
-subgraph var_stream_491 ["var <tt>stream_491</tt>"]
-    style var_stream_491 fill:transparent
+subgraph var_stream_493 ["var <tt>stream_493</tt>"]
+    style var_stream_493 fill:transparent
     238v1
 end
-subgraph var_stream_494 ["var <tt>stream_494</tt>"]
-    style var_stream_494 fill:transparent
+subgraph var_stream_496 ["var <tt>stream_496</tt>"]
+    style var_stream_496 fill:transparent
     239v1
-end
-subgraph var_stream_495 ["var <tt>stream_495</tt>"]
-    style var_stream_495 fill:transparent
-    240v1
 end
 subgraph var_stream_497 ["var <tt>stream_497</tt>"]
     style var_stream_497 fill:transparent
-    241v1
+    240v1
 end
 subgraph var_stream_499 ["var <tt>stream_499</tt>"]
     style var_stream_499 fill:transparent
-    242v1
+    241v1
 end
 subgraph var_stream_50 ["var <tt>stream_50</tt>"]
     style var_stream_50 fill:transparent
     13v1
 end
-subgraph var_stream_500 ["var <tt>stream_500</tt>"]
-    style var_stream_500 fill:transparent
-    243v1
-end
 subgraph var_stream_501 ["var <tt>stream_501</tt>"]
     style var_stream_501 fill:transparent
+    242v1
+end
+subgraph var_stream_502 ["var <tt>stream_502</tt>"]
+    style var_stream_502 fill:transparent
+    243v1
+end
+subgraph var_stream_503 ["var <tt>stream_503</tt>"]
+    style var_stream_503 fill:transparent
     244v1
 end
 subgraph var_stream_52 ["var <tt>stream_52</tt>"]
     style var_stream_52 fill:transparent
     14v1
 end
-subgraph var_stream_529 ["var <tt>stream_529</tt>"]
-    style var_stream_529 fill:transparent
+subgraph var_stream_531 ["var <tt>stream_531</tt>"]
+    style var_stream_531 fill:transparent
     247v1
 end
-subgraph var_stream_530 ["var <tt>stream_530</tt>"]
-    style var_stream_530 fill:transparent
+subgraph var_stream_532 ["var <tt>stream_532</tt>"]
+    style var_stream_532 fill:transparent
     248v1
-end
-subgraph var_stream_533 ["var <tt>stream_533</tt>"]
-    style var_stream_533 fill:transparent
-    250v1
-end
-subgraph var_stream_534 ["var <tt>stream_534</tt>"]
-    style var_stream_534 fill:transparent
-    251v1
 end
 subgraph var_stream_535 ["var <tt>stream_535</tt>"]
     style var_stream_535 fill:transparent
-    252v1
+    250v1
 end
-subgraph var_stream_539 ["var <tt>stream_539</tt>"]
-    style var_stream_539 fill:transparent
-    254v1
+subgraph var_stream_536 ["var <tt>stream_536</tt>"]
+    style var_stream_536 fill:transparent
+    251v1
+end
+subgraph var_stream_537 ["var <tt>stream_537</tt>"]
+    style var_stream_537 fill:transparent
+    252v1
 end
 subgraph var_stream_54 ["var <tt>stream_54</tt>"]
     style var_stream_54 fill:transparent
     15v1
 end
-subgraph var_stream_540 ["var <tt>stream_540</tt>"]
-    style var_stream_540 fill:transparent
-    255v1
+subgraph var_stream_541 ["var <tt>stream_541</tt>"]
+    style var_stream_541 fill:transparent
+    254v1
 end
 subgraph var_stream_542 ["var <tt>stream_542</tt>"]
     style var_stream_542 fill:transparent
-    256v1
+    255v1
 end
 subgraph var_stream_544 ["var <tt>stream_544</tt>"]
     style var_stream_544 fill:transparent
+    256v1
+end
+subgraph var_stream_546 ["var <tt>stream_546</tt>"]
+    style var_stream_546 fill:transparent
     257v1
 end
-subgraph var_stream_547 ["var <tt>stream_547</tt>"]
-    style var_stream_547 fill:transparent
+subgraph var_stream_549 ["var <tt>stream_549</tt>"]
+    style var_stream_549 fill:transparent
     258v1
 end
 subgraph var_stream_55 ["var <tt>stream_55</tt>"]
     style var_stream_55 fill:transparent
     16v1
 end
-subgraph var_stream_551 ["var <tt>stream_551</tt>"]
-    style var_stream_551 fill:transparent
+subgraph var_stream_553 ["var <tt>stream_553</tt>"]
+    style var_stream_553 fill:transparent
     259v1
-end
-subgraph var_stream_552 ["var <tt>stream_552</tt>"]
-    style var_stream_552 fill:transparent
-    260v1
 end
 subgraph var_stream_554 ["var <tt>stream_554</tt>"]
     style var_stream_554 fill:transparent
-    261v1
+    260v1
 end
 subgraph var_stream_556 ["var <tt>stream_556</tt>"]
     style var_stream_556 fill:transparent
+    261v1
+end
+subgraph var_stream_558 ["var <tt>stream_558</tt>"]
+    style var_stream_558 fill:transparent
     262v1
 end
 subgraph var_stream_56 ["var <tt>stream_56</tt>"]


### PR DESCRIPTION
Converted 8 out of 8 cross_singleton usages in paxos.rs to use the
by_ref() singleton reference mechanism:

- recommit_after_leader_election: 3 cross_singleton calls replaced with
  by_ref() captures in filter_map and map closures (p_ballot and
  p_p1b_max_checkpoint captured as refs)
- sequence_payload: 1 cross_singleton replaced with by_ref() in map
  (p_ballot captured as ref)
- index_payloads (sliced!): 1 cross_singleton replaced with by_ref() in
  map (base_slot captured as ref)
- acceptor_p2: 2 cross_singleton calls replaced with by_ref() captures
  in filter_map and map closures (a_max_ballot captured as ref)
- acceptor_p1: both cross_singleton(a_max_ballot) and cross_singleton(a_log)
  replaced with by_ref() captures in the map closure

Added + 'a lifetime bounds where required by by_ref() usage:
- PaxosLike::build, PaxosLike::with_client (paxos_with_client.rs)
- paxos_core, index_payloads (paxos.rs)
- compartmentalized_paxos_core, CoreCompartmentalizedPaxos::build
  (compartmentalized_paxos.rs)
- Added + 'a bounds on L in acceptor_p1 and leader_election signatures

Updated IR snapshots (both stable and nightly) to reflect the new
reference nodes replacing cross_singleton patterns.