### PR TITLE
feat(hydro_lang): make Cluster::sim_input generic over ordering/retries and add SimClusterSender::send_many_unordered

### DIFF
--- a/hydro_lang/src/location/cluster.rs
+++ b/hydro_lang/src/location/cluster.rs
@@ -148,20 +148,27 @@ impl<'a, C> Cluster<'a, C> {
     ///
     /// Returns a `SimClusterSender` that sends `(member_id, T)` messages targeting
     /// specific cluster members, and a `Stream<T>` received by each member.
-    pub fn sim_input<T>(
+    ///
+    /// This method is generic over the [`Ordering`](crate::live_collections::stream::Ordering)
+    /// and [`Retries`](crate::live_collections::stream::Retries) guarantees of the produced
+    /// stream, mirroring [`Location::sim_input`]. For
+    /// unordered inputs (e.g. anything downstream of a `NoOrder` network channel), create the
+    /// input with `O = NoOrder` and drive it with
+    /// [`SimClusterSender::send_many_unordered`](crate::sim::SimClusterSender::send_many_unordered).
+    pub fn sim_input<
+        T,
+        O: crate::live_collections::stream::Ordering,
+        R: crate::live_collections::stream::Retries,
+    >(
         &self,
     ) -> (
-        crate::sim::SimClusterSender<
-            T,
-            crate::live_collections::stream::TotalOrder,
-            crate::live_collections::stream::ExactlyOnce,
-        >,
+        crate::sim::SimClusterSender<T, O, R>,
         crate::live_collections::Stream<
             T,
             Self,
             crate::live_collections::boundedness::Unbounded,
-            crate::live_collections::stream::TotalOrder,
-            crate::live_collections::stream::ExactlyOnce,
+            O,
+            R,
         >,
     )
     where

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -1004,6 +1004,18 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterSender<
     }
 }
 
