### PR TITLE
feat(hydro_lang): support `merge_ordered` on `KeyedStream`

### DIFF
--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2756,6 +2756,71 @@ impl<'a, K, V, L: Location<'a>, O: Ordering, R: Retries> KeyedStream<K, V, L, Un
     }
 }
 
+impl<'a, K, V, L: Location<'a>, B: Boundedness, R: Retries> KeyedStream<K, V, L, B, TotalOrder, R> {
+    /// Produces a new keyed stream that combines the elements of the two input keyed streams,
+    /// preserving the relative order of elements within each group of each input.
+    ///
+    /// Because each group in both inputs is [`TotalOrder`], the output preserves the relative
+    /// order of elements within each group of each input, and the result is [`TotalOrder`].
+    ///
+    /// # Non-Determinism
+    /// For groups whose key appears in both inputs, the order in which the elements of the two
+    /// inputs are interleaved *within that group* is non-deterministic, so the order of elements
+    /// will vary across runs. If the keys across both inputs do not overlap, the ordering is
+    /// deterministic. If the output order within each group is irrelevant, use
+    /// [`KeyedStream::merge_unordered`] instead, which is deterministic but emits an unordered
+    /// keyed stream.
+    ///
+    /// # Example
+    /// ```rust
+    /// # #[cfg(feature = "deploy")] {
+    /// # use hydro_lang::prelude::*;
+    /// # use futures::StreamExt;
+    /// # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
+    /// let numbers1: KeyedStream<i32, i32, _> = // { 1: [2], 3: [4] }
+    /// # process.source_iter(q!(vec![(1, 2), (3, 4)])).into_keyed().into();
+    /// let numbers2: KeyedStream<i32, i32, _> = // { 1: [3], 3: [5] }
+    /// # process.source_iter(q!(vec![(1, 3), (3, 5)])).into_keyed().into();
+    /// numbers1.merge_ordered(numbers2, nondet!(/** example */))
+    /// #   .entries()
+    /// # }, |mut stream| async move {
+    /// // { 1: [2, 3], 3: [4, 5] } with each group interleaved in some order
+    /// # let mut results = Vec::new();
+    /// # for _ in 0..4 {
+    /// #     results.push(stream.next().await.unwrap());
+    /// # }
+    /// # results.sort();
+    /// # assert_eq!(results, vec![(1, 2), (1, 3), (3, 4), (3, 5)]);
+    /// # }));
+    /// # }
+    /// ```
+    pub fn merge_ordered<R2: Retries>(
+        self,
+        other: KeyedStream<K, V, L, B, TotalOrder, R2>,
+        _nondet: NonDet,
+    ) -> KeyedStream<K, V, L::DropConsistency, B, TotalOrder, <R as MinRetries<R2>>::Min>
+    where
+        R: MinRetries<R2>,
+    {
+        let target_location = self.location.drop_consistency();
+        KeyedStream::new(
+            target_location.clone(),
+            HydroNode::MergeOrdered {
+                first: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                second: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
+                metadata: target_location.new_node_metadata(KeyedStream::<
+                    K,
+                    V,
+                    L::DropConsistency,
+                    B,
+                    TotalOrder,
+                    <R as MinRetries<R2>>::Min,
+                >::collection_kind()),
+            },
+        )
+    }
+}
+
 impl<'a, K, V, L, B: Boundedness, O: Ordering, R: Retries> KeyedStream<K, V, Atomic<L>, B, O, R>
 where
     L: Location<'a>,
