### PR TITLE
fix(dfir_rs): eliminate race-induced hangs in kvs, kvs_mut, and chat_dfir example tests

### DIFF
--- a/dfir_rs/examples/chat_dfir/client.rs
+++ b/dfir_rs/examples/chat_dfir/client.rs
@@ -54,7 +54,10 @@ pub(crate) async fn run_client(opts: Opts) {
                     message: l.unwrap(),
                     ts: Utc::now()})
           -> [input]msg_send;
-        inbound_chan[ConnectResponse] -> persist::<'static>() -> [signal]msg_send;
+        inbound_chan[ConnectResponse]
+            -> inspect(|&()| println!("Connected to server!"))
+            -> persist::<'static>()
+            -> [signal]msg_send;
         msg_send = defer_signal() -> map(|msg| (msg, server_addr)) -> [1]outbound_chan;
 
         // receive and print messages

--- a/dfir_rs/examples/chat_dfir/main.rs
+++ b/dfir_rs/examples/chat_dfir/main.rs
@@ -78,9 +78,10 @@ fn test() {
     client1.read_regex("Client is live!");
     client2.read_regex("Client is live!");
 
-    // wait 100ms so we don't drop a packet
-    let hundo_millis = web_time::Duration::from_millis(100);
-    std::thread::sleep(hundo_millis);
+    // Wait for the server to ack both connect requests, so we know the server has registered
+    // both clients before any chat message is sent (otherwise the message would be dropped).
+    client1.read_string("Connected to server!");
+    client2.read_string("Connected to server!");
 
     client1.write_line("Hello");
     client2.read_regex(".*, .* client1: Hello");
@@ -106,9 +107,10 @@ fn test_gossip() {
     client1.read_string("Client is live!");
     client2.read_string("Client is live!");
 
-    // wait 100ms so we don't drop a packet
-    let hundo_millis = web_time::Duration::from_millis(100);
-    std::thread::sleep(hundo_millis);
+    // Wait for the servers to ack the connect requests, so we know each server has registered
+    // its client before any chat message is sent (otherwise the messages would be dropped).
+    client1.read_string("Connected to server!");
+    client2.read_string("Connected to server!");
 
     // Since gossiping has a small probability of a message not being received (maybe more so with
     // 2 servers), we define success as any one of these messages reaching.

--- a/dfir_rs/examples/kvs/README.md
+++ b/dfir_rs/examples/kvs/README.md
@@ -1,7 +1,8 @@
 Simple single-node key-value store example based on a join of PUTs and GETs.
 
 Current semantics are:
-- PUTs are appended: we remember them all forever
+- PUTs are appended: we remember them all forever, and they are acknowledged with a `PutAck`
+  response.
 - GETs are only remembered for the current tick, which may not be monotone depending on how they
   are consumed.
 - GETs for empty keys get no acknowledgement.

--- a/dfir_rs/examples/kvs/main.rs
+++ b/dfir_rs/examples/kvs/main.rs
@@ -79,6 +79,8 @@ fn test() {
     );
 
     client1.write_line("PUT a,7");
+    // Wait for the ack, so we know the server has applied the PUT before issuing GETs.
+    client1.read_string(r#"Got a Response: PutAck { key: "a" }"#);
 
     let mut client2 = run_current_example!("--role client --address 127.0.0.1:2051");
     client2.read_regex(
@@ -86,12 +88,13 @@ fn test() {
     );
 
     client2.write_line("GET a");
-    client2.read_string(r#"Got a Response: KvsResponse { key: "a", value: "7" }"#);
+    client2.read_string(r#"Got a Response: GetResult { key: "a", value: "7" }"#);
 
     client1.write_line("PUT a,8");
+    client1.read_string(r#"Got a Response: PutAck { key: "a" }"#);
     client1.write_line("GET a");
     client1.read_string(
-        r#"Got a Response: KvsResponse { key: "a", value: "7" }
-Got a Response: KvsResponse { key: "a", value: "8" }"#,
+        r#"Got a Response: GetResult { key: "a", value: "7" }
+Got a Response: GetResult { key: "a", value: "8" }"#,
     );
 }

--- a/dfir_rs/examples/kvs/protocol.rs
+++ b/dfir_rs/examples/kvs/protocol.rs
@@ -31,7 +31,9 @@ impl KvsMessageWithAddr {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct KvsResponse {
-    pub key: String,
-    pub value: String,
+pub enum KvsResponse {
+    /// Acknowledgement that a `Put` has been received and applied by the server.
+    PutAck { key: String },
+    /// Response to a `Get`, containing a value for the requested key.
+    GetResult { key: String, value: String },
 }

--- a/dfir_rs/examples/kvs/server.rs
+++ b/dfir_rs/examples/kvs/server.rs
@@ -25,14 +25,20 @@ pub(crate) async fn run_server(opts: Opts) {
 
     let mut flow = dfir_syntax! {
         // Setup network channels.
-        network_send = dest_sink_serde(outbound);
+        network_send = union() -> dest_sink_serde(outbound);
         network_recv = source_stream_serde(inbound)
             -> map(Result::unwrap)
             -> inspect(|(msg, addr)| println!("Message received {:?} from {:?}", msg, addr))
             -> map(|(msg, addr)| KvsMessageWithAddr::from_message(msg, addr))
             -> demux_enum::<KvsMessageWithAddr>();
-        puts = network_recv[Put];
+        puts = network_recv[Put] -> tee();
         gets = network_recv[Get];
+
+        // Acknowledge PUTs back to the sending client, so clients can tell when their PUT has
+        // been received and applied by the server.
+        puts
+            -> map(|(key, _value, addr): (String, String, _)| (KvsResponse::PutAck { key }, addr))
+            -> network_send;
 
         /* DIFFERENCE HERE: SEE README.md */
         // Join PUTs and GETs by key, persisting the PUTs.
@@ -43,7 +49,7 @@ pub(crate) async fn run_server(opts: Opts) {
         // Send GET responses back to the client address.
         lookup
             -> inspect(|tup| println!("Found a match: {:?}", tup))
-            -> map(|(key, (value, client_addr))| (KvsResponse { key, value }, client_addr))
+            -> map(|(key, (value, client_addr))| (KvsResponse::GetResult { key, value }, client_addr))
             -> network_send;
     };
 


### PR DESCRIPTION
The `kvs` example test was observed hanging in CI (under nextest). The
root cause is a synchronization race combined with the example test
harness's untimed blocking reads:

- The test wrote `PUT a,7` to client1's stdin fire-and-forget, then spawned
  client2 and sent `GET a`. If client1 was slow to forward the PUT over UDP
  (e.g. CPU starvation under parallel CI load), the GET reached the server
  first. GETs are `'tick` in the server's `join()`, so an unmatched GET is
  silently dropped and no response is ever sent, leaving the test blocked
  forever on `read_string`.

And `chat_dfir`'s tests had
the same class of race (a chat message racing the other client's
`ConnectRequest`, since broadcast uses `cross_join::<'tick, 'static>`),
mitigated only by a 100ms sleep.

Fixes:

- kvs: change `KvsResponse` from a struct into an enum with
  `PutAck { key }` and `GetResult { key, value }` variants. The server now
  tees PUTs and sends a `PutAck` back to the issuing client (responses are
  merged into the network sink via `union()`). Tests now wait for the ack
  before issuing dependent GETs, making the PUT-then-GET ordering causal
  instead of timing-based. READMEs updated to document the ack semantics.

- chat_dfir: the client already gates outgoing messages on receiving the
  server's `ConnectResponse` (via `defer_signal`), but printed nothing, so
  tests could not synchronize on it. Add a "Connected to server!" print on
  `ConnectResponse` and replace the tests' 100ms sleeps with reads of that
  line from both clients, guaranteeing the server has registered both
  clients before any chat message is sent.

Verified: `cargo test --example kvs --example chat_dfir`
passes, kvs_mut binary re-run 50x in a loop without hangs, clippy clean.