+impl<T: Serialize + DeserializeOwned, O: Ordering> SimClusterSender<T, O, ExactlyOnce> {
+    /// Sends multiple values to specific cluster members. The messages will be asynchronously
+    /// processed as part of the simulation, in non-deterministic order.
+    pub fn send_many_unordered<I: IntoIterator<Item = (u32, T)>>(&self, iter: I) {
+        self.with_sink(|send| {
+            for (member_id, t) in iter {
+                send(member_id, t).unwrap();
+            }
+        })
+    }
+}
+
 impl<T: Serialize + DeserializeOwned> SimClusterSender<T, TotalOrder, ExactlyOnce> {
     /// Sends a value to a specific cluster member.
     pub fn send(&self, member_id: u32, t: T) {

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -287,7 +287,7 @@ fn sim_cluster_e2m_m2e() {
     let mut flow = FlowBuilder::new();
     let cluster = flow.cluster::<()>();
 
-    let (in_send, input) = cluster.sim_input::<i32>();
+    let (in_send, input) = cluster.sim_input::<i32, _, _>();
     let out_recv = input.map(q!(|x| x * 10)).sim_cluster_output();
 
     flow.sim()
@@ -303,6 +303,43 @@ fn sim_cluster_e2m_m2e() {
             assert_eq!(out_recv.next(1).await, Some(20));
             assert_eq!(out_recv.next(2).await, Some(30));
         });
+}
+
+#[test]
+fn sim_cluster_unordered_input() {
+    use crate::live_collections::stream::NoOrder;
+
+    let mut flow = FlowBuilder::new();
+    let cluster = flow.cluster::<()>();
+
+    // Create a cluster input that is semantically unordered, driven directly
+    // via `send_many_unordered` without needing to `weaken_ordering` afterwards.
+    let (in_send, input) = cluster.sim_input::<i32, NoOrder, ExactlyOnce>();
+
+    // Batch the unordered input through a tick via `sliced!` so the simulator
+    // explores the different interleavings of the unordered arrivals.
+    let out_recv = sliced! {
+        let batch = use(input, nondet!(/** test */));
+        batch.map(q!(|x| x * 10))
+    }
+    .sim_cluster_output();
+
+    let count = flow
+        .sim()
+        .with_cluster_size(&cluster, 2)
+        .exhaustive(async || {
+            in_send.send_many_unordered([(0, 1), (0, 2), (1, 3)]);
+
+            let r0 = out_recv.collect_sorted::<Vec<_>>(0).await;
+            assert_eq!(r0, vec![10, 20]);
+
+            let r1 = out_recv.collect_sorted::<Vec<_>>(1).await;
+            assert_eq!(r1, vec![30]);
+        });
+
+    // The two unordered values delivered to member 0 are batched non-deterministically
+    // across ticks, so the simulator explores multiple executions.
+    assert_eq!(count, 8);
 }
 
 #[test]

--- a/hydro_lang/src/sim/versioned_network.rs
+++ b/hydro_lang/src/sim/versioned_network.rs
@@ -112,7 +112,7 @@ mod tests {
     use stageleft::q;
 
     use super::*;
-    use crate::live_collections::stream::TotalOrder;
+    use crate::live_collections::stream::{ExactlyOnce, TotalOrder};
     use crate::nondet::nondet;
     use crate::prelude::{FlowBuilder, TCP};
 
@@ -124,7 +124,7 @@ mod tests {
         let mut flow = FlowBuilder::new();
 
         let servers0 = flow.cluster::<u8>();
-        let (_in0, input0) = servers0.sim_input::<i32>();
+        let (_in0, input0) = servers0.sim_input::<i32, TotalOrder, ExactlyOnce>();
         input0
             .broadcast(
                 &servers0,
@@ -136,7 +136,7 @@ mod tests {
             .for_each(q!(|x| println!("{x}")));
 
         let servers1 = flow.next_version(&servers0);
-        let (_in1, input1) = servers1.sim_input::<i32>();
+        let (_in1, input1) = servers1.sim_input::<i32, TotalOrder, ExactlyOnce>();
         input1
             .broadcast(
                 &servers1,

--- a/hydro_test/src/distributed/versioning.rs
+++ b/hydro_test/src/distributed/versioning.rs
@@ -505,7 +505,7 @@ mod tests {
         hydro_lang::sim::SimClusterSender<usize, TotalOrder, ExactlyOnce>,
         hydro_lang::sim::SimClusterReceiver<usize, TotalOrder, ExactlyOnce>,
     ) {
-        let (inputter, requests) = servers.sim_input::<usize>();
+        let (inputter, requests) = servers.sim_input::<usize, _, _>();
         let output = echo(requests).sim_cluster_output();
         (inputter, output)
     }
@@ -554,7 +554,7 @@ mod tests {
         hydro_lang::sim::SimClusterSender<usize, TotalOrder, ExactlyOnce>,
         hydro_lang::sim::SimClusterReceiver<usize, TotalOrder, ExactlyOnce>,
     ) {
-        let (inputter, requests) = cluster.sim_input::<usize>();
+        let (inputter, requests) = cluster.sim_input::<usize, _, _>();
         let output = requests.map(q!(|x| x + 1)).sim_cluster_output();
         (inputter, output)
     }
@@ -665,11 +665,11 @@ mod tests {
         let mut flow = FlowBuilder::new();
 
         let servers_a = flow.cluster::<GossipServer>();
-        let (inputter_a, requests_a) = servers_a.sim_input::<usize>();
+        let (inputter_a, requests_a) = servers_a.sim_input::<usize, _, _>();
         let output_a = echo(requests_a).sim_cluster_output();
 
         let servers_b = flow.cluster::<GossipServer>();
-        let (inputter_b, requests_b) = servers_b.sim_input::<usize>();
+        let (inputter_b, requests_b) = servers_b.sim_input::<usize, _, _>();
         let output_b = echo(requests_b).sim_cluster_output();
 
         flow.sim()


### PR DESCRIPTION
Fixes hydro-project/hydro#2994.

Previously `Cluster::sim_input` was hardcoded to `TotalOrder`/`ExactlyOnce`,
and `SimClusterSender` only exposed `send`/`send_many` for that combination.
This meant a cluster input that is semantically unordered (e.g. downstream of
a `NoOrder` network channel) could not be created directly — tests had to
create a `TotalOrder` input and then `weaken_ordering`, forcing a fixed send
order and adding boilerplate.

Changes:
- `hydro_lang/src/location/cluster.rs`: `Cluster::sim_input` is now generic
  over `O: Ordering` and `R: Retries`, mirroring `Location::sim_input`. It
  returns `SimClusterSender<T, O, R>` and a `Stream<T, Self, Unbounded, O, R>`.
- `hydro_lang/src/sim/compiled.rs`: added `send_many_unordered` on
  `SimClusterSender<T, O, ExactlyOnce>`, allowing unordered cluster inputs to
  be driven directly (matching the existing `SimSender::send_many_unordered`).
- Updated existing turbofish call sites (`sim_input::<T>()` ->
  `sim_input::<T, _, _>()`, or explicit `TotalOrder, ExactlyOnce` where the
  ordering was otherwise unconstrained) in
  `hydro_lang/src/sim/versioned_network.rs`,
  `hydro_lang/src/sim/tests/mod.rs`, and
  `hydro_test/src/distributed/versioning.rs`.
- Added a `sim_cluster_unordered_input` test that creates a `NoOrder` cluster
  input, batches it through a tick via `sliced!` to exercise the unordered
  interleavings, drives it with `send_many_unordered`, and asserts the exact
  explored-execution count (8).

Verified `hydro_lang` sim tests and `hydro_test` versioning sim tests pass,
and that `hydro_test`/`hydro_std` test targets still compile.

BREAKING CHANGE: `Cluster::sim_input` now takes two additional generic
parameters (`O: Ordering`, `R: Retries`); existing turbofish calls such as
`cluster.sim_input::<T>()` must be updated to `cluster.sim_input::<T, _, _>()`.

Co-authored-by: Infinity 🤖 <infinity@hydro.run>