### PR TITLE
fix(hydro_lang): disallow `by_ref()`/`by_mut()` on top-level bounded sources, fix #3005

### DIFF
--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -882,10 +882,20 @@ impl DfirGraph {
                         ..
                     } => {
                         let buf_ident = self.hoff_buf_ident(ref_node_id, span);
+                        let varname_str = self
+                            .node_varname(ref_node_id)
+                            .map(|v| v.0.to_string())
+                            .unwrap_or_else(|| format!("{:?}", ref_node_id.data()));
+                        let expect_msg = format!(
+                            "singleton `{}` was not populated. Its source operator must run \
+                             before any consumer reads from it. This likely indicates a \
+                             scheduling bug in the DFIR graph.",
+                            varname_str
+                        );
                         if is_mut {
-                            quote_spanned! {span=> #buf_ident.as_mut().unwrap() }
+                            quote_spanned! {span=> #buf_ident.as_mut().expect(#expect_msg) }
                         } else {
-                            quote_spanned! {span=> #buf_ident.as_ref().unwrap() }
+                            quote_spanned! {span=> #buf_ident.as_ref().expect(#expect_msg) }
                         }
                     }
                     GraphNode::Handoff {

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -887,9 +887,8 @@ impl DfirGraph {
                             .map(|v| v.0.to_string())
                             .unwrap_or_else(|| format!("{:?}", ref_node_id.data()));
                         let expect_msg = format!(
-                            "singleton `{}` was not populated. Its source operator must run \
-                             before any consumer reads from it. This likely indicates a \
-                             scheduling bug in the DFIR graph.",
+                            "singleton `{}` was not populated. Its input must re-populate the value on every tick;
+                            ensure the input is a stateful operator such as `fold()`, `reduce()`, `persist()`, etc.",
                             varname_str
                         );
                         if is_mut {

--- a/dfir_rs/tests/surface_handoff.rs
+++ b/dfir_rs/tests/surface_handoff.rs
@@ -217,9 +217,12 @@ pub async fn test_singleton_reference_only_multi_tick() {
 
 /// Regression test for https://github.com/hydro-project/hydro/issues/3005
 ///
-/// A singleton() fed by source_iter (fires once) referenced via #var must work across
-/// multiple ticks. The fix ensures that top-level SingletonSource emits persist::<'static>()
-/// so the singleton buffer is refilled every tick.
+/// Demonstrates the workaround for singleton references across ticks at the DFIR level:
+/// explicitly adding `persist::<'static>()` before the `singleton()` handoff ensures
+/// the buffer stays populated. Without persist, the buffer would be None on tick 1+.
+///
+/// At the Hydro level, by_ref()/by_mut() on top-level bounded singletons is disallowed
+/// because the correct persist semantics are not yet resolved (see #3010).
 #[dfir_rs::test]
 pub async fn test_singleton_reference_no_persist_works_across_ticks() {
     let (send, recv) = dfir_rs::util::unbounded_channel::<i32>();

--- a/dfir_rs/tests/surface_handoff.rs
+++ b/dfir_rs/tests/surface_handoff.rs
@@ -215,6 +215,39 @@ pub async fn test_singleton_reference_only_multi_tick() {
     assert_eq!(vec![43, 45, 142], *output.borrow());
 }
 
+/// Regression test for https://github.com/hydro-project/hydro/issues/3005
+///
+/// A singleton() without persist (fires once) referenced via #var panics on the second tick
+/// when a stream consumer tries to read the singleton buffer via .as_ref().unwrap() but
+/// the buffer is None because the source only produced on tick 0.
+///
+/// This demonstrates that a source singleton's reference is not safe across multiple ticks
+/// unless the singleton is persisted or re-filled.
+#[dfir_rs::test]
+#[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
+pub async fn test_singleton_reference_no_persist_panics_on_second_tick() {
+    let (send, recv) = dfir_rs::util::unbounded_channel::<i32>();
+    let output = std::rc::Rc::new(std::cell::RefCell::new(Vec::<i32>::new()));
+    let out = output.clone();
+    let mut flow = dfir_rs::dfir_syntax! {
+        // source_iter fires once, WITHOUT persist, so the singleton is only filled on tick 0
+        my_val = source_iter([42_i32]) -> singleton();
+        source_stream(recv)
+            -> map(|x| x + #my_val)
+            -> for_each(|v: i32| out.borrow_mut().push(v));
+    };
+    send.send(1).unwrap();
+    flow.run_tick().await;
+    // Tick 0 works fine: singleton has value 42
+    assert_eq!(vec![43], *output.borrow());
+
+    // Tick 1: the singleton buffer was drained at end of tick 0, and source_iter doesn't
+    // fire again (it's exhausted). The singleton buffer is now None.
+    // When the map tries to read #my_val, it calls .as_ref().unwrap() on None → panic.
+    send.send(100).unwrap();
+    flow.run_tick().await;
+}
+
 /// Test: `singleton()` can be mutably referenced via `#mut var`.
 #[dfir_rs::test]
 pub async fn test_singleton_mut_reference() {

--- a/dfir_rs/tests/surface_handoff.rs
+++ b/dfir_rs/tests/surface_handoff.rs
@@ -217,21 +217,17 @@ pub async fn test_singleton_reference_only_multi_tick() {
 
 /// Regression test for https://github.com/hydro-project/hydro/issues/3005
 ///
-/// A singleton() without persist (fires once) referenced via #var panics on the second tick
-/// when a stream consumer tries to read the singleton buffer via .as_ref().unwrap() but
-/// the buffer is None because the source only produced on tick 0.
-///
-/// This demonstrates that a source singleton's reference is not safe across multiple ticks
-/// unless the singleton is persisted or re-filled.
+/// A singleton() fed by source_iter (fires once) referenced via #var must work across
+/// multiple ticks. The fix ensures that top-level SingletonSource emits persist::<'static>()
+/// so the singleton buffer is refilled every tick.
 #[dfir_rs::test]
-#[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
-pub async fn test_singleton_reference_no_persist_panics_on_second_tick() {
+pub async fn test_singleton_reference_no_persist_works_across_ticks() {
     let (send, recv) = dfir_rs::util::unbounded_channel::<i32>();
     let output = std::rc::Rc::new(std::cell::RefCell::new(Vec::<i32>::new()));
     let out = output.clone();
     let mut flow = dfir_rs::dfir_syntax! {
-        // source_iter fires once, WITHOUT persist, so the singleton is only filled on tick 0
-        my_val = source_iter([42_i32]) -> singleton();
+        // source_iter fires once, but persist::<'static>() ensures the singleton is refilled
+        my_val = source_iter([42_i32]) -> persist::<'static>() -> singleton();
         source_stream(recv)
             -> map(|x| x + #my_val)
             -> for_each(|v: i32| out.borrow_mut().push(v));
@@ -241,11 +237,10 @@ pub async fn test_singleton_reference_no_persist_panics_on_second_tick() {
     // Tick 0 works fine: singleton has value 42
     assert_eq!(vec![43], *output.borrow());
 
-    // Tick 1: the singleton buffer was drained at end of tick 0, and source_iter doesn't
-    // fire again (it's exhausted). The singleton buffer is now None.
-    // When the map tries to read #my_val, it calls .as_ref().unwrap() on None → panic.
+    // Tick 1: with persist, the singleton is refilled so the reference works
     send.send(100).unwrap();
     flow.run_tick().await;
+    assert_eq!(vec![43, 142], *output.borrow());
 }
 
 /// Test: `singleton()` can be mutably referenced via `#mut var`.

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -3927,9 +3927,10 @@ impl HydroNode {
                                     );
                                 }
 
-                                if *first_tick_only {
-                                    // Inside a tick, source_iter fires once per tick execution
-                                    // which is sufficient to fill the singleton buffer.
+                                if *first_tick_only
+                                    || (metadata.location_id.is_top_level()
+                                        && metadata.collection_kind.is_bounded())
+                                {
                                     graph_builders.add_dfir_at(
                                         &out_location,
                                         parse_quote! {
@@ -3938,11 +3939,6 @@ impl HydroNode {
                                         Some(&stmt_id.to_string()),
                                     );
                                 } else {
-                                    // At the top level, we need persist::<'static>() so the
-                                    // singleton buffer is refilled every tick. Without it,
-                                    // source_iter fires only on tick 0 and the buffer becomes
-                                    // None on subsequent ticks, causing panics in reference
-                                    // consumers (see #3005).
                                     graph_builders.add_dfir_at(
                                         &out_location,
                                         parse_quote! {
@@ -4040,7 +4036,7 @@ impl HydroNode {
                         ident_stack.push(ret_ident);
                     }
 
-                    HydroNode::Reference { inner, kind, .. } => {
+                    HydroNode::Reference { inner, kind, metadata, .. } => {
                         // we consume a stmt id regardless of if we emit the operator,
                         // so that during rewrites we touch all recipients
                         let stmt_id = next_stmt_id.get_and_increment();
@@ -4070,13 +4066,34 @@ impl HydroNode {
                                         },
                                         Span::call_site(),
                                     );
-                                    graph_builders.add_dfir_at(
-                                        &out_location,
-                                        parse_quote! {
-                                            #ref_ident = #inner_ident -> #op_ident();
-                                        },
-                                        Some(&stmt_id.to_string()),
-                                    );
+
+                                    // For top-level bounded singletons, the source only fires
+                                    // once (tick 0). We need persist so the handoff buffer stays
+                                    // populated on subsequent ticks for reference consumers.
+                                    // This persist is only on the reference path, not the pipe
+                                    // consumer path, preserving bounded into_stream() semantics.
+                                    // See https://github.com/hydro-project/hydro/issues/3005
+                                    let needs_persist = metadata.location_id.is_top_level()
+                                        && metadata.collection_kind.is_bounded()
+                                        && matches!(kind, crate::handoff_ref::HandoffRefKind::Singleton);
+
+                                    if needs_persist {
+                                        graph_builders.add_dfir_at(
+                                            &out_location,
+                                            parse_quote! {
+                                                #ref_ident = #inner_ident -> persist::<'static>() -> #op_ident();
+                                            },
+                                            Some(&stmt_id.to_string()),
+                                        );
+                                    } else {
+                                        graph_builders.add_dfir_at(
+                                            &out_location,
+                                            parse_quote! {
+                                                #ref_ident = #inner_ident -> #op_ident();
+                                            },
+                                            Some(&stmt_id.to_string()),
+                                        );
+                                    }
                                 }
                                 BuildersOrCallback::Callback(_, node_callback) => {
                                     node_callback(node, next_stmt_id);

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -4067,38 +4067,31 @@ impl HydroNode {
                                         Span::call_site(),
                                     );
 
-                                    // For top-level bounded singletons, the source only fires
-                                    // once (tick 0). We need persist so the handoff buffer stays
-                                    // populated on subsequent ticks for reference consumers.
-                                    // This persist is only on the reference path, not the pipe
-                                    // consumer path, preserving bounded into_stream() semantics.
+                                    // Top-level bounded references (by_ref/by_mut on a source
+                                    // singleton, optional, or stream) are not currently supported
+                                    // because the source only fires once and the handoff buffer
+                                    // would be empty on subsequent ticks. The semantics of
+                                    // persist-and-replay for references (especially mutable ones
+                                    // and stream refs) are subtle and not yet resolved.
                                     // See https://github.com/hydro-project/hydro/issues/3005
-                                    //
-                                    // NOTE: For mutable references (by_mut), this means mutations
-                                    // only affect the current tick's copy — the value resets to
-                                    // the original on the next tick. This is a broader semantic
-                                    // question tracked in https://github.com/hydro-project/hydro/issues/3010
-                                    let needs_persist = metadata.location_id.is_top_level()
+                                    // and https://github.com/hydro-project/hydro/issues/3010
+                                    if metadata.location_id.is_top_level()
                                         && metadata.collection_kind.is_bounded()
-                                        && matches!(kind, crate::handoff_ref::HandoffRefKind::Singleton);
-
-                                    if needs_persist {
-                                        graph_builders.add_dfir_at(
-                                            &out_location,
-                                            parse_quote! {
-                                                #ref_ident = #inner_ident -> persist::<'static>() -> #op_ident();
-                                            },
-                                            Some(&stmt_id.to_string()),
-                                        );
-                                    } else {
-                                        graph_builders.add_dfir_at(
-                                            &out_location,
-                                            parse_quote! {
-                                                #ref_ident = #inner_ident -> #op_ident();
-                                            },
-                                            Some(&stmt_id.to_string()),
+                                    {
+                                        panic!(
+                                            "by_ref()/by_mut() on a top-level bounded source is not yet supported. \
+                                             The handoff buffer would be empty after the first tick. \
+                                             See https://github.com/hydro-project/hydro/issues/3010 for details."
                                         );
                                     }
+
+                                    graph_builders.add_dfir_at(
+                                        &out_location,
+                                        parse_quote! {
+                                            #ref_ident = #inner_ident -> #op_ident();
+                                        },
+                                        Some(&stmt_id.to_string()),
+                                    );
                                 }
                                 BuildersOrCallback::Callback(_, node_callback) => {
                                     node_callback(node, next_stmt_id);

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -4073,6 +4073,11 @@ impl HydroNode {
                                     // This persist is only on the reference path, not the pipe
                                     // consumer path, preserving bounded into_stream() semantics.
                                     // See https://github.com/hydro-project/hydro/issues/3005
+                                    //
+                                    // NOTE: For mutable references (by_mut), this means mutations
+                                    // only affect the current tick's copy — the value resets to
+                                    // the original on the next tick. This is a broader semantic
+                                    // question tracked in https://github.com/hydro-project/hydro/issues/3010
                                     let needs_persist = metadata.location_id.is_top_level()
                                         && metadata.collection_kind.is_bounded()
                                         && matches!(kind, crate::handoff_ref::HandoffRefKind::Singleton);

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -3927,10 +3927,9 @@ impl HydroNode {
                                     );
                                 }
 
-                                if *first_tick_only
-                                    || (metadata.location_id.is_top_level()
-                                        && metadata.collection_kind.is_bounded())
-                                {
+                                if *first_tick_only {
+                                    // Inside a tick, source_iter fires once per tick execution
+                                    // which is sufficient to fill the singleton buffer.
                                     graph_builders.add_dfir_at(
                                         &out_location,
                                         parse_quote! {
@@ -3939,6 +3938,11 @@ impl HydroNode {
                                         Some(&stmt_id.to_string()),
                                     );
                                 } else {
+                                    // At the top level, we need persist::<'static>() so the
+                                    // singleton buffer is refilled every tick. Without it,
+                                    // source_iter fires only on tick 0 and the buffer becomes
+                                    // None on subsequent ticks, causing panics in reference
+                                    // consumers (see #3005).
                                     graph_builders.add_dfir_at(
                                         &out_location,
                                         parse_quote! {

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -10,6 +10,115 @@ use crate::sim::{SimReceiver, SimSender};
 
 mod trophies;
 
+/// Regression test for https://github.com/hydro-project/hydro/issues/3005
+///
+/// `Singleton::by_ref()` on a top-level source singleton panics with `unwrap()` on `None`
+/// when the exhaustive simulator explores an interleaving where the stream consumer runs
+/// before the singleton's source operator has produced its value.
+///
+/// The generated DFIR code resolves the `SingletonRef` eagerly via
+/// `hoff_buf.as_ref().unwrap()`, which is `None` before the singleton source has run.
+#[test]
+fn sim_source_singleton_by_ref_in_map() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process::<()>();
+
+    // Source singleton: a bounded singleton created at the top level.
+    let my_singleton = process.singleton(q!(42u32));
+    let singleton_ref = my_singleton.by_ref();
+
+    // Stream input driven by the simulator.
+    let (in_port, input_stream) = process.sim_input::<u32, TotalOrder, ExactlyOnce>();
+
+    // Capture the singleton ref in a map over the input stream.
+    // Under some explored schedule, the map may be polled before the singleton source runs.
+    let out = input_stream.map(q!(move |x| x + *singleton_ref));
+    let out_port = out.sim_output();
+
+    // Consume the singleton so the graph is valid.
+    my_singleton.into_stream().for_each(q!(|_| {}));
+
+    flow.sim().exhaustive(async || {
+        in_port.send(1);
+        let result = out_port.next().await.unwrap();
+        assert_eq!(result, 43);
+    });
+}
+
+/// Same as above but on a cluster, which is the topology described in the bug report.
+///
+/// Currently panics with SIGABRT due to unwrap() on None in the singleton buffer.
+/// Remove #[ignore] once #3005 is fixed.
+#[test]
+#[ignore = "panics with SIGABRT due to https://github.com/hydro-project/hydro/issues/3005"]
+fn sim_source_singleton_by_ref_in_map_cluster() {
+    let mut flow = FlowBuilder::new();
+    let cluster = flow.cluster::<()>();
+
+    // Source singleton: a bounded singleton created at the top level on a cluster.
+    let my_singleton = cluster.singleton(q!(42u32));
+    let singleton_ref = my_singleton.by_ref();
+
+    // Stream input driven by the simulator.
+    let (in_port, input_stream) = cluster.sim_input::<u32, TotalOrder, ExactlyOnce>();
+
+    // Capture the singleton ref in a map over the input stream.
+    let out = input_stream.map(q!(move |x| x + *singleton_ref));
+    let out_port = out.sim_cluster_output();
+
+    // Consume the singleton so the graph is valid.
+    my_singleton.into_stream().for_each(q!(|_| {}));
+
+    flow.sim()
+        .with_cluster_size(&cluster, 2)
+        .exhaustive(async || {
+            in_port.send(0, 1);
+            in_port.send(1, 2);
+            let r0 = out_port.next(0).await.unwrap();
+            let r1 = out_port.next(1).await.unwrap();
+            assert_eq!(r0, 43);
+            assert_eq!(r1, 44);
+        });
+}
+
+/// Variant where the singleton is NOT consumed by a pipe (only by_ref), and the stream
+/// sends multiple items across multiple ticks. After the singleton source fires once (tick 0),
+/// subsequent ticks have no producer output, so the buffer may be None if drained.
+///
+/// Currently panics with SIGABRT due to unwrap() on None in the singleton buffer.
+/// Remove #[ignore] once #3005 is fixed.
+#[test]
+#[ignore = "panics with SIGABRT due to https://github.com/hydro-project/hydro/issues/3005"]
+fn sim_source_singleton_by_ref_multi_send() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process::<()>();
+
+    let my_singleton = process.singleton(q!(42u32));
+    let singleton_ref = my_singleton.by_ref();
+
+    let (in_port, input_stream) = process.sim_input::<u32, TotalOrder, ExactlyOnce>();
+
+    let out = input_stream.map(q!(move |x| x + *singleton_ref));
+    let out_port = out.sim_output();
+
+    // Consume the singleton value so the graph has a pipe consumer (this drains the buffer).
+    my_singleton.into_stream().for_each(q!(|_| {}));
+
+    flow.sim().exhaustive(async || {
+        // First batch of input — should work fine (singleton source runs on same tick).
+        in_port.send(1);
+        let r1 = out_port.next().await.unwrap();
+        assert_eq!(r1, 43);
+
+        // Second input — arrives on a later tick. The singleton source already fired on tick 0
+        // and the pipe consumer drained the buffer. If the reference consumer runs now,
+        // it will try `buf.as_ref().unwrap()` on `None`.
+        in_port.send(2);
+        let r2 = out_port.next().await.unwrap();
+        assert_eq!(r2, 44);
+    });
+}
+
 // Test is currently broken in nightly.
 #[cfg(not(nightly))]
 #[test]

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -47,12 +47,11 @@ fn sim_source_singleton_by_ref_in_map() {
 
 /// Same as above but on a cluster, which is the topology described in the bug report.
 ///
-/// This reproduces a separate aspect of #3005: on a cluster, the exhaustive simulator
-/// may schedule the consumer subgraph before the singleton source subgraph on the
-/// first tick. This is a simulator scheduling issue distinct from the codegen fix
-/// (which addresses the multi-tick problem).
+/// NOTE: This test currently aborts due to a pre-existing cluster sim infrastructure issue
+/// (TaglessMemberId::from_raw_id panics without deploy features). Once that is fixed, this
+/// test should verify the singleton by_ref behavior on clusters.
 #[test]
-#[ignore = "panics with SIGABRT due to https://github.com/hydro-project/hydro/issues/3005 (scheduler ordering)"]
+#[ignore = "cluster sim infrastructure issue: TaglessMemberId::from_raw_id requires deploy features"]
 fn sim_source_singleton_by_ref_in_map_cluster() {
     let mut flow = FlowBuilder::new();
     let cluster = flow.cluster::<()>();

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -12,84 +12,16 @@ mod trophies;
 
 /// Regression test for https://github.com/hydro-project/hydro/issues/3005
 ///
-/// `Singleton::by_ref()` on a top-level source singleton panics with `unwrap()` on `None`
-/// when the exhaustive simulator explores an interleaving where the stream consumer runs
-/// before the singleton's source operator has produced its value.
+/// `Singleton::by_ref()` on a top-level bounded source singleton is not supported because
+/// the source only fires once, leaving the handoff buffer empty on subsequent ticks.
+/// The correct semantics for persist-and-replay of references (especially mutable ones)
+/// are not yet resolved — see https://github.com/hydro-project/hydro/issues/3010.
 ///
-/// The generated DFIR code resolves the `SingletonRef` eagerly via
-/// `hoff_buf.as_ref().unwrap()`, which is `None` before the singleton source has run.
+/// This test verifies that attempting to use by_ref() on a top-level bounded singleton
+/// produces a clear panic at graph compilation time.
 #[test]
-fn sim_source_singleton_by_ref_in_map() {
-    let mut flow = FlowBuilder::new();
-    let process = flow.process::<()>();
-
-    // Source singleton: a bounded singleton created at the top level.
-    let my_singleton = process.singleton(q!(42u32));
-    let singleton_ref = my_singleton.by_ref();
-
-    // Stream input driven by the simulator.
-    let (in_port, input_stream) = process.sim_input::<u32, TotalOrder, ExactlyOnce>();
-
-    // Capture the singleton ref in a map over the input stream.
-    // Under some explored schedule, the map may be polled before the singleton source runs.
-    let out = input_stream.map(q!(move |x| x + *singleton_ref));
-    let out_port = out.sim_output();
-
-    // Consume the singleton so the graph is valid.
-    my_singleton.into_stream().for_each(q!(|_| {}));
-
-    flow.sim().exhaustive(async || {
-        in_port.send(1);
-        let result = out_port.next().await.unwrap();
-        assert_eq!(result, 43);
-    });
-}
-
-/// Same as above but on a cluster, which is the topology described in the bug report.
-///
-/// NOTE: This test currently aborts due to a pre-existing cluster sim infrastructure issue
-/// (TaglessMemberId::from_raw_id panics without deploy features). Once that is fixed, this
-/// test should verify the singleton by_ref behavior on clusters.
-#[test]
-#[ignore = "cluster sim infrastructure issue: TaglessMemberId::from_raw_id requires deploy features"]
-fn sim_source_singleton_by_ref_in_map_cluster() {
-    let mut flow = FlowBuilder::new();
-    let cluster = flow.cluster::<()>();
-
-    // Source singleton: a bounded singleton created at the top level on a cluster.
-    let my_singleton = cluster.singleton(q!(42u32));
-    let singleton_ref = my_singleton.by_ref();
-
-    // Stream input driven by the simulator.
-    let (in_port, input_stream) = cluster.sim_input::<u32, TotalOrder, ExactlyOnce>();
-
-    // Capture the singleton ref in a map over the input stream.
-    let out = input_stream.map(q!(move |x| x + *singleton_ref));
-    let out_port = out.sim_cluster_output();
-
-    // Consume the singleton so the graph is valid.
-    my_singleton.into_stream().for_each(q!(|_| {}));
-
-    flow.sim()
-        .with_cluster_size(&cluster, 2)
-        .exhaustive(async || {
-            in_port.send(0, 1);
-            in_port.send(1, 2);
-            let r0 = out_port.next(0).await.unwrap();
-            let r1 = out_port.next(1).await.unwrap();
-            assert_eq!(r0, 43);
-            assert_eq!(r1, 44);
-        });
-}
-
-/// Variant where the singleton is NOT consumed by a pipe (only by_ref), and the stream
-/// sends multiple items across multiple ticks. After the singleton source fires once (tick 0),
-/// subsequent ticks have no producer output, so the buffer may be None if drained.
-///
-/// With the fix (persist::<'static>() on top-level SingletonSource), the singleton buffer
-/// is refilled every tick and the reference consumer works correctly.
-#[test]
-fn sim_source_singleton_by_ref_multi_send() {
+#[should_panic(expected = "by_ref()/by_mut() on a top-level bounded source is not yet supported")]
+fn sim_source_singleton_by_ref_panics() {
     let mut flow = FlowBuilder::new();
     let process = flow.process::<()>();
 
@@ -99,32 +31,19 @@ fn sim_source_singleton_by_ref_multi_send() {
     let (in_port, input_stream) = process.sim_input::<u32, TotalOrder, ExactlyOnce>();
 
     let out = input_stream.map(q!(move |x| x + *singleton_ref));
-    let out_port = out.sim_output();
+    let _out_port = out.sim_output();
 
-    // Consume the singleton value so the graph has a pipe consumer (this drains the buffer).
     my_singleton.into_stream().for_each(q!(|_| {}));
 
+    // This should panic during graph compilation (sim()) because by_ref() on a
+    // top-level bounded singleton is not supported.
     flow.sim().exhaustive(async || {
-        // First batch of input — should work fine (singleton source runs on same tick).
         in_port.send(1);
-        let r1 = out_port.next().await.unwrap();
-        assert_eq!(r1, 43);
-
-        // Second input — arrives on a later tick. The singleton source already fired on tick 0
-        // and the pipe consumer drained the buffer. If the reference consumer runs now,
-        // it will try `buf.as_ref().unwrap()` on `None`.
-        in_port.send(2);
-        let r2 = out_port.next().await.unwrap();
-        assert_eq!(r2, 44);
     });
 }
 
-/// Verifies that a top-level bounded singleton's `into_stream()` emits its value
-/// only once, NOT on every tick. A bounded singleton represents an immutable value
-/// that is produced exactly once.
-///
-/// If the codegen uses `persist::<'static>()`, this could cause the singleton to
-/// replay its value every tick through the pipe consumer, violating bounded semantics.
+/// Verifies that a top-level bounded singleton's `into_stream()` still works correctly
+/// (emits its value exactly once) — only by_ref/by_mut is disallowed.
 #[test]
 fn sim_source_singleton_into_stream_emits_once() {
     let mut flow = FlowBuilder::new();

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -119,6 +119,35 @@ fn sim_source_singleton_by_ref_multi_send() {
     });
 }
 
+/// Verifies that a top-level bounded singleton's `into_stream()` emits its value
+/// only once, NOT on every tick. A bounded singleton represents an immutable value
+/// that is produced exactly once.
+///
+/// If the codegen uses `persist::<'static>()`, this could cause the singleton to
+/// replay its value every tick through the pipe consumer, violating bounded semantics.
+#[test]
+fn sim_source_singleton_into_stream_emits_once() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process::<()>();
+
+    // A bounded singleton created at the top level.
+    let my_singleton = process.singleton(q!(42u32));
+
+    // Convert to stream and output — should produce exactly one value total.
+    let out_port = my_singleton.into_stream().sim_output();
+
+    flow.sim().exhaustive(async || {
+        // Should receive the singleton value exactly once.
+        let result = out_port.next().await.unwrap();
+        assert_eq!(result, 42);
+
+        // After the singleton has been consumed, there should be nothing else.
+        // If persist causes replay, we'd get another 42 here.
+        let remaining: Vec<u32> = out_port.collect().await;
+        assert_eq!(remaining, Vec::<u32>::new(), "singleton into_stream() should emit only once, but got extra values: {:?}", remaining);
+    });
+}
+
 // Test is currently broken in nightly.
 #[cfg(not(nightly))]
 #[test]

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -63,7 +63,12 @@ fn sim_source_singleton_into_stream_emits_once() {
         // After the singleton has been consumed, there should be nothing else.
         // If persist causes replay, we'd get another 42 here.
         let remaining: Vec<u32> = out_port.collect().await;
-        assert_eq!(remaining, Vec::<u32>::new(), "singleton into_stream() should emit only once, but got extra values: {:?}", remaining);
+        assert_eq!(
+            remaining,
+            Vec::<u32>::new(),
+            "singleton into_stream() should emit only once, but got extra values: {:?}",
+            remaining
+        );
     });
 }
 

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -47,10 +47,12 @@ fn sim_source_singleton_by_ref_in_map() {
 
 /// Same as above but on a cluster, which is the topology described in the bug report.
 ///
-/// Currently panics with SIGABRT due to unwrap() on None in the singleton buffer.
-/// Remove #[ignore] once #3005 is fixed.
+/// This reproduces a separate aspect of #3005: on a cluster, the exhaustive simulator
+/// may schedule the consumer subgraph before the singleton source subgraph on the
+/// first tick. This is a simulator scheduling issue distinct from the codegen fix
+/// (which addresses the multi-tick problem).
 #[test]
-#[ignore = "panics with SIGABRT due to https://github.com/hydro-project/hydro/issues/3005"]
+#[ignore = "panics with SIGABRT due to https://github.com/hydro-project/hydro/issues/3005 (scheduler ordering)"]
 fn sim_source_singleton_by_ref_in_map_cluster() {
     let mut flow = FlowBuilder::new();
     let cluster = flow.cluster::<()>();
@@ -85,10 +87,9 @@ fn sim_source_singleton_by_ref_in_map_cluster() {
 /// sends multiple items across multiple ticks. After the singleton source fires once (tick 0),
 /// subsequent ticks have no producer output, so the buffer may be None if drained.
 ///
-/// Currently panics with SIGABRT due to unwrap() on None in the singleton buffer.
-/// Remove #[ignore] once #3005 is fixed.
+/// With the fix (persist::<'static>() on top-level SingletonSource), the singleton buffer
+/// is refilled every tick and the reference consumer works correctly.
 #[test]
-#[ignore = "panics with SIGABRT due to https://github.com/hydro-project/hydro/issues/3005"]
 fn sim_source_singleton_by_ref_multi_send() {
     let mut flow = FlowBuilder::new();
     let process = flow.process::<()>();

--- a/hydro_lang/src/sim/tests/snapshots/trace_for_fuzzed_batching.snap
+++ b/hydro_lang/src/sim/tests/snapshots/trace_for_fuzzed_batching.snap
@@ -2,12 +2,13 @@
 source: hydro_lang/src/sim/tests/mod.rs
 expression: log_str
 ---
+
 Running Tick
-* --> src/sim/tests/mod.rs:105:10
+* --> src/sim/tests/mod.rs:167:10
 *  |        .batch(&tick, nondet!(/** test */))
 *  |         ^ releasing items: [456, 456, 456, 456, 456, 456, 456, 456, ..] (1000 total)
 
 Running Tick
-* --> src/sim/tests/mod.rs:105:10
+* --> src/sim/tests/mod.rs:167:10
 *  |        .batch(&tick, nondet!(/** test */))
 *  |         ^ releasing items: [100, 23]

--- a/hydro_lang/src/sim/tests/snapshots/trace_for_fuzzed_batching_sliced.snap
+++ b/hydro_lang/src/sim/tests/snapshots/trace_for_fuzzed_batching_sliced.snap
@@ -2,12 +2,13 @@
 source: hydro_lang/src/sim/tests/mod.rs
 expression: log_str
 ---
+
 Running Tick
-* --> src/sim/tests/mod.rs:121:24
+* --> src/sim/tests/mod.rs:183:24
 *  |        let batch = use(input, nondet!(/** test */));
 *  |                       ^ releasing items: [456, 456, 456, 456, 456, 456, 456, 456, ..] (1000 total)
 
 Running Tick
-* --> src/sim/tests/mod.rs:121:24
+* --> src/sim/tests/mod.rs:183:24
 *  |        let batch = use(input, nondet!(/** test */));
 *  |                       ^ releasing items: [100, 23]


### PR DESCRIPTION
Addresses https://github.com/hydro-project/hydro/issues/3005 by disallowing `by_ref()`/`by_mut()` on top-level bounded sources at graph compilation time, and improving the error message for singleton handoff reference failures.

## Problem

`Singleton::by_ref()` on a top-level source singleton (e.g., `process.singleton(q!(42))`) panics with `unwrap()` on `None` under the exhaustive simulator. The root cause: `SingletonSource` emits `source_iter([value])` which only fires on tick 0. On subsequent ticks the singleton handoff buffer is empty, and reference consumers crash.

## Solution

After exploring several approaches:
- Adding `persist::<'static>()` globally breaks `into_stream()` bounded semantics (replays every tick)
- Adding persist only on the reference path works for `by_ref()` but has unclear semantics for `by_mut()` (mutations silently reset each tick) and stream refs

We chose to **panic at graph compilation time** when `by_ref()`/`by_mut()` is used on a top-level bounded source, with a message pointing to https://github.com/hydro-project/hydro/issues/3010 which tracks resolving the correct semantics.

This applies to all handoff ref kinds (singleton, optional, stream) since the persist-and-replay semantics are tricky for all of them.

## Additional improvements

- **Better error messages**: Changed generated `buf.as_ref().unwrap()` to `.expect()` with a descriptive message identifying which singleton was not populated
- **`TaglessMemberId` feature gate** (same fix as #3001): Added `sim_runtime` to the `Legacy` variant's feature gate so cluster sim tests don't abort

## Tests

- `sim_source_singleton_by_ref_panics`: verifies the panic fires with correct message
- `sim_source_singleton_into_stream_emits_once`: verifies `into_stream()` still emits only once
- `test_singleton_reference_no_persist_works_across_ticks` (DFIR): demonstrates the workaround (explicit persist) at the DFIR level