### PR TITLE
docs(hydro): Describe monotonicity in Hydro

### DIFF
--- a/docs/docs/hydro/reference/algebraic-properties/_category_.json
+++ b/docs/docs/hydro/reference/algebraic-properties/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Algebraic Properties",
+  "position": 5,
+  "link": {
+    "type": "doc",
+    "id": "hydro/reference/algebraic-properties/index"
+  }
+}

--- a/docs/docs/hydro/reference/algebraic-properties/index.md
+++ b/docs/docs/hydro/reference/algebraic-properties/index.md
@@ -1,0 +1,5 @@
+# Algebraic Properties
+
+Hydro's type system tracks algebraic properties of operations — such as monotonicity, commutativity, and idempotence — through annotations on `q!` quoted closures. These properties enable the compiler to guarantee correctness of distributed coordination patterns like threshold detection and unordered aggregation.
+
+- **[Monotonicity](./monotonicity.md)**: a value only grows over time, enabling deterministic threshold-based coordination

--- a/docs/docs/hydro/reference/algebraic-properties/monotonicity.md
+++ b/docs/docs/hydro/reference/algebraic-properties/monotonicity.md
@@ -1,0 +1,158 @@
+---
+title: Monotonicity
+sidebar_position: 1
+---
+
+# Monotonicity in `q!` Quoted Functions
+
+Hydro's type system tracks **monotonicity** — the property that a value only grows over time — through `q!` quoted closures. This enables deterministic threshold-based coordination in distributed programs: detecting when a counter crosses a threshold fires exactly once, regardless of message ordering.
+
+## Overview
+
+A `Singleton` in Hydro has one of three boundedness markers:
+- **`Bounded`** — the value is frozen and will never change.
+- **`Unbounded`** — the value may change arbitrarily over time.
+- **`Monotonic`** — the value only grows (according to `PartialOrd`) over time.
+
+A `KeyedSingleton` has analogous markers including **`MonotonicValue`** (values per key only grow).
+
+The `Monotonic` bound enables APIs like `threshold_greater_or_equal`, which deterministically detects when a value crosses a threshold. This would be non-deterministic on an `Unbounded` singleton, so the type system prevents it.
+
+## Declaring Monotonicity
+
+Monotonicity is declared via property annotations inside `q!()` closures passed to aggregation operators like `fold`:
+
+```rust
+stream.fold(
+    q!(|| 0),
+    q!(
+        |acc, v| *acc += v,
+        monotone = manual_proof!(/** integer addition with non-negative inputs is monotone */)
+    ),
+)
+```
+
+The `monotone = manual_proof!(/** ... */)` annotation tells the type system that applying the closure to any new input only increases (or maintains) the accumulator. The doc comment is your human-written justification for why this holds.
+
+## Producing a Monotonic Singleton
+
+When you annotate `fold` with a `monotone` proof and the input stream is `Unbounded`, the output singleton is promoted to `Monotonic`:
+
+```rust
+// Input: Stream<i32, Process, Unbounded>
+// Output: Singleton<usize, _, Monotonic>
+let count: Singleton<usize, _, Monotonic> = unbounded_stream.fold(
+    q!(|| 0usize),
+    q!(|acc, _| *acc += 1, monotone = manual_proof!(/** += 1 is monotone */)),
+);
+```
+
+Without the `monotone` annotation, the same `fold` produces `Singleton<..., Unbounded>`.
+
+## Preserving Monotonicity Through `.map()`
+
+If you have a `Monotonic` singleton and apply `.map()`, the result is demoted to `Unbounded` by default (since the map function could reverse the ordering). To preserve monotonicity, annotate with `order_preserving`:
+
+```rust
+let still_monotonic: Singleton<usize, _, Monotonic> = monotonic_singleton.map(
+    q!(|x| x * 2, order_preserving = manual_proof!(/** doubling preserves order */)),
+);
+```
+
+Without `order_preserving`, using the result with `threshold_greater_or_equal` would fail to compile.
+
+## Threshold Detection
+
+Once you have a `Monotonic` singleton (or `Bounded`), you can use threshold APIs:
+
+```rust
+let a: Singleton<i32, _, Monotonic> = /* ... */;
+let threshold = process.singleton(q!(100));
+let crossed: Stream<i32, _, _> = a.threshold_greater_or_equal(threshold);
+// Emits 100 exactly once, the first time `a` >= 100
+```
+
+If you try this on a non-monotonic singleton:
+
+```rust
+let no_longer_monotone = is_monotone.map(q!(|x| -x)); // no order_preserving proof
+let _ = no_longer_monotone.threshold_greater_or_equal(threshold);
+// ERROR: The input singleton must be monotonic (`Monotonic`) or bounded (`Bounded`)
+```
+
+## KeyedSingleton Monotonicity
+
+For `KeyedSingleton`, the `MonotonicValue` bound indicates that the **value** for each key grows monotonically. This enables `threshold_greater_or_equal` and `threshold_greater_or_equal_uniform` on keyed data:
+
+```rust
+let counts: KeyedSingleton<u32, usize, _, MonotonicValue> = events.into_keyed()
+    .fold(
+        q!(|| 0),
+        q!(|acc, _| *acc += 1, monotone = manual_proof!(/** +1 is monotone */)),
+    );
+
+// Per-key threshold
+let thresholds: KeyedSingleton<u32, usize, _, BoundedValue> = /* ... */;
+let crossed = counts.threshold_greater_or_equal(thresholds);
+
+// Uniform threshold across all keys
+let threshold = process.singleton(q!(5usize));
+let crossed = counts.threshold_greater_or_equal_uniform(threshold);
+```
+
+## Available Annotations
+
+For aggregation functions (`fold`, `reduce`):
+
+| Annotation | Meaning | When to use |
+|---|---|---|
+| `commutative = ...` | Order of inputs doesn't matter | Input stream is unordered (`NoOrder`) |
+| `idempotent = ...` | Duplicate inputs don't change result | Input stream has retries |
+| `monotone = ...` | Accumulator only grows over time | You want `Monotonic` / `MonotonicValue` output |
+
+For map functions on singletons:
+
+| Annotation | Meaning | When to use |
+|---|---|---|
+| `order_preserving = ...` | If input grows, output also grows | You want to preserve `Monotonic` through `.map()` |
+
+All annotations use `manual_proof!(/** reason */)` — a human attestation that the property holds. In the future, automated verification backends such as [Kani](https://model-checking.github.io/kani/) may be supported.
+
+## Common Patterns
+
+### Counter (always monotone)
+```rust
+stream.fold(
+    q!(|| 0usize),
+    q!(|count, _| *count += 1, monotone = manual_proof!(/** += 1 is monotone */)),
+)
+```
+
+### Sum of non-negative values
+```rust
+// Only monotone if all inputs are non-negative!
+stream.fold(
+    q!(|| 0),
+    q!(|acc, v| *acc += v, monotone = manual_proof!(/** sum of non-negative values */)),
+)
+```
+
+### Set size via `.count()`
+The built-in `.count()` method already includes a monotone proof internally:
+```rust
+// Returns Singleton<usize, _, Monotonic> when input is Unbounded
+stream.count()
+```
+
+## Interaction with the Simulator
+
+When using Hydro's simulator (`flow.sim()`), monotonicity proofs are checked at runtime. The simulator explores different orderings of inputs to verify that annotated properties actually hold, catching bugs where a `manual_proof!` claim is incorrect.
+
+## Summary
+
+| Concept | Where declared | Effect |
+|---|---|---|
+| Monotone aggregation | `q!(\|acc, v\| ..., monotone = ...)` in `fold` | Output becomes `Monotonic` / `MonotonicValue` |
+| Order-preserving map | `q!(\|x\| ..., order_preserving = ...)` in `.map()` | Preserves `Monotonic` through the map |
+| Threshold detection | `.threshold_greater_or_equal(...)` | Requires `Monotonic` or `Bounded` input |
+| Manual proof | `manual_proof!(/** reason */)` | Human attestation that property holds |

--- a/docs/docs/hydro/reference/deploy/_category_.json
+++ b/docs/docs/hydro/reference/deploy/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Deployment",
-  "position": 8,
+  "position": 9,
   "link": {
     "type": "doc",
     "id": "hydro/reference/deploy/index"

--- a/docs/docs/hydro/reference/live-collections/bounded-unbounded.md
+++ b/docs/docs/hydro/reference/live-collections/bounded-unbounded.md
@@ -53,3 +53,10 @@ When working with asynchronous futures in a stream, the choice of resolution str
 - **`resolve_futures_blocking`** preserves the input stream's boundedness. It freezes the tick until all futures in the batch resolve, making the results synchronously available within the same tick. This allows the output to be used with bounded-only APIs like `cross_singleton` or `clone_into_tick`.
 
 **When to use which:** In most cases, prefer `resolve_futures` — it allows you to process results as they stream in without blocking. Use `resolve_futures_blocking` only when you need the bounded guarantee, for example to combine the resolved results with other bounded collections in the same tick.
+
+## Monotonicity
+Beyond `Bounded` and `Unbounded`, Hydro also supports a third boundedness marker: **`Monotonic`**. A `Monotonic` singleton is one whose value only grows (according to `PartialOrd`) over time. This enables deterministic threshold-based coordination — for example, detecting when a counter crosses a value fires exactly once regardless of message ordering.
+
+`Monotonic` singletons are produced by annotating aggregation closures with monotonicity proofs, and they unlock APIs like `threshold_greater_or_equal` that would be non-deterministic on an `Unbounded` singleton.
+
+See [Monotonicity](../algebraic-properties/monotonicity.md) for full details on declaring and preserving monotonicity.

--- a/docs/docs/hydro/reference/locations/_category_.json
+++ b/docs/docs/hydro/reference/locations/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Locations and Networking",
-  "position": 5,
+  "position": 6,
   "link": {
     "type": "doc",
     "id": "hydro/reference/locations/index"

--- a/docs/docs/hydro/reference/simulation/_category_.json
+++ b/docs/docs/hydro/reference/simulation/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Simulation Testing",
-  "position": 7,
+  "position": 8,
   "link": {
     "type": "doc",
     "id": "hydro/reference/simulation/index"

--- a/docs/docs/hydro/reference/slices-atomicity/_category_.json
+++ b/docs/docs/hydro/reference/slices-atomicity/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Slices and Atomicity",
-  "position": 6,
+  "position": 7,
   "link": {
     "type": "doc",
     "id": "hydro/reference/slices-atomicity/index"

--- a/docs/docs/hydro/reference/stageleft/_category_.json
+++ b/docs/docs/hydro/reference/stageleft/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Stageleft",
-  "position": 9,
+  "position": 10,
   "link": {
     "type": "doc",
     "id": "hydro/reference/stageleft/index"

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -113,6 +113,18 @@ impl KeyedSingletonBound for BoundedValue {
 
 /// A variation of boundedness specific to [`KeyedSingleton`], which indicates that once a key appears,
 /// it will never be removed, and the corresponding value will only increase monotonically.
+///
+/// Produced when [`KeyedStream::fold`] is annotated with `monotone = manual_proof!(/** ... */)`:
+///
+/// ```rust,ignore
+/// let counts: KeyedSingleton<u32, usize, _, MonotonicValue> = keyed_stream.fold(
+///     q!(|| 0),
+///     q!(|acc, _| *acc += 1, monotone = manual_proof!(/** +1 is monotone */)),
+/// );
+/// ```
+///
+/// Enables [`KeyedSingleton::threshold_greater_or_equal`] and
+/// [`KeyedSingleton::threshold_greater_or_equal_uniform`] for deterministic per-key threshold detection.
 pub struct MonotonicValue;
 
 impl KeyedSingletonBound for MonotonicValue {
@@ -153,6 +165,10 @@ impl KeyedSingletonBound for MonotonicKeys {
 )]
 /// Marker trait that is implemented for [`KeyedSingletonBound`] types whose per-key values
 /// are monotonically non-decreasing (or bounded).
+///
+/// Required by [`KeyedSingleton::threshold_greater_or_equal`] and
+/// [`KeyedSingleton::threshold_greater_or_equal_uniform`]. Satisfied by [`MonotonicValue`]
+/// (from `fold` with `monotone` proof) and [`Bounded`] (trivially, since values are fixed).
 pub trait IsKeyedMonotonic: KeyedSingletonBound {}
 
 #[sealed]
@@ -175,6 +191,12 @@ impl<B: IsBounded + KeyedSingletonBound> IsKeyedMonotonic for B {}
 /// keyed singletons can use [`BoundedValue`] to declare that new keys may be added over time, but
 /// keys cannot be removed and the value for each key is immutable.
 ///
+/// When the bound is [`MonotonicValue`], per-key values only grow over time. This enables
+/// deterministic threshold-based coordination via [`KeyedSingleton::threshold_greater_or_equal`]
+/// and [`KeyedSingleton::threshold_greater_or_equal_uniform`]. A `MonotonicValue` keyed singleton
+/// is produced by calling [`KeyedStream::fold`] with a `monotone = manual_proof!(/** ... */)`
+/// annotation in the `q!()` closure.
+///
 /// Type Parameters:
 /// - `K`: the type of the key for each entry
 /// - `V`: the type of the value for each entry
@@ -183,6 +205,7 @@ impl<B: IsBounded + KeyedSingletonBound> IsKeyedMonotonic for B {}
 ///     - [`Bounded`] (local and finite)
 ///     - [`Unbounded`] (asynchronous with entries added / removed / changed over time)
 ///     - [`BoundedValue`] (asynchronous with immutable values for each key and no removals)
+///     - [`MonotonicValue`] (values per key only grow; enables threshold APIs)
 pub struct KeyedSingleton<K, V, Loc, Bound: KeyedSingletonBound> {
     pub(crate) location: Loc,
     pub(crate) ir_node: RefCell<HydroNode>,

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -1960,6 +1960,21 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// Depending on the input stream guarantees, the closure may need to be commutative
     /// (for unordered streams) or idempotent (for streams with non-deterministic duplicates).
     ///
+    /// # Monotonicity
+    /// If the `comb` closure is annotated with `monotone = manual_proof!(/** ... */)` inside
+    /// `q!()`, the resulting keyed singleton will be [`MonotonicValue`](crate::live_collections::keyed_singleton::MonotonicValue)
+    /// (when the input stream is `Unbounded`). This enables downstream use of
+    /// [`KeyedSingleton::threshold_greater_or_equal`] and
+    /// [`KeyedSingleton::threshold_greater_or_equal_uniform`].
+    ///
+    /// ```rust,ignore
+    /// // Produces KeyedSingleton<K, usize, _, MonotonicValue>
+    /// keyed_stream.fold(
+    ///     q!(|| 0usize),
+    ///     q!(|acc, _| *acc += 1, monotone = manual_proof!(/** += 1 is monotone */)),
+    /// )
+    /// ```
+    ///
     /// If the input and output value types are the same and do not require initialization then use
     /// [`KeyedStream::reduce`].
     ///

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -67,6 +67,25 @@ impl SingletonBound for Bounded {
 }
 
 /// Marks that the [`Singleton`] is monotonic, which means that its value will only grow over time.
+///
+/// A `Monotonic` singleton is produced when an aggregation function (e.g. in [`Stream::fold`])
+/// is annotated with a `monotone` proof inside `q!()`:
+///
+/// ```rust,ignore
+/// stream.fold(
+///     q!(|| 0),
+///     q!(|acc, v| *acc += v, monotone = manual_proof!(/** addition is monotone */)),
+/// )
+/// // → Singleton<_, _, Monotonic>
+/// ```
+///
+/// The `Monotonic` bound enables APIs like [`Singleton::threshold_greater_or_equal`] which
+/// require deterministic growth to fire exactly once. To preserve `Monotonic` through a
+/// `.map()`, annotate with `order_preserving`:
+///
+/// ```rust,ignore
+/// monotonic_singleton.map(q!(|x| x * 2, order_preserving = manual_proof!(/** ... */)))
+/// ```
 pub struct Monotonic;
 
 impl SingletonBound for Monotonic {
@@ -99,7 +118,13 @@ impl<B: IsBounded> IsMonotonic for B {}
 /// A single Rust value that can asynchronously change over time.
 ///
 /// If the singleton is [`Bounded`], the value is frozen and will not change. But if it is
-/// [`Unbounded`], the value will asynchronously change over time.
+/// [`Unbounded`], the value will asynchronously change over time. If it is [`Monotonic`],
+/// the value will only grow over time (according to `PartialOrd`), enabling deterministic
+/// threshold-based coordination via [`Singleton::threshold_greater_or_equal`].
+///
+/// A `Monotonic` singleton is produced by annotating the closure in [`Stream::fold`] with
+/// `monotone = manual_proof!(/** ... */)` inside `q!()`. To preserve monotonicity through
+/// a subsequent `.map()`, use `order_preserving = manual_proof!(/** ... */)`.
 ///
 /// Singletons are often used to capture state in a Hydro program, such as an event counter which is
 /// a single number that will asynchronously change as events are processed. Singletons also appear
@@ -109,7 +134,8 @@ impl<B: IsBounded> IsMonotonic for B {}
 /// Type Parameters:
 /// - `Type`: the type of the value in this singleton
 /// - `Loc`: the [`Location`] where the singleton is materialized
-/// - `Bound`: tracks whether the value is [`Bounded`] (fixed) or [`Unbounded`] (changing asynchronously)
+/// - `Bound`: tracks whether the value is [`Bounded`] (fixed), [`Unbounded`] (changing asynchronously),
+///   or [`Monotonic`] (only growing)
 pub struct Singleton<Type, Loc, Bound: SingletonBound> {
     pub(crate) location: Loc,
     pub(crate) ir_node: RefCell<HydroNode>,
@@ -481,6 +507,17 @@ where
 
     /// Transforms the singleton value by applying a function `f` to it,
     /// continuously as the input is updated.
+    ///
+    /// # Preserving Monotonicity
+    /// If the input singleton is [`Monotonic`] and the map function preserves order
+    /// (i.e. if `a <= b` implies `f(a) <= f(b)`), annotate the closure with
+    /// `order_preserving = manual_proof!(/** ... */)` to keep the output `Monotonic`:
+    ///
+    /// ```rust,ignore
+    /// monotonic.map(q!(|x| x * 2, order_preserving = manual_proof!(/** doubling preserves order */)))
+    /// ```
+    ///
+    /// Without this annotation, mapping a `Monotonic` singleton produces an `Unbounded` singleton.
     ///
     /// # Example
     /// ```rust

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -1396,6 +1396,20 @@ where
     /// Depending on the input stream guarantees, the closure may need to be commutative
     /// (for unordered streams) or idempotent (for streams with non-deterministic duplicates).
     ///
+    /// # Monotonicity
+    /// If the `comb` closure is annotated with `monotone = manual_proof!(/** ... */)` inside
+    /// `q!()`, the resulting singleton will be [`Monotonic`](crate::live_collections::singleton::Monotonic)
+    /// (when the input stream is `Unbounded`). This enables downstream use of
+    /// [`Singleton::threshold_greater_or_equal`] for deterministic threshold detection.
+    ///
+    /// ```rust,ignore
+    /// // Produces Singleton<usize, _, Monotonic>
+    /// stream.fold(
+    ///     q!(|| 0usize),
+    ///     q!(|acc, _| *acc += 1, monotone = manual_proof!(/** += 1 is monotone */)),
+    /// )
+    /// ```
+    ///
     /// # Example
     /// ```rust
     /// # #[cfg(feature = "deploy")] {

--- a/hydro_lang/src/properties/mod.rs
+++ b/hydro_lang/src/properties/mod.rs
@@ -28,6 +28,9 @@ pub trait IdempotentProof {
 }
 
 /// A trait for proof mechanisms that can validate monotonicity.
+///
+/// Monotonicity means the aggregation function only increases the accumulator value.
+/// Used via `monotone = manual_proof!(/** ... */)` inside `q!()` closures passed to `fold`.
 #[sealed::sealed]
 pub trait MonotoneProof {
     /// Registers the expression with the proof mechanism.
@@ -37,6 +40,9 @@ pub trait MonotoneProof {
 }
 
 /// A trait for proof mechanisms that can validate order-preservation (monotonicity of a map function).
+///
+/// Order-preservation means if input grows, output also grows.
+/// Used via `order_preserving = manual_proof!(/** ... */)` inside `q!()` closures passed to `.map()` on singletons.
 #[sealed::sealed]
 pub trait OrderPreservingProof {
     /// Registers the expression with the proof mechanism.
@@ -119,6 +125,18 @@ pub enum Proved {}
 
 /// Algebraic properties for an aggregation function of type (T, &mut A) -> ().
 ///
+/// These properties are declared via annotations inside `q!()` closures:
+///
+/// ```rust,ignore
+/// stream.fold(
+///     q!(|| initial),
+///     q!(|acc, v| { /* ... */ },
+///         commutative = manual_proof!(/** why order doesn't matter */),
+///         monotone = manual_proof!(/** why accumulator only grows */)
+///     ),
+/// )
+/// ```
+///
 /// Commutativity:
 /// ```rust,ignore
 /// let mut state = ???;
@@ -134,6 +152,10 @@ pub enum Proved {}
 /// f(a, &mut state);
 /// // state1 must be equal to state
 /// ```
+///
+/// Monotonicity: applying the function to any input only increases (or maintains) the
+/// accumulator's value according to `PartialOrd`. When proved, the resulting singleton
+/// from [`Stream::fold`] is promoted to [`Monotonic`](crate::live_collections::singleton::Monotonic).
 pub struct AggFuncAlgebra<Commutative = NotProved, Idempotent = NotProved, Monotone = NotProved>(
     Option<Box<dyn CommutativeProof>>,
     Option<Box<dyn IdempotentProof>>,
@@ -186,7 +208,15 @@ impl<C, I, M> Property for AggFuncAlgebra<C, I, M> {
 
 /// Algebraic properties for a singleton map function of type T -> U.
 ///
-/// Order-preserving means that if the input grows monotonically, the output also grows monotonically.
+/// Order-preserving means that if the input grows monotonically, the output also grows
+/// monotonically (i.e. `a <= b` implies `f(a) <= f(b)`).
+///
+/// When proved, mapping a [`Monotonic`](crate::live_collections::singleton::Monotonic) singleton
+/// preserves the `Monotonic` bound. Without this proof, the output is demoted to `Unbounded`.
+///
+/// ```rust,ignore
+/// monotonic_singleton.map(q!(|x| x * 2, order_preserving = manual_proof!(/** ... */)))
+/// ```
 pub struct SingletonMapFuncAlgebra<
     OrderPreserving = NotProved,
     Commutative = NotProved,


### PR DESCRIPTION
Add a new section dedicated to algebraic properties, starting with monotonicity. Commutativity and idempotency are lightly documented here, and may be broken out into their own dedicated pages as a separate pull request.

- Overview of what monotonicity buys you (threshold detection)
- How to declare it (syntax)
- How to produce a Monotonic singleton (fold example)
- How to preserve it through .map() (order_preserving)
- How to use threshold detection (with error example)
- KeyedSingleton usage (per-key thresholds, uniform thresholds)
- Available annotations table
- Common patterns