### PR TITLE
fix(hydro_lang): fix macOS-only Maelstrom node startup timeouts and improve failure diagnostics [ci-full]

### DIFF
--- a/hydro_lang/src/deploy/maelstrom/deploy_maelstrom.rs
+++ b/hydro_lang/src/deploy/maelstrom/deploy_maelstrom.rs
@@ -7,7 +7,7 @@
 use std::cell::RefCell;
 use std::future::Future;
 use std::io::{BufRead, BufReader, Error};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::process::Stdio;
 use std::rc::Rc;
@@ -505,6 +505,21 @@ impl MaelstromDeployment {
     pub fn run(self) -> Result<(), Error> {
         let binary_path = self.build()?;
 
+        // Warm up the binary before handing it to Maelstrom. On macOS, the
+        // first execution of a freshly written binary triggers a Gatekeeper /
+        // XProtect (`syspolicyd`) scan that can take several seconds on loaded
+        // CI machines. Maelstrom only waits 10 seconds for each node to answer
+        // the `init` RPC, so a cold first exec (multiplied across concurrently
+        // launched nodes) can cause spurious node-startup timeouts. The warmup
+        // invocation sees EOF on stdin and exits immediately, priming the
+        // system's first-exec caches for the real run.
+        std::process::Command::new(&binary_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?
+            .wait()?;
+
         // Use a unique working directory per run to avoid conflicts with concurrent tests.
         let run_dir = tempfile::tempdir().map_err(Error::other)?;
 
@@ -547,6 +562,7 @@ impl MaelstromDeployment {
 
             if line.starts_with("Analysis invalid!") {
                 let path = run_dir.keep();
+                dump_node_logs(&path);
                 return Err(Error::other(format!(
                     "Analysis was invalid. Maelstrom store at: {}",
                     path.display()
@@ -559,6 +575,7 @@ impl MaelstromDeployment {
         }
 
         let path = run_dir.keep();
+        dump_node_logs(&path);
         Err(Error::other(format!(
             "Maelstrom produced an unexpected result. Store at: {}",
             path.display()
@@ -568,5 +585,47 @@ impl MaelstromDeployment {
     /// Get the path to the compiled binary, building it if necessary.
     pub fn binary_path(&self) -> Option<PathBuf> {
         self.build().ok()
+    }
+}
+
+/// Print the per-node logs from a Maelstrom run directory to stderr.
+///
+/// Maelstrom truncates node stderr in its own error messages (keeping only the
+/// tail), so when a node crashes the actual panic message is often cut off.
+/// The full logs live in `store/<workload>/<timestamp>/node-logs/*.log` under
+/// the run directory; dump them so failures are debuggable in CI, where the
+/// preserved store directory is not otherwise accessible.
+fn dump_node_logs(run_dir: &Path) {
+    fn collect(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            // Skip symlinks (e.g. `store/latest`) to avoid duplicates.
+            if path.is_symlink() || !path.is_dir() {
+                continue;
+            }
+            if path.file_name().is_some_and(|name| name == "node-logs") {
+                if let Ok(logs) = std::fs::read_dir(&path) {
+                    out.extend(logs.flatten().map(|e| e.path()));
+                }
+            } else {
+                collect(&path, out);
+            }
+        }
+    }
+
+    let mut log_files = Vec::new();
+    collect(&run_dir.join("store"), &mut log_files);
+    log_files.sort();
+
+    for log in log_files {
+        eprintln!("==== Maelstrom node log: {} ====", log.display());
+        match std::fs::read_to_string(&log) {
+            Ok(contents) => eprint!("{}", contents),
+            Err(e) => eprintln!("(failed to read log: {})", e),
+        }
+        eprintln!("==== end of node log: {} ====", log.display());
     }
 }

--- a/hydro_lang/src/deploy/maelstrom/deploy_runtime_maelstrom.rs
+++ b/hydro_lang/src/deploy/maelstrom/deploy_runtime_maelstrom.rs
@@ -92,17 +92,48 @@ pub fn maelstrom_init() -> MaelstromMeta {
     let stdin = std::io::stdin();
     let mut stdout = std::io::stdout();
 
-    // Read the init message
-    let mut line = String::new();
-    stdin
-        .lock()
-        .read_line(&mut line)
-        .expect("Failed to read init message");
+    // Read until the init message arrives. Maelstrom delivers node-to-node
+    // messages to a node's stdin as soon as the process starts, so a
+    // fast-starting peer may already be broadcasting `hydro_data` messages
+    // before the init RPC for this node is sent — the first line on stdin is
+    // not necessarily `init`. Such pre-init messages are dropped: inter-node
+    // channels in the Maelstrom backend are lossy, so dropped messages are
+    // handled the same as network loss.
+    let msg: MaelstromMessage<InitBody> = loop {
+        let mut line = String::new();
+        let bytes_read = stdin
+            .lock()
+            .read_line(&mut line)
+            .expect("Failed to read init message");
 
-    let msg: MaelstromMessage<InitBody> =
-        serde_json::from_str(&line).expect("Failed to parse init message");
+        if bytes_read == 0 {
+            // stdin reached EOF before an init message arrived. This happens when
+            // Maelstrom tears the node down (e.g. after an init timeout) or during
+            // a warmup invocation with no input. Exit cleanly instead of panicking
+            // so the node is not reported as "crashed", which would mask the real
+            // error (such as the init timeout).
+            eprintln!("stdin closed before an init message was received; exiting");
+            std::process::exit(0);
+        }
 
-    assert_eq!(msg.body.msg_type, "init", "First message must be init");
+        let parsed: MaelstromMessage<serde_json::Value> =
+            serde_json::from_str(&line).expect("Failed to parse message while waiting for init");
+
+        if parsed.body.get("type").and_then(|t| t.as_str()) == Some("init") {
+            let body: InitBody =
+                serde_json::from_value(parsed.body).expect("Failed to parse init message");
+            break MaelstromMessage {
+                src: parsed.src,
+                dest: parsed.dest,
+                body,
+            };
+        } else {
+            eprintln!(
+                "dropping message received before init (lossy channel): {}",
+                line.trim_end()
+            );
+        }
+    };
 
     // Set up broadcast channel for stdin lines
     let (stdin_tx, _) = tokio::sync::broadcast::channel::<String>(1024);


### PR DESCRIPTION
Investigated the consistently-failing `broadcast_3b_maelstrom` test on macOS CI.
Root cause reconstruction from the Jepsen log timeline:

1. All 5 node processes launch at T+0; Jepsen tears down at exactly T+10s —
   Maelstrom's `db setup!` waits 10 seconds for each node to answer the `init`
   RPC, and node n0 never answered (its captured STDOUT was empty).
2. On macOS, the first execution of a freshly written binary triggers a
   Gatekeeper/XProtect (`syspolicyd`) scan that can take many seconds on loaded
   CI runners. Since each test copies the built binary to a brand-new temp file,
   every run pays this cost — multiplied across 5 concurrently launched nodes —
   and blows Maelstrom's 10s init deadline. Linux has no such scan, which is
   why this is macOS-only (and why the 1-node echo test survives).
3. During teardown Maelstrom closes the node's stdin; the node, still blocked
   in `maelstrom_init`'s `read_line`, saw EOF, failed the
   `expect("Failed to parse init message")`, and panicked (exit 101). Maelstrom
   then reported "Node n0 crashed", masking the real init-timeout error — and
   truncated the node's stderr, hiding the panic message.

Fixes:

- `MaelstromDeployment::run`: warm up the compiled binary once (stdin closed,
  exits immediately) before invoking Maelstrom, priming macOS's first-exec
  scan/dyld caches so all node launches fit within the 10s init timeout.
- `maelstrom_init`: exit cleanly (status 0) with a clear message when stdin
  reaches EOF before an init message, instead of panicking. This both makes
  the warmup invocation possible and stops teardown-induced EOF panics from
  masking the true failure as a node "crash".
- `MaelstromDeployment::run`: on failure, dump the full per-node logs from
  `store/*/node-logs/*.log` to stderr, so the real panic message (which
  Maelstrom truncates in its own exception output) is visible in CI logs.

Verified with `cargo check`/`cargo clippy` on `hydro_lang` under both the
`maelstrom` and `maelstrom_runtime` features.