### PR TITLE
refactor(hydro_lang): simplify state builder phantoms to `PhantomData<S>`

### DIFF
--- a/hydro_lang/src/live_collections/sliced/style.rs
+++ b/hydro_lang/src/live_collections/sliced/style.rs
@@ -83,7 +83,7 @@ pub fn state<'t, S, L>(tick: &'t Tick<L>) -> StateBuilder<'t, S, L> {
 #[cfg(stageleft_runtime)]
 pub struct StateBuilder<'t, S, L> {
     tick: &'t Tick<L>,
-    _phantom: PhantomData<fn() -> S>,
+    _phantom: PhantomData<S>,
 }
 
 #[cfg(stageleft_runtime)]
@@ -127,7 +127,7 @@ pub fn state_null<'t, S, L>(tick: &'t Tick<L>) -> StateNullBuilder<'t, S, L> {
 #[cfg(stageleft_runtime)]
 pub struct StateNullBuilder<'t, S, L> {
     tick: &'t Tick<L>,
-    _phantom: PhantomData<fn() -> S>,
+    _phantom: PhantomData<S>,
 }
 
 #[cfg(stageleft_runtime)]


### PR DESCRIPTION
Replace `PhantomData<fn() -> S>` with plain `PhantomData<S>` in
`StateBuilder` and `StateNullBuilder` in `sliced/style.rs`.

The `fn() -> S` wrapper only decouples auto traits (`Send`/`Sync`) and
drop-check from `S`, but the builders are constructed and immediately
consumed by `.build()` inside the `sliced!` macro expansion, so that
decoupling is never observable. Variance is identical (covariant in `S`
either way), so the simpler form has no semantic effect.

Verified with `cargo check` on hydro_lang (all features), hydro_std, and
hydro_test, plus the trybuild compile-fail suite (including the
sliced-state initializer error-span tests).