### PR TITLE
fix(hydro_lang): attribute `sliced!` state errors to the originating `use::` statement

### DIFF
--- a/copy_span/src/lib.rs
+++ b/copy_span/src/lib.rs
@@ -26,6 +26,14 @@ impl syn::parse::Parse for CopySpanInput {
 
 fn recursively_set_span(token: &mut proc_macro2::TokenTree, span: proc_macro2::Span) {
     match token {
+        proc_macro2::TokenTree::Group(group)
+            if group.delimiter() == proc_macro2::Delimiter::None =>
+        {
+            // None-delimited groups wrap interpolated metavariable fragments (e.g. `$arg:expr`
+            // passed through a `macro_rules!` transcriber). Leave them untouched so that the
+            // fragment's original spans are preserved, both for precise error attribution
+            // within the fragment and to keep the hygiene of its tokens intact.
+        }
         proc_macro2::TokenTree::Group(group) => {
             let new_stream = group
                 .stream()
@@ -40,7 +48,10 @@ fn recursively_set_span(token: &mut proc_macro2::TokenTree, span: proc_macro2::S
             new_group.set_span(span);
             *group = new_group;
         }
-        proc_macro2::TokenTree::Ident(i) if *i == "$crate" => {
+        proc_macro2::TokenTree::Ident(_) => {
+            // Move the ident's location to the target span, but keep its original
+            // resolution context so that hygiene (e.g. for `$crate` or local variables
+            // introduced by a `macro_rules!` expansion) is preserved.
             token.set_span(span.resolved_at(token.span()));
         }
         _ => {

--- a/hydro_lang/src/live_collections/sliced/mod.rs
+++ b/hydro_lang/src/live_collections/sliced/mod.rs
@@ -86,9 +86,24 @@ macro_rules! __sliced_parse_uses__ {
                 $($use_name,)+
             ) = __sliced;
 
-            // Create all cycles and pack handles/values into tuples
+            // Create all cycles and pack handles/values into tuples.
+            //
+            // The `copy_span!` wrapper re-spans the macro-generated tokens (the style function
+            // path and the `build` call) to the user's tokens, so that errors arising from the
+            // state creation (e.g. an initializer that is not general enough over lifetimes) are
+            // attributed to the originating `use` statement instead of the entire `sliced!`
+            // invocation. The `$state_ty` and `$state_arg` fragments are passed through untouched
+            // (as interpolated fragments), preserving the precise spans of errors within the
+            // user-provided argument.
+            //
+            // Each state borrows its own clone of the tick (created inside the `copy_span!`
+            // target and spanned to the style name, e.g. `state`), so lifetime errors caused
+            // by a bad initializer point at the originating `use` statement rather than the
+            // shared `__tick` local, whose span covers the entire macro invocation.
             let (__handles, __states) = $crate::live_collections::sliced::unzip_cycles((
-                $($crate::live_collections::sliced::style::$state_style$(::<$state_ty, _>)?(& __tick, $($state_arg)?),)*
+                $($crate::macro_support::copy_span::copy_span!($state_style, {
+                    $crate::live_collections::sliced::style::$state_style$(::<$state_ty, _>)?(& __tick.clone()).build($($state_arg)?)
+                }),)*
             ));
 
             // Unpack mutable state values

--- a/hydro_lang/src/live_collections/sliced/style.rs
+++ b/hydro_lang/src/live_collections/sliced/style.rs
@@ -3,6 +3,9 @@
 //! This module provides wrapper types that store both a collection and its associated
 //! non-determinism guard, allowing the nondet to be properly passed through during slicing.
 
+#[cfg(stageleft_runtime)]
+use std::marker::PhantomData;
+
 use super::Slicable;
 #[cfg(stageleft_runtime)]
 use crate::forward_handle::{CycleCollection, CycleCollectionWithInitial};
@@ -58,45 +61,88 @@ pub fn atomic<T>(t: T, nondet: NonDet) -> Atomic<T> {
 
 /// Creates a stateful cycle with an initial value for use in `sliced!`.
 ///
+/// The tick (which is the source of truth for lifetimes) is bound first, returning a
+/// [`StateBuilder`] which accepts the user-provided initializer via [`StateBuilder::build`].
+/// This two-step layout ensures that type errors caused by a bad initializer are attributed
+/// to the initializer argument rather than the tick or the entire macro invocation.
+///
 /// The initial value is computed from a closure that receives the location
 /// for the body of the slice.
 ///
 /// The initial value is used on the first iteration, and subsequent iterations receive
 /// the value assigned to the mutable binding at the end of the previous iteration.
 #[cfg(stageleft_runtime)]
-#[expect(
-    private_bounds,
-    reason = "only Hydro collections can implement CycleCollectionWithInitial"
-)]
-pub fn state<
-    'a,
-    S: CycleCollectionWithInitial<'a, TickCycle, Location = Tick<L::DropConsistency>>,
-    L: Location<'a>,
->(
-    tick: &Tick<L>,
-    initial_fn: impl FnOnce(&Tick<L>) -> S,
-) -> (TickCycleHandle<'a, S>, S) {
-    let initial = initial_fn(tick);
-    initial.location().clone().cycle_with_initial(initial)
+pub fn state<'t, S, L>(tick: &'t Tick<L>) -> StateBuilder<'t, S, L> {
+    StateBuilder {
+        tick,
+        _phantom: PhantomData,
+    }
+}
+
+/// Builder returned by [`state`], which accepts the user-provided initializer.
+#[cfg(stageleft_runtime)]
+pub struct StateBuilder<'t, S, L> {
+    tick: &'t Tick<L>,
+    _phantom: PhantomData<fn() -> S>,
+}
+
+#[cfg(stageleft_runtime)]
+impl<'t, 'a, S, L: Location<'a>> StateBuilder<'t, S, L> {
+    /// Supplies the initializer closure and creates the stateful cycle.
+    ///
+    /// The initializer takes the tick at the builder's `'t` lifetime (rather than a
+    /// higher-ranked `for<'x>` bound), since the builder already stores the tick reference.
+    /// This way, an initializer that requires a specific tick reference lifetime produces a
+    /// borrow error directly on the tick, instead of a confusing "implementation of `Fn` is
+    /// not general enough" error that blames an unrelated variable.
+    #[expect(
+        private_bounds,
+        reason = "only Hydro collections can implement CycleCollectionWithInitial"
+    )]
+    pub fn build(self, initial_fn: impl FnOnce(&'t Tick<L>) -> S) -> (TickCycleHandle<'a, S>, S)
+    where
+        S: CycleCollectionWithInitial<'a, TickCycle, Location = Tick<L::DropConsistency>>,
+    {
+        let initial = initial_fn(self.tick);
+        initial.location().clone().cycle_with_initial(initial)
+    }
 }
 
 /// Creates a stateful cycle without an initial value for use in `sliced!`.
 ///
+/// The tick (which is the source of truth for lifetimes) is bound first, returning a
+/// [`StateNullBuilder`] which creates the cycle via [`StateNullBuilder::build`].
+///
 /// On the first iteration, the state will be null/empty. Subsequent iterations receive
 /// the value assigned to the mutable binding at the end of the previous iteration.
 #[cfg(stageleft_runtime)]
-#[expect(
-    private_bounds,
-    reason = "only Hydro collections can implement CycleCollection"
-)]
-pub fn state_null<
-    'a,
-    S: CycleCollection<'a, TickCycle, Location = Tick<L::DropConsistency>> + DeferTick,
-    L: Location<'a>,
->(
-    tick: &Tick<L>,
-) -> (TickCycleHandle<'a, S>, S) {
-    tick.cycle::<S, _>()
+pub fn state_null<'t, S, L>(tick: &'t Tick<L>) -> StateNullBuilder<'t, S, L> {
+    StateNullBuilder {
+        tick,
+        _phantom: PhantomData,
+    }
+}
+
+/// Builder returned by [`state_null`], which creates the cycle.
+#[cfg(stageleft_runtime)]
+pub struct StateNullBuilder<'t, S, L> {
+    tick: &'t Tick<L>,
+    _phantom: PhantomData<fn() -> S>,
+}
+
+#[cfg(stageleft_runtime)]
+impl<'t, 'a, S, L: Location<'a>> StateNullBuilder<'t, S, L> {
+    /// Creates the stateful cycle, which starts as null/empty on the first iteration.
+    #[expect(
+        private_bounds,
+        reason = "only Hydro collections can implement CycleCollection"
+    )]
+    pub fn build(self) -> (TickCycleHandle<'a, S>, S)
+    where
+        S: CycleCollection<'a, TickCycle, Location = Tick<L::DropConsistency>> + DeferTick,
+    {
+        self.tick.cycle::<S, _>()
+    }
 }
 
 // ============================================================================