@@ -3685,5 +3750,129 @@ mod tests {
 
         assert!(saw, "did not see an instance with (1, 1) before (1, 2)");
         assert_eq!(instance_count, 78);
+    }
+
+    /// Tests that `merge_ordered` on a keyed stream explores every valid
+    /// interleaving within a shared key while always preserving per-input
+    /// order.
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_keyed_merge_ordered() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (in_send, input) = node.sim_input::<_, TotalOrder, _>();
+        let (in_send2, input2) = node.sim_input::<_, TotalOrder, _>();
+
+        let out_recv = input
+            .into_keyed()
+            .merge_ordered(input2.into_keyed(), nondet!(/** test */))
+            .entries_partially_ordered(nondet!(/** test */))
+            .sim_output();
+
+        let mut saw_first = false;
+        let mut saw_interleaved = false;
+        let mut saw_second_first = false;
+        let instances = flow.sim().exhaustive(async || {
+            in_send.send((1, 'a'));
+            in_send.send((1, 'b'));
+            in_send2.send((1, 'c'));
+
+            let out: Vec<(i32, char)> = out_recv.collect().await;
+            let key1: Vec<char> = out
+                .iter()
+                .filter(|(k, _)| *k == 1)
+                .map(|(_, v)| *v)
+                .collect();
+
+            // Within-group order for the first input must always be preserved.
+            let first_order: Vec<char> = key1
+                .iter()
+                .filter(|c| **c == 'a' || **c == 'b')
+                .copied()
+                .collect();
+            assert_eq!(
+                first_order,
+                vec!['a', 'b'],
+                "within-group order violated: {:?}",
+                out
+            );
+
+            match key1.as_slice() {
+                ['a', 'b', 'c'] => saw_first = true,
+                ['a', 'c', 'b'] => saw_interleaved = true,
+                ['c', 'a', 'b'] => saw_second_first = true,
+                other => panic!("unexpected interleaving: {:?}", other),
+            }
+        });
+
+        assert!(saw_first, "did not observe [a, b, c]");
+        assert!(saw_interleaved, "did not observe [a, c, b]");
+        assert!(saw_second_first, "did not observe [c, a, b]");
+        assert_eq!(instances, 33);
+    }
+
+    /// Tests that `merge_ordered` on a keyed stream interleaves each group
+    /// *independently*. It must be possible to observe, in the same execution,
+    /// key `10` taking its second-input value before its first-input value
+    /// while key `20` does the opposite. A merge that treated the two inputs
+    /// as a single totally-ordered sequence could not produce this combination.
+    #[cfg(feature = "sim")]
+    #[test]
+    fn sim_keyed_merge_ordered_independent_keys() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+
+        let (in_send, input) = node.sim_input::<_, TotalOrder, _>();
+        let (in_send2, input2) = node.sim_input::<_, TotalOrder, _>();
+
+        let out_recv = input
+            .into_keyed()
+            .merge_ordered(input2.into_keyed(), nondet!(/** test */))
+            .entries_partially_ordered(nondet!(/** test */))
+            .sim_output();
+
+        let mut saw_independent = false;
+        let instances = flow.sim().exhaustive(async || {
+            // First input: key 10 -> [1], key 20 -> [2].
+            in_send.send((10, 1));
+            in_send.send((20, 2));
+            // Second input: key 10 -> [4], key 20 -> [3].
+            in_send2.send((10, 4));
+            in_send2.send((20, 3));
+
+            let out: Vec<(i32, i32)> = out_recv.collect().await;
+            let key10: Vec<i32> = out
+                .iter()
+                .filter(|(k, _)| *k == 10)
+                .map(|(_, v)| *v)
+                .collect();
+            let key20: Vec<i32> = out
+                .iter()
+                .filter(|(k, _)| *k == 20)
+                .map(|(_, v)| *v)
+                .collect();
+
+            // Within-input order must be preserved within each key (each key has
+            // a single value per input here, so only the multiset is checked).
+            let mut s10 = key10.clone();
+            s10.sort();
+            assert_eq!(s10, vec![1, 4], "unexpected values for key 10: {:?}", out);
+            let mut s20 = key20.clone();
+            s20.sort();
+            assert_eq!(s20, vec![2, 3], "unexpected values for key 20: {:?}", out);
+
+            // key 10: second-input value (4) before first-input value (1).
+            // key 20: first-input value (2) before second-input value (3).
+            if key10 == vec![4, 1] && key20 == vec![2, 3] {
+                saw_independent = true;
+            }
+        });
+
+        assert!(
+            saw_independent,
+            "did not observe per-key-independent interleaving"
+        );
+        assert_eq!(instances, 2944);
     }
 }

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -1178,6 +1178,16 @@ impl DfirBuilder for SimBuilder {
             } => parse_quote!((#key_type, #value_type)),
         };
 
+        // A `KeyedStream` only guarantees ordering *within* each key. A plain
+        // stream merge over the `(K, V)` pairs already preserves each input's
+        // order (and hence each key's order), so it would be correct here too.
+        // Using dedicated keyed hooks is an optimization tailored to keyed
+        // streams: since cross-key order is unobservable, they interleave the two
+        // inputs independently per key and explore those per-key orderings
+        // directly, rather than global interleavings that differ only in
+        // unobservable cross-key order.
+        let is_keyed = matches!(in_kind, CollectionKind::KeyedStream { .. });
+
         if !location.is_root() || in_kind.is_bounded() {
             // Inside a tick: both inputs are fully materialized batches.
             // Generate a valid interleaving preserving per-input order.
@@ -1211,18 +1221,33 @@ impl DfirBuilder for SimBuilder {
                 let #buffered_second_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(None));
             });
 
-            self.add_inline_hook(
-                location,
-                syn::parse_quote!(
-                    Box::new(#root::sim::runtime::MergeOrderedHook::<_>::new(
-                        #buffered_first_ident.clone(),
-                        #buffered_second_ident.clone(),
-                        #hoff_send_ident,
-                        (#assume_location, #line, #caret),
-                        #root::__maybe_debug__!(#element_type),
-                    ))
-                ),
-            );
+            if is_keyed {
+                self.add_inline_hook(
+                    location,
+                    syn::parse_quote!(
+                        Box::new(#root::sim::runtime::KeyedMergeOrderedHook::<_, _>::new(
+                            #buffered_first_ident.clone(),
+                            #buffered_second_ident.clone(),
+                            #hoff_send_ident,
+                            (#assume_location, #line, #caret),
+                            #root::__maybe_debug__!(#element_type),
+                        ))
+                    ),
+                );
+            } else {
+                self.add_inline_hook(
+                    location,
+                    syn::parse_quote!(
+                        Box::new(#root::sim::runtime::MergeOrderedHook::<_>::new(
+                            #buffered_first_ident.clone(),
+                            #buffered_second_ident.clone(),
+                            #hoff_send_ident,
+                            (#assume_location, #line, #caret),
+                            #root::__maybe_debug__!(#element_type),
+                        ))
+                    ),
+                );
+            }
 
             let builder = self.get_dfir_mut(location);
 
@@ -1290,43 +1315,84 @@ impl DfirBuilder for SimBuilder {
             self.add_extra_stmt_internal(location, syn::parse_quote! {
                 let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
             });
-            self.add_extra_stmt_internal(location, syn::parse_quote! {
-                let #buffered_first_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
-            });
-            self.add_extra_stmt_internal(location, syn::parse_quote! {
-                let #buffered_second_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
-            });
-            self.add_hook(
-                location,
-                location,
-                syn::parse_quote!(
-                    Box::new(#root::sim::runtime::TopLevelMergeOrderedHook::<_> {
-                        first: #buffered_first_ident.clone(),
-                        second: #buffered_second_ident.clone(),
-                        to_release: None,
-                        release_source: None,
-                        output: #hoff_send_ident,
-                        location: (#assume_location, #line, #caret),
-                        format_item_debug: #root::__maybe_debug__!(#element_type),
-                    })
-                ),
-            );
 
-            self.get_dfir_mut(location).add_dfir(
-                parse_quote! {
-                    #first_ident -> for_each(|v| #buffered_first_ident.borrow_mut().push_back(v));
-                },
-                None,
-                None,
-            );
+            if is_keyed {
+                self.add_extra_stmt_internal(location, syn::parse_quote! {
+                    let #buffered_first_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(__root_dfir_rs::rustc_hash::FxHashMap::default()));
+                });
+                self.add_extra_stmt_internal(location, syn::parse_quote! {
+                    let #buffered_second_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(__root_dfir_rs::rustc_hash::FxHashMap::default()));
+                });
+                self.add_hook(
+                    location,
+                    location,
+                    syn::parse_quote!(
+                        Box::new(#root::sim::runtime::TopLevelKeyedMergeOrderedHook::<_, _> {
+                            first: #buffered_first_ident.clone(),
+                            second: #buffered_second_ident.clone(),
+                            to_release: None,
+                            release_source: None,
+                            output: #hoff_send_ident,
+                            location: (#assume_location, #line, #caret),
+                            format_item_debug: #root::__maybe_debug__!(#element_type),
+                        })
+                    ),
+                );
 
-            self.get_dfir_mut(location).add_dfir(
-                parse_quote! {
-                    #second_ident -> for_each(|v| #buffered_second_ident.borrow_mut().push_back(v));
-                },
-                None,
-                None,
-            );
+                self.get_dfir_mut(location).add_dfir(
+                    parse_quote! {
+                        #first_ident -> for_each(|(k, v)| #buffered_first_ident.borrow_mut().entry(k).or_insert_with(::std::collections::VecDeque::new).push_back(v));
+                    },
+                    None,
+                    None,
+                );
+
+                self.get_dfir_mut(location).add_dfir(
+                    parse_quote! {
+                        #second_ident -> for_each(|(k, v)| #buffered_second_ident.borrow_mut().entry(k).or_insert_with(::std::collections::VecDeque::new).push_back(v));
+                    },
+                    None,
+                    None,
+                );
+            } else {
+                self.add_extra_stmt_internal(location, syn::parse_quote! {
+                    let #buffered_first_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
+                });
+                self.add_extra_stmt_internal(location, syn::parse_quote! {
+                    let #buffered_second_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
+                });
+                self.add_hook(
+                    location,
+                    location,
+                    syn::parse_quote!(
+                        Box::new(#root::sim::runtime::TopLevelMergeOrderedHook::<_> {
+                            first: #buffered_first_ident.clone(),
+                            second: #buffered_second_ident.clone(),
+                            to_release: None,
+                            release_source: None,
+                            output: #hoff_send_ident,
+                            location: (#assume_location, #line, #caret),
+                            format_item_debug: #root::__maybe_debug__!(#element_type),
+                        })
+                    ),
+                );
+
+                self.get_dfir_mut(location).add_dfir(
+                    parse_quote! {
+                        #first_ident -> for_each(|v| #buffered_first_ident.borrow_mut().push_back(v));
+                    },
+                    None,
+                    None,
+                );
+
+                self.get_dfir_mut(location).add_dfir(
+                    parse_quote! {
+                        #second_ident -> for_each(|v| #buffered_second_ident.borrow_mut().push_back(v));
+                    },
+                    None,
+                    None,
+                );
+            }
 
             self.get_dfir_mut(location).add_dfir(
                 parse_quote! {

--- a/hydro_lang/src/sim/runtime.rs
+++ b/hydro_lang/src/sim/runtime.rs
@@ -1860,6 +1860,294 @@ impl<T> SimHook for TopLevelMergeOrderedHook<T> {
     }
 }
 
+type KeyedMergeOrderedInput<K, V> = Rc<RefCell<Option<Vec<(K, V)>>>>;
+
+/// Keyed variant of [`MergeOrderedHook`], used for bounded / non-root keyed
+/// streams. Both inputs are fully materialized batches. Interleaves the two
+/// batches *independently within each key*, preserving per-input order within
+/// each key. The interleaving across different keys is irrelevant because a
+/// [`crate::live_collections::keyed_stream::KeyedStream`] carries no ordering
+/// guarantee across keys.
+pub struct KeyedMergeOrderedHook<K: Hash + Eq + Clone, V> {
+    first: KeyedMergeOrderedInput<K, V>,
+    second: KeyedMergeOrderedInput<K, V>,
+    to_release: Option<Vec<(K, V)>>,
+    release_sources: Option<Vec<bool>>,
+    output: UnboundedSender<Vec<(K, V)>>,
+    batch_location: HookLocationMeta,
+    format_item_debug: fn(&(K, V)) -> Option<String>,
+}
+
+impl<K: Hash + Eq + Clone, V> KeyedMergeOrderedHook<K, V> {
+    pub fn new(
+        first: KeyedMergeOrderedInput<K, V>,
+        second: KeyedMergeOrderedInput<K, V>,
+        output: UnboundedSender<Vec<(K, V)>>,
+        batch_location: HookLocationMeta,
+        format_item_debug: fn(&(K, V)) -> Option<String>,
+    ) -> Self {
+        Self {
+            first,
+            second,
+            to_release: None,
+            release_sources: None,
+            output,
+            batch_location,
+            format_item_debug,
+        }
+    }
+}
+
+impl<K: Hash + Eq + Clone, V> SimInlineHook for KeyedMergeOrderedHook<K, V> {
+    fn pending_decision(&self) -> bool {
+        self.first.borrow().is_some() && self.second.borrow().is_some()
+    }
+
+    fn has_decision(&self) -> bool {
+        self.to_release.is_some()
+    }
+
+    fn autonomous_decision<'a>(&mut self, driver: &mut Borrowed<'a>) {
+        let first_input = self.first.borrow_mut().take().unwrap();
+        let second_input = self.second.borrow_mut().take().unwrap();
+
+        // Group each input by key, preserving per-input order within each key
+        // and recording the order in which keys are first seen so that output
+        // is deterministic given the same random choices.
+        let mut key_order: Vec<K> = Vec::new();
+        let mut first_grouped: FxHashMap<K, VecDeque<V>> = FxHashMap::default();
+        let mut second_grouped: FxHashMap<K, VecDeque<V>> = FxHashMap::default();
+
+        for (k, v) in first_input {
+            if !first_grouped.contains_key(&k) && !second_grouped.contains_key(&k) {
+                key_order.push(k.clone());
+            }
+            first_grouped.entry(k).or_default().push_back(v);
+        }
+        for (k, v) in second_input {
+            if !first_grouped.contains_key(&k) && !second_grouped.contains_key(&k) {
+                key_order.push(k.clone());
+            }
+            second_grouped.entry(k).or_default().push_back(v);
+        }
+
+        let mut result = Vec::new();
+        let mut sources = Vec::new();
+
+        for key in key_order {
+            let mut first_q = first_grouped.remove(&key).unwrap_or_default();
+            let mut second_q = second_grouped.remove(&key).unwrap_or_default();
+
+            // Generate a valid interleaving of this key's two sub-sequences,
+            // preserving per-input order.
+            while !first_q.is_empty() && !second_q.is_empty() {
+                let take_second: bool = produce().generate(driver).unwrap();
+                if take_second {
+                    result.push((key.clone(), second_q.pop_front().unwrap()));
+                    sources.push(true);
+                } else {
+                    result.push((key.clone(), first_q.pop_front().unwrap()));
+                    sources.push(false);
+                }
+            }
+            for v in first_q {
+                result.push((key.clone(), v));
+                sources.push(false);
+            }
+            for v in second_q {
+                result.push((key.clone(), v));
+                sources.push(true);
+            }
+        }
+
+        self.to_release = Some(result);
+        self.release_sources = Some(sources);
+    }
+
+    fn release_decision(&mut self, log_writer: &mut dyn std::fmt::Write) {
+        if let Some(to_release) = self.to_release.take() {
+            let sources = self.release_sources.take().unwrap();
+            if !to_release.is_empty() {
+                let (batch_location, line, caret_indent) = self.batch_location;
+
+                let labeled_iter =
+                    sources
+                        .iter()
+                        .zip(to_release.iter())
+                        .map(|(is_second, item)| {
+                            let label: &'static str = if *is_second { "r" } else { "l" };
+                            (label, item)
+                        });
+
+                let note_str = format!(
+                    "^ observed non-deterministic merge order: {:?}",
+                    TruncatedLabeledVecDebug(
+                        RefCell::new(Some(labeled_iter)),
+                        8,
+                        self.format_item_debug
+                    )
+                );
+
+                let _ = writeln!(
+                    log_writer,
+                    "{} {}",
+                    "-->".color(colored::Color::Blue),
+                    batch_location
+                );
+
+                let _ = writeln!(log_writer, " {}{}", "|".color(colored::Color::Blue), line);
+
+                let _ = writeln!(
+                    log_writer,
+                    " {}{}{}",
+                    "|".color(colored::Color::Blue),
+                    caret_indent,
+                    note_str.color(colored::Color::Cyan)
+                );
+            }
+
+            self.output.send(to_release).unwrap();
+        } else {
+            panic!("No decision to release");
+        }
+    }
+}
+
+/// Keyed variant of [`TopLevelMergeOrderedHook`]. Releases one element at a
+/// time, picking from the front of some key's queue in either the first or the
+/// second input. This preserves per-input order within each key while allowing
+/// arbitrary interleaving both across the two inputs and across keys (which is
+/// unconstrained for keyed streams), and lets feedback cycles deliver elements
+/// between releases.
+pub struct TopLevelKeyedMergeOrderedHook<K: Hash + Eq + Clone, V> {
+    pub first: Rc<RefCell<FxHashMap<K, VecDeque<V>>>>,
+    pub second: Rc<RefCell<FxHashMap<K, VecDeque<V>>>>,
+    pub to_release: Option<Vec<(K, V)>>,
+    pub release_source: Option<&'static str>,
+    pub output: UnboundedSender<(K, V)>,
+    pub location: HookLocationMeta,
+    pub format_item_debug: fn(&(K, V)) -> Option<String>,
+}
+
+impl<K: Hash + Eq + Clone, V> SimHook for TopLevelKeyedMergeOrderedHook<K, V> {
+    fn current_decision(&self) -> Option<bool> {
+        self.to_release.as_ref().map(|v| !v.is_empty())
+    }
+
+    fn can_make_nontrivial_decision(&self) -> bool {
+        #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
+        let first_nonempty = !self.first.borrow().values().all(|q| q.is_empty());
+        #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
+        let second_nonempty = !self.second.borrow().values().all(|q| q.is_empty());
+        first_nonempty || second_nonempty
+    }
+
+    fn autonomous_decision<'a>(
+        &mut self,
+        driver: &mut Borrowed<'a>,
+        force_nontrivial: bool,
+    ) -> bool {
+        // Collect candidates: for each non-empty key queue in either input, we
+        // can release its front element. `false` = first input, `true` = second.
+        let mut candidates: Vec<(bool, K)> = Vec::new();
+        {
+            #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
+            for (k, q) in self.first.borrow().iter() {
+                if !q.is_empty() {
+                    candidates.push((false, k.clone()));
+                }
+            }
+            #[expect(clippy::disallowed_methods, reason = "FxHasher is deterministic")]
+            for (k, q) in self.second.borrow().iter() {
+                if !q.is_empty() {
+                    candidates.push((true, k.clone()));
+                }
+            }
+        }
+
+        if candidates.is_empty() {
+            self.to_release = Some(vec![]);
+            self.release_source = None;
+            return false;
+        }
+
+        if !force_nontrivial && produce().generate(driver).unwrap() {
+            // don't release anything
+            self.to_release = Some(vec![]);
+            self.release_source = None;
+            return false;
+        }
+
+        let idx = (0..candidates.len()).generate(driver).unwrap();
+        let (take_second, key) = &candidates[idx];
+        let take_second = *take_second;
+
+        let item = if take_second {
+            self.second
+                .borrow_mut()
+                .get_mut(key)
+                .unwrap()
+                .pop_front()
+                .unwrap()
+        } else {
+            self.first
+                .borrow_mut()
+                .get_mut(key)
+                .unwrap()
+                .pop_front()
+                .unwrap()
+        };
+
+        self.to_release = Some(vec![(key.clone(), item)]);
+        self.release_source = Some(if take_second { "r" } else { "l" });
+        true
+    }
+
+    fn release_decision(&mut self, log_writer: &mut dyn std::fmt::Write) {
+        if let Some(to_release) = self.to_release.take() {
+            let source = self.release_source.take();
+            if !to_release.is_empty() {
+                let (batch_location, line, caret_indent) = self.location;
+                let source_label = source.unwrap_or("?");
+
+                let labeled_iter = to_release.iter().map(|item| (source_label, item));
+
+                let note_str = format!(
+                    "^ observed non-deterministic merge order: {:?}",
+                    TruncatedLabeledVecDebug(
+                        RefCell::new(Some(labeled_iter)),
+                        8,
+                        self.format_item_debug
+                    )
+                );
+
+                let _ = writeln!(
+                    log_writer,
+                    "\n{} {}",
+                    "-->".color(colored::Color::Blue),
+                    batch_location
+                );
+
+                let _ = writeln!(log_writer, " {}{}", "|".color(colored::Color::Blue), line);
+
+                let _ = writeln!(
+                    log_writer,
+                    " {}{}{}",
+                    "|".color(colored::Color::Blue),
+                    caret_indent,
+                    note_str.color(colored::Color::Green)
+                );
+            }
+
+            for item in to_release {
+                self.output.send(item).unwrap();
+            }
+        } else {
+            panic!("No decision to release");
+        }
+    }
+}
+
 #[cfg(test)]
 mod maybe_debug_tests {
     struct NotDebuggable;


### PR DESCRIPTION
Fixes #2987. Adds `KeyedStream::merge_ordered`, mirroring `Stream::merge_ordered`:
it combines two `TotalOrder` keyed streams, preserving the relative order of
elements within each group of each input and producing a `TotalOrder` result on
a `DropConsistency` location, reusing the existing `HydroNode::MergeOrdered` IR
node for deploy lowering (a `union()`).

Adds dedicated simulation hooks so the merge is explored *per key* rather than
treating the whole batch as one totally-ordered sequence (the flat merge hook
couples ordering across keys and cannot reach some valid per-key interleavings):
- `KeyedMergeOrderedHook` (inline / bounded): groups both batches by key and
  interleaves each key independently, preserving per-input order.
- `TopLevelKeyedMergeOrderedHook` (top-level / unbounded): releases one element
  at a time from the front of some key's queue in either input, preserving
  per-input within-key order while allowing arbitrary cross-input and cross-key
  interleaving.
The sim builder now routes `KeyedStream` inputs to these hooks, buffering
top-level inputs into per-key `FxHashMap<K, VecDeque<V>>` queues; the non-keyed
path is unchanged.

Adds exhaustive sim tests covering within-group order preservation, full
interleaving exploration, and per-key-independent interleaving.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>