### PR TITLE
feat(hydro_lang): add `UDP` network transport with lossy-only fault policies

### DIFF
--- a/docs/docs/hydro/reference/locations/network-configuration.md
+++ b/docs/docs/hydro/reference/locations/network-configuration.md
@@ -38,7 +38,7 @@ The `.bincode()` API configures the channel to use the [`bincode`](https://docs.
 
 ## TCP
 
-TCP is currently the only transport backend. When using `TCP`, you **must** choose a fault tolerance policy before configuring serialization. Calling `TCP.bincode()` directly will result in a compile error—you need to first call `.fail_stop()`, `.lossy_delayed_forever()`, or `.lossy()`.
+TCP is one of two available transport backends (see also [UDP](#udp)). When using `TCP`, you **must** choose a fault tolerance policy before configuring serialization. Calling `TCP.bincode()` directly will result in a compile error—you need to first call `.fail_stop()`, `.lossy_delayed_forever()`, or `.lossy()`.
 
 ### Fail-Stop
 
@@ -80,13 +80,13 @@ When using `lossy_delayed_forever` in the Hydro simulator, you must call `.test_
 flow.sim().test_safety_only().exhaustive(async || { /* ... */ });
 ```
 
-This is required because the simulator models dropped messages as delayed to after the undropped messages, which only tests **safety** (race-condition) properties (not **liveness**). A message that is "delayed forever" may never arrive, so the simulator cannot guarantee that your program will eventually make progress—only that it won't produce incorrect results.
+This is required because the simulator will not actually drop packets—instead, it delays "dropped" messages until the end of the execution. This catches **safety** bugs (such as race conditions where a message arrives later than expected), but cannot test **liveness**: a message that is "delayed forever" may never arrive in a real deployment, so the simulator cannot guarantee that your program will eventually make progress—only that it won't produce incorrect results.
 
 :::
 
 :::caution
 
-The `lossy_delayed_forever` fault model is currently only available for the Hydro simulator and Maelstrom testing. Support in Hydro Deploy will be available once TCP reconnect is implemented.
+The `lossy_delayed_forever` fault model is currently available for [embedded deployments](../deploy/embedded.mdx) (the only production deployment option), Maelstrom testing, and the Hydro simulator (with `.test_safety_only()`). Support in Hydro Deploy will be available once TCP reconnect is implemented.
 
 :::
 
@@ -109,10 +109,46 @@ In most cases, prefer [`lossy_delayed_forever`](#lossy-delayed-forever) over `lo
 
 :::caution
 
-The `lossy` fault model is currently only available for [embedded deployments](../deploy/embedded.mdx) and Maelstrom testing. Support in Hydro Deploy will be available in the near future.
+The `lossy` fault model is currently available for [embedded deployments](../deploy/embedded.mdx) (the only production deployment option) and Maelstrom testing. It is **not supported in the Hydro simulator**—use `lossy_delayed_forever` if you want to simulate message loss. Support in Hydro Deploy will be available in the near future.
 
 :::
 
 This is appropriate for protocols that are designed to tolerate message loss, such as gossip protocols or systems running under network partition testing (e.g. [Maelstrom](https://github.com/jepsen-io/maelstrom)).
 
 Because message loss is non-deterministic, `lossy` requires a `nondet!` marker to make this explicit in your code. You should document why your protocol is correct despite potential message loss.
+
+## UDP
+
+UDP is a connectionless transport that guarantees **neither delivery nor ordering**. Output streams from a UDP channel always have a [`NoOrder`](rust:hydro_lang::live_collections::stream::NoOrder) guarantee, imposing stricter conditions on downstream consumers (e.g. you cannot use order-dependent operators like `fold` without proving commutativity).
+
+Like `TCP`, you **must** choose a fault tolerance policy before configuring serialization. Because UDP is connectionless, there is no connection that can fail, so there is **no `fail_stop` policy**—only `.lossy_delayed_forever()` and `.lossy()` are available.
+
+### Lossy Delayed Forever
+
+```rust,no_run
+# use hydro_lang::prelude::*;
+let config = UDP.lossy_delayed_forever().bincode();
+```
+
+With `lossy_delayed_forever`, dropped messages are modeled as being **indefinitely delayed** rather than lost. Like the TCP mode of the same name, this does **not** require a `nondet!` annotation because the output stream is unordered, so even if messages are lost the output will have a subset of the intended elements.
+
+This is the **preferred** UDP mode, for the same reasons as [TCP's `lossy_delayed_forever`](#lossy-delayed-forever): it does not require `nondet!` and can be simulated in exhaustive mode (with `.test_safety_only()`).
+
+### Lossy
+
+```rust,no_run
+# use hydro_lang::prelude::*;
+let config = UDP.lossy(nondet!(/** messages may be dropped, explanation... */)).bincode();
+```
+
+With `lossy`, messages may be **arbitrarily dropped and reordered**. Because message loss is non-deterministic, this requires a `nondet!` marker to make it explicit in your code.
+
+Unlike TCP's `lossy` mode, UDP's `lossy` mode does **not** preserve the ordering of the input stream—the output is always `NoOrder`.
+
+:::caution
+
+UDP is **not yet available** in "deploy" deployment mode (via Hydro Deploy, including Docker and ECS deployments)—attempting to deploy a UDP channel there will panic at compile time.
+
+Both UDP modes are available for [embedded deployments](../deploy/embedded.mdx) (the only production deployment option) and Maelstrom testing. In the Hydro simulator, only `lossy_delayed_forever` is supported, and it requires `.test_safety_only()`: the simulator will not actually drop packets—it delays "dropped" messages until the end of the execution, which catches safety bugs but cannot test liveness.
+
+:::

--- a/hydro_lang/src/deploy/maelstrom/deploy_maelstrom.rs
+++ b/hydro_lang/src/deploy/maelstrom/deploy_maelstrom.rs
@@ -135,6 +135,7 @@ impl<'a> Deploy<'a> for MaelstromDeploy {
                 }
                 (TcpFault::FailStop, Some(_)) => {} // other nemeses are fine with fail_stop
             },
+            NetworkingInfo::Udp { .. } => {} // UDP is always lossy, which is always allowed
         }
         deploy_maelstrom_m2m(RuntimeData::new("__hydro_lang_maelstrom_meta"))
     }

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -60,7 +60,7 @@ pub mod prelude {
     pub use crate::live_collections::sliced::sliced;
     pub use crate::live_collections::stream::Stream;
     pub use crate::location::{Cluster, External, Location as _, Process, Tick};
-    pub use crate::networking::TCP;
+    pub use crate::networking::{TCP, UDP};
     pub use crate::nondet::{NonDet, nondet};
     pub use crate::properties::{ConsistencyProof, ManualProof, manual_proof};
 

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -1754,6 +1754,61 @@ mod tests {
 
     #[cfg(feature = "sim")]
     #[test]
+    fn sim_udp_lossy_delayed_forever_o2o() {
+        use std::collections::HashSet;
+
+        use crate::networking::UDP;
+        use crate::properties::manual_proof;
+
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<()>();
+        let node2 = flow.process::<()>();
+
+        let received = node
+            .source_iter(q!(0..3_u32))
+            .send(&node2, UDP.lossy_delayed_forever().bincode())
+            .fold(
+                q!(|| std::collections::HashSet::<u32>::new()),
+                q!(
+                    |set, v| {
+                        set.insert(v);
+                    },
+                    commutative = manual_proof!(/** set insert is commutative */)
+                ),
+            );
+
+        let out_recv = sliced! {
+            let snapshot = use(received, nondet!(/** test */));
+            snapshot.into_stream()
+        }
+        .sim_output();
+
+        let mut saw_non_contiguous = false;
+
+        flow.sim().test_safety_only().exhaustive(async || {
+            let snapshots = out_recv.collect::<Vec<HashSet<u32>>>().await;
+
+            // Check each individual snapshot for a non-contiguous subset.
+            for set in &snapshots {
+                #[expect(clippy::disallowed_methods, reason = "min / max are deterministic")]
+                if set.len() >= 2 && set.len() < 3 {
+                    let min = *set.iter().min().unwrap();
+                    let max = *set.iter().max().unwrap();
+                    if set.len() < (max - min + 1) as usize {
+                        saw_non_contiguous = true;
+                    }
+                }
+            }
+        });
+
+        assert!(
+            saw_non_contiguous,
+            "Expected at least one execution with a non-contiguous subset of inputs"
+        );
+    }
+
+    #[cfg(feature = "sim")]
+    #[test]
     fn sim_broadcast_closed_o2m() {
         let mut flow = FlowBuilder::new();
         let cluster = flow.cluster::<()>();

--- a/hydro_lang/src/networking/mod.rs
+++ b/hydro_lang/src/networking/mod.rs
@@ -98,7 +98,7 @@ impl TcpFailPolicy for FailStop {
     }
 }
 
-/// A TCP failure policy that allows messages to be lost.
+/// A failure policy that allows messages to be lost.
 pub enum Lossy {}
 #[sealed::sealed]
 impl TcpFailPolicy for Lossy {
@@ -109,7 +109,7 @@ impl TcpFailPolicy for Lossy {
     }
 }
 
-/// A TCP failure policy that treats dropped messages as indefinitely delayed.
+/// A failure policy that treats dropped messages as indefinitely delayed.
 ///
 /// Unlike [`Lossy`], this does not require a [`NonDet`] annotation because the output
 /// stream is always lower in the partial order than the ideal stream (dropped messages
@@ -117,9 +117,9 @@ impl TcpFailPolicy for Lossy {
 /// guarantees, imposing stricter conditions on downstream consumers.
 ///
 /// When using this mode in the Hydro simulator, you must call
-/// [`.test_safety_only()`](crate::sim::flow::SimFlow::test_safety_only) because the
-/// simulator models dropped messages as indefinitely delayed, which only tests safety
-/// properties (not liveness).
+/// [`.test_safety_only()`](crate::sim::flow::SimFlow::test_safety_only): the simulator
+/// will not actually drop packets—it delays "dropped" messages until the end of the
+/// execution, which catches safety bugs but cannot test liveness.
 pub enum LossyDelayedForever {}
 #[sealed::sealed]
 impl TcpFailPolicy for LossyDelayedForever {
@@ -127,6 +127,33 @@ impl TcpFailPolicy for LossyDelayedForever {
 
     fn tcp_fault() -> TcpFault {
         TcpFault::LossyDelayedForever
+    }
+}
+
+#[sealed::sealed]
+#[diagnostic::on_unimplemented(
+    message = "UDP transport requires a failure policy. For example, `UDP.lossy_delayed_forever()` treats dropped messages as indefinitely delayed."
+)]
+/// A failure policy for UDP channels, determining how the transport handles
+/// message loss. Because UDP provides no ordering guarantees, all policies
+/// produce [`NoOrder`] output streams, and there is no `fail_stop` option
+/// (UDP is connectionless, so there is no connection to fail).
+pub trait UdpFailPolicy {
+    /// Returns the [`UdpFault`] variant for this failure policy.
+    fn udp_fault() -> UdpFault;
+}
+
+#[sealed::sealed]
+impl UdpFailPolicy for Lossy {
+    fn udp_fault() -> UdpFault {
+        UdpFault::Lossy
+    }
+}
+
+#[sealed::sealed]
+impl UdpFailPolicy for LossyDelayedForever {
+    fn udp_fault() -> UdpFault {
+        UdpFault::LossyDelayedForever
     }
 }
 
@@ -142,6 +169,22 @@ impl<F: TcpFailPolicy> TransportKind for Tcp<F> {
     fn networking_info() -> NetworkingInfo {
         NetworkingInfo::Tcp {
             fault: F::tcp_fault(),
+        }
+    }
+}
+
+/// Send items across a UDP channel, which does not guarantee delivery or ordering.
+pub struct Udp<F> {
+    _phantom: PhantomData<F>,
+}
+
+#[sealed::sealed]
+impl<F: UdpFailPolicy> TransportKind for Udp<F> {
+    type OrderingGuarantee = NoOrder;
+
+    fn networking_info() -> NetworkingInfo {
+        NetworkingInfo::Udp {
+            fault: F::udp_fault(),
         }
     }
 }
@@ -185,6 +228,18 @@ pub enum TcpFault {
     LossyDelayedForever,
 }
 
+/// The fault model for a UDP channel.
+///
+/// UDP is connectionless and never guarantees delivery, so there is no
+/// `FailStop` variant — messages can always be dropped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
+pub enum UdpFault {
+    /// Messages may be lost (e.g. due to network partitions or congestion).
+    Lossy,
+    /// Dropped messages are treated as indefinitely delayed.
+    LossyDelayedForever,
+}
+
 /// Describes the networking configuration for a network channel at the IR level.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]
 pub enum NetworkingInfo {
@@ -192,6 +247,11 @@ pub enum NetworkingInfo {
     Tcp {
         /// The fault model for this TCP connection.
         fault: TcpFault,
+    },
+    /// A UDP-based network channel with a specific fault model.
+    Udp {
+        /// The fault model for this UDP channel.
+        fault: UdpFault,
     },
 }
 
@@ -282,10 +342,50 @@ impl<S: ?Sized> NetworkingConfig<Tcp<()>, S> {
     /// without running into fairness issues.
     ///
     /// When using this mode in the Hydro simulator, you must call
-    /// [`.test_safety_only()`](crate::sim::flow::SimFlow::test_safety_only) to opt in,
-    /// because the simulator models dropped messages as indefinitely delayed, which only
-    /// tests safety properties (not liveness).
+    /// [`.test_safety_only()`](crate::sim::flow::SimFlow::test_safety_only) to opt in:
+    /// the simulator will not actually drop packets—it delays "dropped" messages until
+    /// the end of the execution, which catches safety bugs but cannot test liveness.
     pub const fn lossy_delayed_forever(self) -> NetworkingConfig<Tcp<LossyDelayedForever>, S> {
+        NetworkingConfig {
+            name: self.name,
+            _phantom: (PhantomData, PhantomData),
+        }
+    }
+}
+
+impl<S: ?Sized> NetworkingConfig<Udp<()>, S> {
+    /// Configures the UDP transport to allow messages to be lost.
+    ///
+    /// UDP never guarantees delivery or ordering, so unlike TCP there is no `fail_stop`
+    /// policy — messages may always be dropped and the output stream always has
+    /// [`NoOrder`] guarantees.
+    ///
+    /// # Non-Determinism
+    /// A lossy UDP channel will non-deterministically drop messages during execution.
+    pub const fn lossy(self, nondet: NonDet) -> NetworkingConfig<Udp<Lossy>, S> {
+        let _ = nondet;
+        NetworkingConfig {
+            name: self.name,
+            _phantom: (PhantomData, PhantomData),
+        }
+    }
+
+    /// Configures the UDP transport to treat dropped messages as indefinitely delayed.
+    ///
+    /// UDP never guarantees delivery or ordering, so unlike TCP there is no `fail_stop`
+    /// policy. Unlike [`Self::lossy`], this does *not* require a [`NonDet`] annotation
+    /// because the output is always lower in the partial order than the ideal stream
+    /// (dropped messages are modeled as infinite delays). The output stream has
+    /// [`NoOrder`] guarantees, imposing stricter conditions on downstream consumers.
+    ///
+    /// Unlike [`Self::lossy`], this mode can easily be simulated in exhaustive mode
+    /// without running into fairness issues.
+    ///
+    /// When using this mode in the Hydro simulator, you must call
+    /// [`.test_safety_only()`](crate::sim::flow::SimFlow::test_safety_only) to opt in:
+    /// the simulator will not actually drop packets—it delays "dropped" messages until
+    /// the end of the execution, which catches safety bugs but cannot test liveness.
+    pub const fn lossy_delayed_forever(self) -> NetworkingConfig<Udp<LossyDelayedForever>, S> {
         NetworkingConfig {
             name: self.name,
             _phantom: (PhantomData, PhantomData),
@@ -353,6 +453,27 @@ where
 
 /// A network channel that uses length-delimited TCP for transport.
 pub const TCP: NetworkingConfig<Tcp<()>, NoSer> = NetworkingConfig {
+    name: None,
+    _phantom: (PhantomData, PhantomData),
+};
+
+/// A network channel that uses UDP for transport.
+///
+/// Unlike [`TCP`], UDP does not guarantee delivery or ordering, so output streams
+/// always have [`NoOrder`] guarantees. Because UDP is connectionless, there is no
+/// `fail_stop` policy; only [`lossy`](NetworkingConfig::lossy) and
+/// [`lossy_delayed_forever`](NetworkingConfig::lossy_delayed_forever) are available.
+///
+/// # Availability
+/// UDP is **not yet available** in "deploy" deployment mode (via Hydro Deploy,
+/// including Docker and ECS deployments); attempting to deploy a UDP channel there
+/// will panic at compile time. Both UDP modes are available for embedded
+/// deployments (the only production deployment option) and Maelstrom testing. In
+/// the Hydro simulator, only `lossy_delayed_forever` is supported, and it requires
+/// [`.test_safety_only()`](crate::sim::flow::SimFlow::test_safety_only): the
+/// simulator will not actually drop packets—it delays "dropped" messages until the
+/// end of the execution, which catches safety bugs but cannot test liveness.
+pub const UDP: NetworkingConfig<Udp<()>, NoSer> = NetworkingConfig {
     name: None,
     _phantom: (PhantomData, PhantomData),
 };

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -1429,7 +1429,7 @@ impl DfirBuilder for SimBuilder {
         tag_id: StmtId,
         networking_info: &crate::networking::NetworkingInfo,
     ) {
-        use crate::networking::{NetworkingInfo, TcpFault};
+        use crate::networking::{NetworkingInfo, TcpFault, UdpFault};
         match networking_info {
             NetworkingInfo::Tcp { fault } => match fault {
                 TcpFault::FailStop => {}
@@ -1445,6 +1445,18 @@ impl DfirBuilder for SimBuilder {
                 _ => todo!(
                     "SimBuilder only supports fail-stop and lossy-delayed-forever TCP networking"
                 ),
+            },
+            NetworkingInfo::Udp { fault } => match fault {
+                UdpFault::LossyDelayedForever => {
+                    assert!(
+                        self.test_safety_only,
+                        "Simulating `lossy_delayed_forever` requires `.test_safety_only()` on the \
+                         SimFlow because the simulator models dropped messages as indefinitely \
+                         delayed, which only tests safety (not liveness). Call \
+                         `.sim().test_safety_only()` to opt in."
+                    );
+                }
+                _ => todo!("SimBuilder only supports lossy-delayed-forever UDP networking"),
             },
         }
 


### PR DESCRIPTION
Adds a `UDP` networking option alongside the existing `TCP` transport. UDP is
connectionless and guarantees neither delivery nor ordering, so:

- Output streams always have `NoOrder` guarantees (the `Udp<F>`
  `TransportKind` impl fixes `OrderingGuarantee = NoOrder` regardless of
  policy, unlike TCP where `fail_stop`/`lossy` preserve `TotalOrder`).
- Only `lossy(nondet!(...))` and `lossy_delayed_forever()` fault policies are
  offered; there is no `fail_stop` since there is no connection to fail.
  Attempting `UDP.bincode()` without a policy produces a tailored
  `on_unimplemented` diagnostic, mirroring TCP's behavior.

Details:

- `networking/mod.rs`:
  - New sealed `UdpFailPolicy` trait, implemented for the existing `Lossy`
    and `LossyDelayedForever` marker types (docs generalized from "TCP
    failure policy" to "failure policy").
  - New `Udp<F>` transport struct, `UdpFault` IR enum, and
    `NetworkingInfo::Udp { fault }` variant.
  - `NetworkingConfig<Udp<()>, S>` builder methods `lossy` /
    `lossy_delayed_forever`, and the `UDP` const entry point, exported in the
    prelude next to `TCP`.
- `sim/builder.rs`: simulator accepts `UdpFault::LossyDelayedForever`
  (requires `.test_safety_only()`, same as the TCP equivalent);
  `UdpFault::Lossy` is unsupported in sim like TCP's lossy.
- `deploy/maelstrom/deploy_maelstrom.rs`: UDP channels are always allowed
  under any nemesis since they are inherently lossy.
- Deploy backends (hydro_deploy / containerized / ECS) reject UDP channels
  via their existing wildcard panic arms, consistent with lossy TCP.
- Added sim test `sim_udp_lossy_delayed_forever_o2o` verifying UDP drops
  messages non-contiguously (unordered subset semantics).
- Docs (`network-configuration.md` + rustdoc): new UDP section, plus accurate
  availability cautions for both transports: `lossy` and
  `lossy_delayed_forever` are available in embedded deployments (the only
  production deployment option) and Maelstrom; the simulator supports only
  `lossy_delayed_forever`, which requires `.test_safety_only()` because the
  simulator does not actually drop packets—it delays "dropped" messages until
  the end of the execution, catching safety bugs but not testing liveness.
  UDP additionally is not yet available in "deploy" deployment mode (Hydro
  Deploy / Docker / ECS) and panics at compile time there.

Verified with `cargo check`/`clippy`/`doc` (features sim,deploy) and the new
sim test passing.