--- a/hydro_lang/tests/compile-fail/nightly/sliced_missing_arg.stderr
+++ b/hydro_lang/tests/compile-fail/nightly/sliced_missing_arg.stderr
@@ -28,12 +28,7 @@ note: function defined here
    |
    | pub fn default<T>(t: T, nondet: NonDet) -> Default<T> {
    |        ^^^^^^^
-help: provide the argument
-  --> src/live_collections/sliced/mod.rs
-   |
-   -             @uses [$($uses)* { $name, $crate::macro_support::copy_span::copy_span!($($args,)* default)($($args),*), $($args),* }]
-   +             @uses [$($uses)* { $name, (input, /* NonDet */), $($args),* }]
-   |
+   = note: this error originates in the macro `$crate::__sliced_parse_uses__` which comes from the expansion of the macro `sliced` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> tests/compile-fail/nightly/sliced_missing_arg.rs:10:22

--- a/hydro_lang/tests/compile-fail/nightly/sliced_state_bad_initializer.stderr
+++ b/hydro_lang/tests/compile-fail/nightly/sliced_state_bad_initializer.stderr
@@ -1,0 +1,26 @@
+error[E0716]: temporary value dropped while borrowed
+  --> tests/compile-fail/nightly/sliced_state_bad_initializer.rs:30:28
+   |
+21 | fn test<'a>(input: Stream<u32, Process<'a, P1>>) {
+   |         -- lifetime `'a` defined here
+22 |     let clock = Clock {
+23 |         initializer: |l: &Tick<Process<'a, P1>>| l.singleton(q!(0)),
+   |                      ---------------------------------------------- this usage requires that borrow lasts for `'a`
+...
+30 |         let mut bad = use::state(&clock.initializer);
+   |                            ^^^^-
+   |                            |   |
+   |                            |   temporary value is freed at the end of this statement
+   |                            creates a temporary value which is freed while still in use
+   |
+note: requirements that the value outlives `'a` introduced here
+  --> tests/compile-fail/nightly/sliced_state_bad_initializer.rs:15:18
+   |
+15 |     Initializer: Fn(&'a Tick<Process<'a, Tag>>) -> Singleton<u32, Tick<Process<'a, Tag>>, Bounded>,
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+  ::: src/live_collections/sliced/style.rs
+   |
+   |     pub fn build(self, initial_fn: impl FnOnce(&'t Tick<L>) -> S) -> (TickCycleHandle<'a, S>, S)
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `$crate::__sliced_parse_uses__` which comes from the expansion of the macro `sliced` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/hydro_lang/tests/compile-fail/nightly/sliced_state_error_in_initializer.stderr
+++ b/hydro_lang/tests/compile-fail/nightly/sliced_state_error_in_initializer.stderr
@@ -1,0 +1,7 @@
+error[E0308]: mismatched types
+  --> tests/compile-fail/nightly/sliced_state_error_in_initializer.rs:14:26
+   |
+14 |             let x: u32 = "not a number";
+   |                    ---   ^^^^^^^^^^^^^^ expected `u32`, found `&str`
+   |                    |
+   |                    expected due to this

--- a/hydro_lang/tests/compile-fail/sliced_state_bad_initializer.rs
+++ b/hydro_lang/tests/compile-fail/sliced_state_bad_initializer.rs
@@ -1,0 +1,36 @@
+#![allow(unexpected_cfgs)]
+
+use std::marker::PhantomData;
+
+use hydro_lang::prelude::*;
+
+struct P1 {}
+
+struct Clock<'a, Initializer, Tag>
+where
+    Tag: 'a,
+    // The signature here should be `Fn(&Tick<...>)` (generic over the reference lifetime),
+    // not `Fn(&'a Tick<...>)`. This mistake causes the initializer to only implement `Fn`
+    // for one specific lifetime, which is incompatible with `use::state`.
+    Initializer: Fn(&'a Tick<Process<'a, Tag>>) -> Singleton<u32, Tick<Process<'a, Tag>>, Bounded>,
+{
+    initializer: Initializer,
+    _phantom: PhantomData<&'a Tag>,
+}
+
+fn test<'a>(input: Stream<u32, Process<'a, P1>>) {
+    let clock = Clock {
+        initializer: |l: &Tick<Process<'a, P1>>| l.singleton(q!(0)),
+        _phantom: PhantomData,
+    };
+
+    sliced! {
+        let s = use(input, nondet!(/** test */));
+
+        let mut bad = use::state(&clock.initializer);
+
+        s
+    };
+}
+
+fn main() {}

--- a/hydro_lang/tests/compile-fail/sliced_state_error_in_initializer.rs
+++ b/hydro_lang/tests/compile-fail/sliced_state_error_in_initializer.rs
@@ -1,0 +1,23 @@
+#![allow(unexpected_cfgs)]
+
+use hydro_lang::prelude::*;
+
+struct P1 {}
+
+fn test<'a>(input: Stream<u32, Process<'a, P1>>) {
+    sliced! {
+        let s = use(input, nondet!(/** test */));
+
+        // The error inside the initializer body should be attributed to the exact
+        // expression that caused it, not the entire `sliced!` block.
+        let mut bad = use::state(|l: &Tick<Process<'a, P1>>| {
+            let x: u32 = "not a number";
+            l.singleton(q!(x))
+        });
+
+        bad = bad.clone();
+        s
+    };
+}
+
+fn main() {}

