### PR TITLE
feat(dfir_lang): expose programmatic loop creation on `FlatGraphBuilder`

### DIFF
--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -144,6 +144,9 @@ impl FlatGraphBuilder {
     ///
     /// The returned [`GraphLoopId`] can be passed as the `current_loop` argument of
     /// [`Self::add_dfir`] / [`Self::append_assign_pipeline`] to place statements inside the loop,
+    ///
+    /// # Panics
+    /// Panics if `parent_loop` is a loop not belonging to this instance.
     /// across multiple calls. This is the programmatic equivalent of a
     /// [`DfirStatement::Loop`] block in the surface syntax, but allows the loop body to be built
     /// up incrementally.
@@ -1259,8 +1262,9 @@ mod test {
 
         // One root loop, containing the `batch()` and `for_each()` (but not `source_iter()`).
         assert_eq!(1, flat_graph.loops().count());
-        let (loop_id, _) = flat_graph.loops().next().unwrap();
-        assert_eq!(None, flat_graph.loop_parent(loop_id));
+        let (built_loop_id, _) = flat_graph.loops().next().unwrap();
+        assert_eq!(loop_id, built_loop_id);
+        assert_eq!(None, flat_graph.loop_parent(built_loop_id));
 
         for (node_id, _node) in flat_graph.nodes() {
             let Some(op_inst) = flat_graph.node_op_inst(node_id) else {
@@ -1268,7 +1272,7 @@ mod test {
             };
             let expected_loop = match op_inst.op_constraints.name {
                 "source_iter" => None,
-                "batch" | "for_each" => Some(loop_id),
+                "batch" | "for_each" => Some(built_loop_id),
                 other => panic!("Unexpected operator: {}", other),
             };
             assert_eq!(

--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -139,6 +139,18 @@ impl FlatGraphBuilder {
         self.add_statement_internal(stmt, None, None);
     }
 
+    /// Programmatically create a new `loop { ... }` context, with the given parent loop context
+    /// (or `None` for a root-level loop).
+    ///
+    /// The returned [`GraphLoopId`] can be passed as the `current_loop` argument of
+    /// [`Self::add_dfir`] / [`Self::append_assign_pipeline`] to place statements inside the loop,
+    /// across multiple calls. This is the programmatic equivalent of a
+    /// [`DfirStatement::Loop`] block in the surface syntax, but allows the loop body to be built
+    /// up incrementally.
+    pub fn insert_loop(&mut self, parent_loop: Option<GraphLoopId>) -> GraphLoopId {
+        self.flat_graph.insert_loop(parent_loop)
+    }
+
     /// Add a single [`DfirStatement`] line to this [`DfirGraph`] with given configuration.
     ///
     /// Optional configuration:
@@ -1203,5 +1215,142 @@ impl FlatGraphBuilder {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use syn::parse_quote;
+
+    use super::*;
+
+    /// Test that [`FlatGraphBuilder::insert_loop`] can be used to programmatically build a loop
+    /// context, with statements added across multiple [`FlatGraphBuilder::add_dfir`] calls.
+    #[test]
+    fn test_insert_loop_programmatic() {
+        let mut builder = FlatGraphBuilder::new();
+        builder.add_dfir(
+            parse_quote! {
+                inp = source_iter([1, 2, 3]);
+            },
+            None,
+            None,
+        );
+        let loop_id = builder.insert_loop(None);
+        builder.add_dfir(
+            parse_quote! {
+                batched = inp -> batch();
+            },
+            Some(loop_id),
+            None,
+        );
+        builder.add_dfir(
+            parse_quote! {
+                batched -> for_each(std::mem::drop);
+            },
+            Some(loop_id),
+            None,
+        );
+
+        let output = builder.build().unwrap_or_else(|diagnostics| {
+            panic!("Should build without errors, got: {:?}", diagnostics);
+        });
+        let flat_graph = output.flat_graph;
+
+        // One root loop, containing the `batch()` and `for_each()` (but not `source_iter()`).
+        assert_eq!(1, flat_graph.loops().count());
+        let (loop_id, _) = flat_graph.loops().next().unwrap();
+        assert_eq!(None, flat_graph.loop_parent(loop_id));
+
+        for (node_id, _node) in flat_graph.nodes() {
+            let Some(op_inst) = flat_graph.node_op_inst(node_id) else {
+                continue;
+            };
+            let expected_loop = match op_inst.op_constraints.name {
+                "source_iter" => None,
+                "batch" | "for_each" => Some(loop_id),
+                other => panic!("Unexpected operator: {}", other),
+            };
+            assert_eq!(
+                expected_loop,
+                flat_graph.node_loop(node_id),
+                "Wrong loop context for operator `{}`.",
+                op_inst.op_constraints.name,
+            );
+        }
+    }
+
+    /// Test that programmatically-built nested loops have the correct parent relationship.
+    #[test]
+    fn test_insert_loop_nested() {
+        let mut builder = FlatGraphBuilder::new();
+        let outer_loop = builder.insert_loop(None);
+        let inner_loop = builder.insert_loop(Some(outer_loop));
+
+        builder.add_dfir(
+            parse_quote! {
+                inp = source_iter([1, 2, 3]);
+            },
+            None,
+            None,
+        );
+        builder.add_dfir(
+            parse_quote! {
+                outer = inp -> batch();
+            },
+            Some(outer_loop),
+            None,
+        );
+        builder.add_dfir(
+            parse_quote! {
+                outer -> batch() -> for_each(std::mem::drop);
+            },
+            Some(inner_loop),
+            None,
+        );
+
+        let output = builder.build().unwrap_or_else(|diagnostics| {
+            panic!("Should build without errors, got: {:?}", diagnostics);
+        });
+        let flat_graph = output.flat_graph;
+
+        assert_eq!(2, flat_graph.loops().count());
+        assert_eq!(None, flat_graph.loop_parent(outer_loop));
+        assert_eq!(Some(outer_loop), flat_graph.loop_parent(inner_loop));
+    }
+
+    /// Test that loop validation (windowing operator required at loop entry) applies to
+    /// programmatically-created loop contexts, same as parsed `loop { ... }` blocks.
+    #[test]
+    fn test_insert_loop_requires_windowing() {
+        let mut builder = FlatGraphBuilder::new();
+        builder.add_dfir(
+            parse_quote! {
+                inp = source_iter([1, 2, 3]);
+            },
+            None,
+            None,
+        );
+        let loop_id = builder.insert_loop(None);
+        // `map` is not a windowing operator, so this should fail to build.
+        builder.add_dfir(
+            parse_quote! {
+                inp -> map(|x: usize| x) -> for_each(std::mem::drop);
+            },
+            Some(loop_id),
+            None,
+        );
+
+        let Err(diagnostics) = builder.build() else {
+            panic!("Should fail to build due to missing windowing operator.");
+        };
+        assert!(
+            diagnostics.iter().any(|diagnostic| {
+                Level::Error == diagnostic.level
+                    && diagnostic.message.contains("windowing operator")
+            }),
+            "Expected a windowing operator error, got: {:?}",
+            diagnostics,
+        );
     }
 }


### PR DESCRIPTION
Add `FlatGraphBuilder::insert_loop(parent: Option<GraphLoopId>) -> GraphLoopId`, a thin public wrapper around `DfirGraph::insert_loop`, so callers can create `loop { ... }` contexts programmatically and incrementally add statements into them via the existing `current_loop` parameter of `add_dfir` / `append_assign_pipeline`, across multiple calls. This is the programmatic equivalent of a parsed `loop { ... }` block.

This is groundwork for hydro-project/hydro#2902: the Hydro → DFIR production codegen will emit each (unified) Hydro tick as a root-level DFIR `loop { ... }` block, which requires building loop bodies incrementally rather than from a single parsed block.

## Changes

- `dfir_lang/src/graph/flat_graph_builder.rs`: new `insert_loop` method (delegates to `DfirGraph::insert_loop`, which was already public but unreachable through the builder's private `flat_graph` field).

## Tests

- Building a gated root-level loop across multiple `add_dfir` calls, verifying loop membership of each operator (`source_iter` outside; `batch` / `for_each` inside).
- Nested loop creation with correct parent relationships.
- Loop validation (windowing operator required at loop entry) applies to programmatically-created loops the same as parsed ones.

Verified with `cargo test --lib flat_graph_builder` (3/3), `cargo clippy -p dfir_lang --all-targets`, and `cargo fmt --check`.