### PR TITLE
feat(hydro_lang): remove unnecessary rustflags in examples and accept optional strings in `rustflags` builder APIs

### DIFF
--- a/hydro_lang/src/deploy/deploy_graph_containerized.rs
+++ b/hydro_lang/src/deploy/deploy_graph_containerized.rs
@@ -68,7 +68,7 @@ pub struct DockerDeployProcess {
 
     docker_container_name: Rc<RefCell<Option<String>>>,
 
-    compilation_options: Option<String>,
+    rustflags: Option<String>,
 
     config: Vec<String>,
 
@@ -155,7 +155,7 @@ pub struct DockerDeployCluster {
 
     docker_container_name: Rc<RefCell<Vec<String>>>,
 
-    compilation_options: Option<String>,
+    rustflags: Option<String>,
 
     config: Vec<String>,
 
@@ -629,18 +629,18 @@ async fn create_and_start_container(
 #[instrument(level = "trace", skip_all, fields(%image_name))]
 async fn build_and_create_image(
     rust_crate: &Rc<RefCell<Option<RustCrate>>>,
-    compilation_options: Option<&str>,
+    rustflags: Option<&str>,
     config: &[String],
     exposed_ports: &[u16],
     image_name: &str,
     base_image: Option<&str>,
     linux_compile_type: LinuxCompileType,
 ) -> Result<(), anyhow::Error> {
-    let mut rust_crate = rust_crate
-        .borrow_mut()
-        .take()
-        .unwrap()
-        .rustflags(compilation_options.unwrap_or_default());
+    let mut rust_crate = rust_crate.borrow_mut().take().unwrap();
+
+    if let Some(rustflags) = rustflags {
+        rust_crate = rust_crate.rustflags(rustflags);
+    }
 
     for cfg in config {
         rust_crate = rust_crate.config(cfg);
@@ -780,11 +780,11 @@ impl DockerDeploy {
     /// Add an internal docker service to the deployment.
     pub fn add_localhost_docker(
         &mut self,
-        compilation_options: Option<String>,
+        rustflags: Option<String>,
         config: Vec<String>,
     ) -> DockerDeployProcessSpec {
         let process = DockerDeployProcessSpec {
-            compilation_options,
+            rustflags,
             config,
             network: self.network.clone(),
             deployment_instance: self.deployment_instance.clone(),
@@ -801,12 +801,12 @@ impl DockerDeploy {
     /// Add an internal docker cluster to the deployment.
     pub fn add_localhost_docker_cluster(
         &mut self,
-        compilation_options: Option<String>,
+        rustflags: Option<String>,
         config: Vec<String>,
         count: usize,
     ) -> DockerDeployClusterSpec {
         let cluster = DockerDeployClusterSpec {
-            compilation_options,
+            rustflags,
             config,
             count,
             deployment_instance: self.deployment_instance.clone(),
@@ -838,7 +838,7 @@ impl DockerDeploy {
 
             build_and_create_image(
                 &process.rust_crate,
-                process.compilation_options.as_deref(),
+                process.rustflags.as_deref(),
                 &process.config,
                 &exposed_ports,
                 &process.name,
@@ -852,7 +852,7 @@ impl DockerDeploy {
             let exposed_ports = cluster.exposed_ports.borrow().clone();
             build_and_create_image(
                 &cluster.rust_crate,
-                cluster.compilation_options.as_deref(),
+                cluster.rustflags.as_deref(),
                 &cluster.config,
                 &exposed_ports,
                 &cluster.name,
@@ -1381,7 +1381,7 @@ fn get_docker_container_name(image_name: &str, instance: Option<usize>) -> Strin
 /// Represents a Process running in a docker container
 #[derive(Clone)]
 pub struct DockerDeployProcessSpec {
-    compilation_options: Option<String>,
+    rustflags: Option<String>,
     config: Vec<String>,
     network: DockerNetwork,
     deployment_instance: String,
@@ -1404,7 +1404,7 @@ impl<'a> ProcessSpec<'a, DockerDeploy> for DockerDeployProcessSpec {
 
             docker_container_name: Rc::new(RefCell::new(None)),
 
-            compilation_options: self.compilation_options,
+            rustflags: self.rustflags,
             config: self.config,
 
             network: self.network.clone(),
@@ -1419,7 +1419,7 @@ impl<'a> ProcessSpec<'a, DockerDeploy> for DockerDeployProcessSpec {
 /// Represents a Cluster running across `count` docker containers.
 #[derive(Clone)]
 pub struct DockerDeployClusterSpec {
-    compilation_options: Option<String>,
+    rustflags: Option<String>,
     config: Vec<String>,
     count: usize,
     deployment_instance: String,
@@ -1442,7 +1442,7 @@ impl<'a> ClusterSpec<'a, DockerDeploy> for DockerDeployClusterSpec {
 
             docker_container_name: Rc::new(RefCell::new(Vec::new())),
 
-            compilation_options: self.compilation_options,
+            rustflags: self.rustflags,
             config: self.config,
 
             count: self.count,

--- a/hydro_test/examples/compute_pi.rs
+++ b/hydro_test/examples/compute_pi.rs
@@ -65,12 +65,28 @@ async fn main() {
         Box::new(move |_| -> Arc<dyn Host> { localhost.clone() })
     };
 
-    let rustflags = if std::env::var("RUNNING_AS_EXAMPLE_TEST").is_ok_and(|v| v == "1") {
-        ""
+    // Since this example measures throughput, use optimized builds, except when running as an
+    // example test where skipping custom rustflags preserves the fast shared-prebuild /
+    // dynamic-linking build path.
+    let rustflags: Option<&str> = if std::env::var("RUNNING_AS_EXAMPLE_TEST")
+        .is_ok_and(|v| v == "1")
+    {
+        None
     } else if args.gcp.is_some() || args.aws {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off -C link-args=--no-rosegment"
+        Some(
+            "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off -C link-args=--no-rosegment",
+        )
     } else {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off"
+        Some("-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off")
+    };
+
+    let create_trybuild_host = |host: Arc<dyn Host>| {
+        let tbh = TrybuildHost::new(host).features(["tokio"]);
+        if let Some(rustflags) = rustflags {
+            tbh.rustflags(rustflags)
+        } else {
+            tbh
+        }
     };
 
     let mut builder = hydro_lang::compile::builder::FlowBuilder::new();
@@ -90,19 +106,10 @@ async fn main() {
 
     let _nodes = built
         .with_default_optimize()
-        .with_process(
-            &leader,
-            TrybuildHost::new(create_host(&mut deployment))
-                .rustflags(rustflags)
-                .features(["tokio"]),
-        )
+        .with_process(&leader, create_trybuild_host(create_host(&mut deployment)))
         .with_cluster(
             &cluster,
-            (0..8).map(|_| {
-                TrybuildHost::new(create_host(&mut deployment))
-                    .rustflags(rustflags)
-                    .features(["tokio"])
-            }),
+            (0..8).map(|_| create_trybuild_host(create_host(&mut deployment))),
         )
         .deploy(&mut deployment);
 

--- a/hydro_test/examples/echo.rs
+++ b/hydro_test/examples/echo.rs
@@ -66,12 +66,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Box::new(move |_| -> Arc<dyn Host> { localhost.clone() })
     };
 
-    let rustflags = if args.gcp.is_some() || args.aws {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off -C link-args=--no-rosegment"
-    } else {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off"
-    };
-
     let mut flow = hydro_lang::compile::builder::FlowBuilder::new();
 
     let process = flow.process::<()>();
@@ -97,9 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_default_optimize()
         .with_process(
             &process,
-            TrybuildHost::new(create_host(&mut deployment))
-                .rustflags(rustflags)
-                .features(["tokio"]),
+            TrybuildHost::new(create_host(&mut deployment)).features(["tokio"]),
         )
         .with_external(&external, deployment.Localhost())
         .deploy(&mut deployment);

--- a/hydro_test/examples/first_ten_distributed.rs
+++ b/hydro_test/examples/first_ten_distributed.rs
@@ -85,12 +85,6 @@ async fn main() {
         Box::new(move |_| -> Arc<dyn Host> { localhost.clone() })
     };
 
-    let rustflags = if args.gcp.is_some() || args.aws {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off -C link-args=--no-rosegment"
-    } else {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off"
-    };
-
     let mut builder = hydro_lang::compile::builder::FlowBuilder::new();
     let external = builder.external();
     let p1 = builder.process();
@@ -116,15 +110,11 @@ async fn main() {
     let nodes = optimized
         .with_process(
             &p1,
-            TrybuildHost::new(create_host(&mut deployment))
-                .rustflags(rustflags)
-                .features(["tokio"]),
+            TrybuildHost::new(create_host(&mut deployment)).features(["tokio"]),
         )
         .with_process(
             &p2,
-            TrybuildHost::new(create_host(&mut deployment))
-                .rustflags(rustflags)
-                .features(["tokio"]),
+            TrybuildHost::new(create_host(&mut deployment)).features(["tokio"]),
         )
         .with_external(&external, deployment.Localhost())
         .deploy(&mut deployment);

--- a/hydro_test/examples/http_counter.rs
+++ b/hydro_test/examples/http_counter.rs
@@ -67,12 +67,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Box::new(move |_| -> Arc<dyn Host> { localhost.clone() })
     };
 
-    let rustflags = if args.gcp.is_some() || args.aws {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off -C link-args=--no-rosegment"
-    } else {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off"
-    };
-
     let mut flow = hydro_lang::compile::builder::FlowBuilder::new();
 
     let process = flow.process::<()>();
@@ -96,9 +90,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_default_optimize()
         .with_process(
             &process,
-            TrybuildHost::new(create_host(&mut deployment))
-                .rustflags(rustflags)
-                .features(["tokio"]),
+            TrybuildHost::new(create_host(&mut deployment)).features(["tokio"]),
         )
         .with_external(&external, deployment.Localhost())
         .deploy(&mut deployment);

--- a/hydro_test/examples/http_hello.rs
+++ b/hydro_test/examples/http_hello.rs
@@ -67,12 +67,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Box::new(move |_| -> Arc<dyn Host> { localhost.clone() })
     };
 
-    let rustflags = if args.gcp.is_some() || args.aws {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off -C link-args=--no-rosegment"
-    } else {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off"
-    };
-
     let mut flow = hydro_lang::compile::builder::FlowBuilder::new();
 
     let process = flow.process::<()>();
@@ -98,9 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_default_optimize()
         .with_process(
             &process,
-            TrybuildHost::new(create_host(&mut deployment))
-                .rustflags(rustflags)
-                .features(["tokio"]),
+            TrybuildHost::new(create_host(&mut deployment)).features(["tokio"]),
         )
         .with_external(&external, deployment.Localhost())
         .deploy(&mut deployment);

--- a/hydro_test/examples/map_reduce.rs
+++ b/hydro_test/examples/map_reduce.rs
@@ -65,12 +65,6 @@ async fn main() {
         Box::new(move |_| -> Arc<dyn Host> { localhost.clone() })
     };
 
-    let rustflags = if args.gcp.is_some() || args.aws {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off -C link-args=--no-rosegment"
-    } else {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off"
-    };
-
     let mut builder = hydro_lang::compile::builder::FlowBuilder::new();
     let (leader, cluster) = hydro_test::cluster::map_reduce::map_reduce(&mut builder);
 
@@ -89,13 +83,10 @@ async fn main() {
     let optimized = built.with_default_optimize();
 
     let _nodes = optimized
-        .with_process(
-            &leader,
-            TrybuildHost::new(create_host(&mut deployment)).rustflags(rustflags),
-        )
+        .with_process(&leader, TrybuildHost::new(create_host(&mut deployment)))
         .with_cluster(
             &cluster,
-            (0..2).map(|_| TrybuildHost::new(create_host(&mut deployment)).rustflags(rustflags)),
+            (0..2).map(|_| TrybuildHost::new(create_host(&mut deployment))),
         )
         .deploy(&mut deployment);
 

--- a/hydro_test/examples/simple_cluster.rs
+++ b/hydro_test/examples/simple_cluster.rs
@@ -65,12 +65,6 @@ async fn main() {
         Box::new(move |_| -> Arc<dyn Host> { localhost.clone() })
     };
 
-    let rustflags = if args.gcp.is_some() || args.aws {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off -C link-args=--no-rosegment"
-    } else {
-        "-C opt-level=3 -C codegen-units=1 -C strip=none -C debuginfo=2 -C lto=off"
-    };
-
     let mut builder = hydro_lang::compile::builder::FlowBuilder::new();
     let (process, cluster) = hydro_test::cluster::simple_cluster::simple_cluster(&mut builder);
 
@@ -88,13 +82,10 @@ async fn main() {
 
     let _nodes = built
         .with_default_optimize()
-        .with_process(
-            &process,
-            TrybuildHost::new(create_host(&mut deployment)).rustflags(rustflags),
-        )
+        .with_process(&process, TrybuildHost::new(create_host(&mut deployment)))
         .with_cluster(
             &cluster,
-            (0..2).map(|_| TrybuildHost::new(create_host(&mut deployment)).rustflags(rustflags)),
+            (0..2).map(|_| TrybuildHost::new(create_host(&mut deployment))),
         )
         .deploy(&mut deployment);
     deployment.run_ctrl_c().await.unwrap();


### PR DESCRIPTION
The perf-oriented rustflags (`-C opt-level=3 -C codegen-units=1 -C strip=none
-C debuginfo=2 -C lto=off [-C link-args=--no-rosegment]`) exist to support
performance profiling via `.tracing(...)`, but had been cargo-culted into
functional demo examples that never enable tracing. Setting any custom
rustflags on a TrybuildHost forces static linking and bypasses the shared
prebuild/dylib machinery, making local runs and example tests much slower.

Changes:
- Remove rustflags entirely from the functional demos: http_counter,
  http_hello, echo, first_ten_distributed, simple_cluster, and map_reduce.
  Their example tests now finish in ~2-3s via the dylib fast path.
- compute_pi measures throughput, so it keeps optimized-build rustflags as
  an `Option<&str>` that is `None` under `RUNNING_AS_EXAMPLE_TEST`, applied
  via a `create_trybuild_host` closure with an `if let`. This replaces the
  previous empty-string hack, which still disabled dynamic linking because
  `Some("")` counts as custom flags.
- deploy_graph_containerized: rename `compilation_options` to `rustflags`
  throughout and use `if let` instead of `.rustflags(x.unwrap_or_default())`,
  so `None` no longer degrades into `Some("")`.
- The `rustflags` builder APIs (`TrybuildHost::rustflags`,
  `RustCrate::rustflags`) keep their original `impl Into<String>` signatures;
  an Option-accepting variant was considered but dropped per review feedback
  on PR https://github.com/hydro-project/hydro/pull/3031 in favor of plain `if`s at call sites.

Left untouched: paxos, paxos_log, perf_compute_pi (use `.tracing()`;
perf_compute_pi is embedded in the docs), two_pc, compartmentalized_paxos,
and paxos_bench (throughput benchmarks where opt-level=3 is meaningful).

Verified with `cargo check --all-features` on hydro_deploy/hydro_lang,
`cargo check -p hydro_test --examples --benches`, `cargo +nightly fmt --all`,
and the example tests for compute_pi, http_counter, echo, http_hello,
first_ten_distributed, and map_reduce.