--- a/hydro_lang/tests/compile-fail/stable/sliced_missing_arg.stderr
+++ b/hydro_lang/tests/compile-fail/stable/sliced_missing_arg.stderr
@@ -28,12 +28,7 @@ note: function defined here
    |
    | pub fn default<T>(t: T, nondet: NonDet) -> Default<T> {
    |        ^^^^^^^
-help: provide the argument
-  --> src/live_collections/sliced/mod.rs
-   |
-   -             @uses [$($uses)* { $name, $crate::macro_support::copy_span::copy_span!($($args,)* default)($($args),*), $($args),* }]
-   +             @uses [$($uses)* { $name, (input, /* NonDet */), $($args),* }]
-   |
+   = note: this error originates in the macro `$crate::__sliced_parse_uses__` which comes from the expansion of the macro `sliced` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> tests/compile-fail/stable/sliced_missing_arg.rs:10:22

--- a/hydro_lang/tests/compile-fail/stable/sliced_state_bad_initializer.stderr
+++ b/hydro_lang/tests/compile-fail/stable/sliced_state_bad_initializer.stderr
@@ -1,0 +1,26 @@
+error[E0716]: temporary value dropped while borrowed
+  --> tests/compile-fail/stable/sliced_state_bad_initializer.rs:30:28
+   |
+21 | fn test<'a>(input: Stream<u32, Process<'a, P1>>) {
+   |         -- lifetime `'a` defined here
+22 |     let clock = Clock {
+23 |         initializer: |l: &Tick<Process<'a, P1>>| l.singleton(q!(0)),
+   |                      ---------------------------------------------- this usage requires that borrow lasts for `'a`
+...
+30 |         let mut bad = use::state(&clock.initializer);
+   |                            ^^^^-
+   |                            |   |
+   |                            |   temporary value is freed at the end of this statement
+   |                            creates a temporary value which is freed while still in use
+   |
+note: requirements that the value outlives `'a` introduced here
+  --> tests/compile-fail/stable/sliced_state_bad_initializer.rs:15:18
+   |
+15 |     Initializer: Fn(&'a Tick<Process<'a, Tag>>) -> Singleton<u32, Tick<Process<'a, Tag>>, Bounded>,
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+  ::: src/live_collections/sliced/style.rs
+   |
+   |     pub fn build(self, initial_fn: impl FnOnce(&'t Tick<L>) -> S) -> (TickCycleHandle<'a, S>, S)
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `$crate::__sliced_parse_uses__` which comes from the expansion of the macro `sliced` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/hydro_lang/tests/compile-fail/stable/sliced_state_error_in_initializer.stderr
+++ b/hydro_lang/tests/compile-fail/stable/sliced_state_error_in_initializer.stderr
@@ -1,0 +1,7 @@
+error[E0308]: mismatched types
+  --> tests/compile-fail/stable/sliced_state_error_in_initializer.rs:14:26
+   |
+14 |             let x: u32 = "not a number";
+   |                    ---   ^^^^^^^^^^^^^^ expected `u32`, found `&str`
+   |                    |
+   |                    expected due to this


### PR DESCRIPTION
Fixes #3032. Previously, when a bad state initializer was passed to
`use::state(...)` inside `sliced!` (e.g. a closure that is not general enough
over the tick reference lifetime), the resulting errors ("implementation of
`Fn` is not general enough", E0521, etc.) were attributed to the entire
`sliced!` macro invocation, making it very hard to find the offending line.

Three coordinated changes fix the attribution:

- `copy_span`: preserve hygiene and fragment spans while re-spanning.
  - Skip None-delimited (invisible) groups, which wrap interpolated
    metavariable fragments (e.g. `$arg:expr` passed through a `macro_rules!`
    transcriber), so the user-written tokens inside a fragment keep their
    precise spans.
  - For idents, move only the span *location* while keeping the original
    *resolution context* (`resolved_at`), so hygienic locals like `__tick` and
    `$crate` (previously a special case, now subsumed) still resolve correctly.

- `sliced::style`: restructure `state` / `state_null` into tick-first builders.
  Each style function now takes only the tick (the source of truth for
  lifetimes) and returns a style-specific builder (`StateBuilder` /
  `StateNullBuilder`) whose `build(...)` method accepts the remaining
  user-provided arguments. This separates the tick binding from the user
  argument so diagnostics involve only the initializer, and preserves turbofish
  compatibility (`use::state_null::<Type>()`).

- `sliced`: in the `__sliced_parse_uses__` terminal case, wrap the builder
  invocation in `copy_span!`, re-spanning the macro-generated tokens (style
  path, `build` call) to the user's `use::` statement tokens while `$state_ty`
  / `$state_arg` pass through as interpolated fragments.

With this, on both stable and nightly:
- a non-general initializer produces errors pointing at
  `use::state(&clock.initializer)` (at the argument), and
- errors *inside* the initializer body keep their exact spans.

As a bonus, the `resolved_at` change also removed a confusing "help: provide
the argument" suggestion in sliced_missing_arg.stderr that previously pointed
into hydro_lang's macro source code.

Adds two compile-fail tests (with stable + nightly stderr snapshots):
- sliced_state_bad_initializer.rs: reproduces issue #3032 (initializer only
  implements `Fn` for a specific lifetime).
- sliced_state_error_in_initializer.rs: verifies spans within the initializer
  argument are preserved, not overwritten.

Verified: hydro_lang/hydro_std/hydro_test all-features check, sliced sim tests,
compile-fail suites on stable and nightly (three unrelated nightly stderr files
have pre-existing drift with newer nightlies: "33 more" vs "32 more" cfg names),
and clippy.