### PR TITLE
feat(hydro_deploy, hydro_lang): make trybuild final compiles actually link dynamically [ci-full]

### DIFF
--- a/hydro_concurrent_cargo/src/lib.rs
+++ b/hydro_concurrent_cargo/src/lib.rs
@@ -76,10 +76,6 @@ pub struct CargoBuildLock {
 
 impl CargoBuildLock {
     pub fn lock_shared(lock_path: &Path) -> Self {
-        eprintln!(
-            "[hydro-build] acquiring .cargo-build-lock shared: {}",
-            lock_path.display()
-        );
         let file = fs::OpenOptions::new()
             .read(true)
             .write(true)
@@ -88,7 +84,6 @@ impl CargoBuildLock {
             .open(lock_path)
             .unwrap();
         file.lock_shared().unwrap();
-        eprintln!("[hydro-build] acquired .cargo-build-lock shared");
         CargoBuildLock { _file: file }
     }
 }
@@ -120,10 +115,6 @@ impl PrebuildGuard {
     /// Acquire an upgradable lock (in-process upgradable read + file shared).
     /// When `features_hash` is Some, uses a per-hash lock (for `__CARGO_DEFAULT_LIB_METADATA` mode).
     pub fn lock_upgradable(lock_path: &Path, features_hash: Option<&str>) -> Self {
-        eprintln!(
-            "[hydro-build] acquiring prebuild upgradable lock: {}",
-            lock_path.display()
-        );
         let rw_guard = get_dep_lock(features_hash).upgradable_read();
         let lock_dir = lock_path.parent().unwrap().to_owned();
         let file = fs::OpenOptions::new()
@@ -134,7 +125,6 @@ impl PrebuildGuard {
             .open(lock_path)
             .unwrap();
         file.lock_shared().unwrap();
-        eprintln!("[hydro-build] acquired prebuild upgradable lock");
         PrebuildGuard {
             _rw_guard: RwGuard::Upgradable(rw_guard),
             _global_guard: None,
@@ -146,7 +136,6 @@ impl PrebuildGuard {
 
     /// Upgrade to exclusive (in-process write + file exclusive + global locks).
     pub fn upgrade(self) -> Self {
-        eprintln!("[hydro-build] upgrading prebuild lock to exclusive");
         let file = self._file;
         let rw_guard = match self._rw_guard {
             RwGuard::Upgradable(u) => parking_lot::RwLockUpgradableReadGuard::upgrade(u),
@@ -155,7 +144,6 @@ impl PrebuildGuard {
         // Release per-feature shared lock before acquiring global exclusive
         // to avoid deadlock (other processes hold per-feature shared and wait for global).
         file.unlock().unwrap();
-        eprintln!("[hydro-build] acquiring global prebuild file lock");
         let global_guard = GLOBAL_PREBUILD_LOCK.write();
         let global_file = fs::OpenOptions::new()
             .read(true)
@@ -165,9 +153,7 @@ impl PrebuildGuard {
             .open(self.lock_dir.join(".global-prebuild.lock"))
             .unwrap();
         global_file.lock().unwrap();
-        eprintln!("[hydro-build] acquiring exclusive on per-feature lock");
         file.lock().unwrap();
-        eprintln!("[hydro-build] acquired prebuild exclusive lock");
         PrebuildGuard {
             _rw_guard: RwGuard::Write(rw_guard),
             _global_guard: Some(global_guard),

--- a/hydro_deploy/core/src/rust_crate/build.rs
+++ b/hydro_deploy/core/src/rust_crate/build.rs
@@ -165,58 +165,16 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
                             |prebuild_target| {
                                 set_msg("building dependencies".to_owned());
 
-                                let mut dep_cmd = Command::new("cargo");
-                                dep_cmd.current_dir(src.join("..").join("dylib"));
-                                dep_cmd.args(["build", "--locked"]);
-
-                                if let Some(profile) = profile.as_ref() {
-                                    dep_cmd.args(["--profile", profile]);
-                                }
-
-                                match target_type {
-                                    HostTargetType::Local => {}
-                                    HostTargetType::Linux(crate::LinuxCompileType::Glibc) => {
-                                        dep_cmd.args(["--target", "x86_64-unknown-linux-gnu"]);
-                                    }
-                                    HostTargetType::Linux(crate::LinuxCompileType::Musl) => {
-                                        dep_cmd.args(["--target", "x86_64-unknown-linux-musl"]);
-                                    }
-                                }
-
-                                if no_default_features {
-                                    dep_cmd.arg("--no-default-features");
-                                }
-
-                                if !features_for_closure.is_empty() {
-                                    dep_cmd.args(["--features", &features_for_closure.join(",")]);
-                                }
-
-                                for c in &config {
-                                    dep_cmd.args(["--config", c]);
-                                }
-
-                                dep_cmd.args(["--target-dir", prebuild_target.to_str().unwrap()]);
-
-                                if let Some(rustflags) = rustflags.as_ref() {
-                                    dep_cmd.env("RUSTFLAGS", rustflags);
-                                }
-
-                                for (k, v) in &build_env {
-                                    dep_cmd.env(k, v);
-                                }
-
-                                eprintln!("[hydro-build] starting deploy prebuild child cargo");
-                                let status = dep_cmd
-                                    .stdin(Stdio::null())
-                                    .status()
-                                    .unwrap();
-                                eprintln!("[hydro-build] deploy prebuild child cargo finished, success={}", status.success());
-                                if !status.success() {
-                                    panic!("dep prebuild failed");
-                                }
-
-                                // Also prebuild the dylib-examples lib.
-                                eprintln!("[hydro-build] starting deploy prebuild dylib-examples lib");
+                                // Prebuild the dylib-examples lib (`src` in dylib mode), which
+                                // transitively builds the trybuild dylib *as a dependency*.
+                                // This matters: cargo passes `-C prefer-dynamic` to dylib
+                                // crates when they are built as dependencies (linking libstd
+                                // dynamically), but *not* when they are the primary build
+                                // target — and the two variants share a cargo fingerprint. If
+                                // the dylib were prebuilt as a primary target, the cached
+                                // variant would statically link libstd and the final example
+                                // builds would fail to link ("cannot satisfy dependencies so
+                                // `std` only shows up once").
                                 let mut lib_cmd = Command::new("cargo");
                                 lib_cmd.current_dir(&src);
                                 lib_cmd.args(["build", "--locked", "--lib"]);
@@ -253,7 +211,7 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
                                     .status()
                                     .unwrap();
                                 if !lib_status.success() {
-                                    panic!("dylib-examples lib prebuild failed");
+                                    panic!("dep prebuild failed");
                                 }
                             },
                         );

--- a/hydro_lang/src/compile/trybuild/generate.rs
+++ b/hydro_lang/src/compile/trybuild/generate.rs
@@ -393,6 +393,23 @@ pub struct ExampleBuildConfig<'a> {
     pub allow_fuzz: bool,
 }
 
+/// Returns the toolchain's target libdir (where the shared `libstd` lives), memoized.
+#[cfg(any(feature = "sim", feature = "maelstrom"))]
+fn rustc_target_libdir() -> Option<String> {
+    static LIBDIR: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    LIBDIR
+        .get_or_init(|| {
+            let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_owned());
+            std::process::Command::new(rustc)
+                .args(["--print", "target-libdir"])
+                .output()
+                .ok()
+                .filter(|out| out.status.success())
+                .map(|out| String::from_utf8(out.stdout).unwrap().trim().to_owned())
+        })
+        .clone()
+}
+
 /// Compiles a generated trybuild example against the prebuilt dylib crate,
 /// using the shared parallel-compilation machinery (per-job target dirs with
 /// symlinked shared artifacts, plus a prebuild of the dylib dependencies).
@@ -427,6 +444,8 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
     };
 
     let (final_target_dir, _prebuild_guard, _cargo_lock) = if !has_custom_rustflags {
+        let prebuild_span =
+            tracing::debug_span!(target: "hydro_build", "prebuild", bin_name = %bin_name).entered();
         let shared_debug = trybuild.target_dir.join("debug");
         let jobs_dir = trybuild.target_dir.join("jobs");
         let per_job = hydro_concurrent_cargo::setup_job_dir(&jobs_dir, &bin_name, &shared_debug);
@@ -452,47 +471,41 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
             |prebuild_target| {
                 let features_str = features_for_closure.join(",");
 
-                let dylib_crate = path!(project_dir / "dylib");
-                let mut dep_cmd = Command::new("cargo");
-                dep_cmd.current_dir(&dylib_crate);
-                dep_cmd.args(["build", "--locked"]);
-                dep_cmd.args(["--target-dir", prebuild_target.to_str().unwrap()]);
-                dep_cmd.arg("--no-default-features");
-                dep_cmd.args(["--features", &features_str]);
-                dep_cmd.args(["--config", "build.incremental = false"]);
-                dep_cmd.env("STAGELEFT_TRYBUILD_BUILD_STAGED", "1");
-                eprintln!("[hydro-build] starting prebuild child cargo");
-                let status = dep_cmd.stdin(Stdio::null()).status().unwrap();
-                eprintln!(
-                    "[hydro-build] prebuild child cargo finished, success={}",
-                    status.success()
-                );
+                // Prebuild the lib that final builds will link against, which transitively
+                // builds the trybuild dylib *as a dependency*. This matters: cargo passes
+                // `-C prefer-dynamic` to dylib crates when they are built as dependencies
+                // (linking libstd dynamically), but *not* when they are the primary build
+                // target — and the two variants share a cargo fingerprint, so whichever is
+                // built first wins. Building the dylib as a primary target would poison the
+                // cache with a statically-linked-std variant that later fails to link into
+                // examples ("cannot satisfy dependencies so `std` only shows up once").
+                //
+                // In fuzz mode, examples are compiled from the base trybuild crate directly
+                // (no dylib-examples), so prebuild the base crate's lib instead.
+                let prebuild_crate = if is_fuzz_for_closure {
+                    project_dir.clone()
+                } else {
+                    path!(project_dir / "dylib-examples")
+                };
+                let mut lib_cmd = Command::new("cargo");
+                lib_cmd.current_dir(&prebuild_crate);
+                lib_cmd.args(["build", "--locked", "--lib"]);
+                lib_cmd.args(["--target-dir", prebuild_target.to_str().unwrap()]);
+                lib_cmd.arg("--no-default-features");
+                lib_cmd.args(["--features", &features_str]);
+                lib_cmd.args(["--config", "build.incremental = false"]);
+                lib_cmd.env("STAGELEFT_TRYBUILD_BUILD_STAGED", "1");
+                let status = lib_cmd.stdin(Stdio::null()).status().unwrap();
                 if !status.success() {
                     panic!("dep prebuild failed");
-                }
-
-                // Also prebuild the dylib-examples lib so concurrent final builds
-                // don't race on compiling it. Skip in fuzz mode since fuzzing
-                // compiles from the base trybuild crate directly (no dylib-examples).
-                if !is_fuzz_for_closure {
-                    eprintln!("[hydro-build] starting prebuild dylib-examples lib");
-                    let dylib_examples_crate = path!(project_dir / "dylib-examples");
-                    let mut lib_cmd = Command::new("cargo");
-                    lib_cmd.current_dir(&dylib_examples_crate);
-                    lib_cmd.args(["build", "--locked", "--lib"]);
-                    lib_cmd.args(["--target-dir", prebuild_target.to_str().unwrap()]);
-                    lib_cmd.arg("--no-default-features");
-                    lib_cmd.args(["--features", &features_str]);
-                    lib_cmd.args(["--config", "build.incremental = false"]);
-                    lib_cmd.env("STAGELEFT_TRYBUILD_BUILD_STAGED", "1");
-                    let lib_status = lib_cmd.stdin(Stdio::null()).status().unwrap();
-                    if !lib_status.success() {
-                        panic!("dylib-examples lib prebuild failed");
-                    }
                 }
             },
         );
 
+        // Close the prebuild span before returning the guards: the guards are held for the
+        // entire final build, but the prebuild phase (freshness check + possible dep build)
+        // ends here.
+        drop(prebuild_span);
         (per_job, Some(guard), Some(cargo_lock))
     } else {
         (trybuild.target_dir.clone(), None, None)
@@ -500,15 +513,24 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
 
     // Populate per-job build/ dir right before final build. Hold guard for entire build.
     let _job_build_guard = if !has_custom_rustflags {
+        let populate_span =
+            tracing::debug_span!(target: "hydro_build", "populate_job_dir", bin_name = %bin_name)
+                .entered();
         let shared_debug = trybuild.target_dir.join("debug");
-        Some(hydro_concurrent_cargo::populate_job_build_dir(
+        let guard = hydro_concurrent_cargo::populate_job_build_dir(
             &final_target_dir.join("debug"),
             &shared_debug,
-        ))
+        );
+        // Close the populate span here: the returned guard is held until the final build
+        // finishes, but the population work itself ends here.
+        drop(populate_span);
+        Some(guard)
     } else {
         None
     };
 
+    let final_build_span =
+        tracing::debug_span!(target: "hydro_build", "final_build", bin_name = %bin_name).entered();
     let mut command = Command::new("cargo");
     command.current_dir(&crate_to_compile);
     command.args([
@@ -551,19 +573,35 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
 
     command.arg("--");
 
-    if cfg!(target_os = "linux") {
+    if cfg!(any(target_os = "linux", target_os = "macos")) {
         let debug_path = if let Ok(target) = std::env::var("CARGO_BUILD_TARGET") {
             path!(final_target_dir / target / "debug")
         } else {
             path!(final_target_dir / "debug")
         };
 
-        command.args([&format!(
-            "-Clink-arg=-Wl,-rpath,{}",
-            debug_path.to_str().unwrap()
-        )]);
+        // The built example links the trybuild dylib dynamically. Bake rpath entries for
+        // where cargo places it (debug/ and debug/deps/) and for the toolchain's shared
+        // libstd, so the artifact can be loaded/run without LD_LIBRARY_PATH.
+        let mut rpaths = vec![debug_path.clone(), path!(debug_path / "deps")];
+        if let Some(libdir) = rustc_target_libdir() {
+            rpaths.push(PathBuf::from(libdir));
+        }
+        for rpath in rpaths {
+            if cfg!(target_os = "macos") {
+                // On macOS rustc may invoke the linker directly (`rust-lld -flavor darwin`),
+                // which rejects `-Wl,`-wrapped arguments. Use raw ld64 syntax (`-rpath <path>`
+                // as two arguments), which the clang driver also forwards to the linker.
+                command.args([
+                    "-Clink-arg=-rpath".to_owned(),
+                    format!("-Clink-arg={}", rpath.to_str().unwrap()),
+                ]);
+            } else {
+                command.args([format!("-Clink-arg=-Wl,-rpath,{}", rpath.to_str().unwrap())]);
+            }
+        }
 
-        if cfg!(target_env = "gnu") {
+        if cfg!(all(target_os = "linux", target_env = "gnu")) {
             command.arg(
                 // https://github.com/rust-lang/rust/issues/91979
                 "-Clink-args=-Wl,-z,nodelete",
@@ -586,6 +624,13 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
             }
         }
     }
+
+    tracing::debug!(
+        target: "hydro_build",
+        "final build command (cwd={}): {:?}",
+        crate_to_compile.display(),
+        command
+    );
 
     let mut spawned = command
         .stdout(Stdio::piped())
@@ -647,6 +692,7 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
 
     spawned.wait().unwrap();
     let stderr_output = stderr_thread.join().unwrap();
+    drop(final_build_span);
 
     // Check for unexpected recompilations — only dylib-examples should be compiled.
     // (Only relevant when prebuild is active, i.e. no custom RUSTFLAGS.)
@@ -832,11 +878,21 @@ pub fn create_trybuild()
             proc_macro2::Span::call_site(),
         );
         write_atomic(
-            prettyplease::unparse(&syn::parse_quote! {
-                #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case, unexpected_cfgs, unfulfilled_lint_expectations)]
-                pub use #trybuild_crate_name_ident::*;
-            })
-            .as_bytes(),
+            // The leading comment busts cargo's fingerprint for caches where the dylib was
+            // built as a *primary* target (statically linking libstd); it must be built as a
+            // dependency (with `-C prefer-dynamic`) for examples to link against it. The
+            // linkage variant is not part of cargo's fingerprint, so a content change is
+            // needed to force old caches to rebuild.
+            [
+                "// v2: dylib must be built as a dependency (prefer-dynamic).\n".as_bytes(),
+                prettyplease::unparse(&syn::parse_quote! {
+                    #![allow(unused_imports, unused_crate_dependencies, missing_docs, non_snake_case, unexpected_cfgs, unfulfilled_lint_expectations)]
+                    pub use #trybuild_crate_name_ident::*;
+                })
+                .as_bytes(),
+            ]
+            .concat()
+            .as_slice(),
             &path!(dylib_dir / "src" / "lib.rs"),
         )?;
 
@@ -888,23 +944,32 @@ crate-type = ["{}"]
             &path!(dylib_examples_dir / "src" / "lib.rs"),
         )?;
 
-        // Build feature forwarding for dylib-examples - forward to both base and dylib crates
+        // Build feature forwarding for dylib-examples - forward through the (renamed) dylib crate
         let features_section = feature_names
             .iter()
-            .map(|f| format!("{f} = [\"{project_name}/{f}\", \"{project_name}-dylib/{f}\"]"))
+            .map(|f| format!("{f} = [\"{project_name}/{f}\"]"))
             .collect::<Vec<_>>()
             .join("\n");
 
-        // Dylib-examples crate Cargo.toml - has base crate and dylib as dev-dependencies
+        // Dylib-examples crate Cargo.toml - depends *only* on the dylib crate, renamed to the
+        // base crate's package name so that generated examples referencing
+        // `{crate}_hydro_trybuild` resolve to the dylib. This is what makes dynamic linking
+        // actually kick in: if the base crate were also a direct dependency, rustc would
+        // statically link its rlib (and the entire dependency graph) into every example,
+        // making the per-example "final compile" link take several seconds. With only the
+        // dylib in scope, examples link against the prebuilt shared library instead.
+        //
+        // The dylib is a regular dependency (not a dev-dependency) so that prebuilding this
+        // crate's (empty) lib builds the dylib as a dependency, which is required for cargo
+        // to pass `-C prefer-dynamic` (see the prebuild in `compile_trybuild_example`).
         let dylib_examples_manifest = format!(
             r#"[package]
 name = "{project_name}-dylib-examples"
 version = "0.0.0"
 {}
 
-[dev-dependencies]
-{project_name} = {{ path = "..", default-features = false }}
-{project_name}-dylib = {{ path = "../dylib", default-features = false }}
+[dependencies]
+{project_name} = {{ package = "{project_name}-dylib", path = "../dylib", default-features = false }}
 
 [features]
 {features_section}
@@ -951,11 +1016,18 @@ members = ["dylib", "dylib-examples"]
             &path!(project.dir / "Cargo.toml"),
         )?;
 
-        // Compute hash for cache invalidation (dylib and dylib-examples are functions of workspace_manifest)
-        let manifest_hash = format!("{:X}", Sha256::digest(&workspace_manifest))
-            .chars()
-            .take(8)
-            .collect::<String>();
+        // Compute hash for cache invalidation, covering all generated manifests (the dylib and
+        // dylib-examples manifests affect Cargo.lock, so they must participate in the hash)
+        let manifest_hash = {
+            let mut hasher = Sha256::new();
+            hasher.update(&workspace_manifest);
+            hasher.update(&dylib_manifest);
+            hasher.update(&dylib_examples_manifest);
+            format!("{:X}", hasher.finalize())
+                .chars()
+                .take(8)
+                .collect::<String>()
+        };
 
         let workspace_cargo_lock = path!(project.workspace / "Cargo.lock");
         let workspace_cargo_lock_contents_and_hash = if workspace_cargo_lock.exists() {

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -167,6 +167,9 @@ mod test_init {
         #[ctor(unsafe)]
         fn init() {
             crate::compile::init_test();
+            // Install a tracing subscriber so diagnostics (e.g. the `hydro_build` build-timing
+            // events used by scripts/bench_trybuild.sh) can be enabled via RUST_LOG.
+            crate::telemetry::initialize_tracing();
         }
     );
 }

--- a/scripts/bench_trybuild.sh
+++ b/scripts/bench_trybuild.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#
+# Benchmark the per-test "final compile" of trybuild-generated binaries.
+#
+# Hydro tests (sim, maelstrom, localhost deploy) generate a Rust source file per test and
+# compile it as a cargo `--example` against a prebuilt dylib of the trybuild project. With a
+# fully warm cache (e.g. CI with `__CARGO_DEFAULT_LIB_METADATA=1`), the *final compile* of each
+# generated example is the remaining per-test cost (~6s in CI). This script measures exactly
+# that step so we can iterate on flags / linking strategies.
+#
+# How it works:
+#   1. "Warm" phase: runs a couple of hydro_lang sim tests via nextest (twice: once to populate
+#      caches / run prebuilds, once to capture logs with everything cached). The build phases in
+#      `hydro_lang::compile::trybuild::generate` are instrumented with `tracing` spans (target
+#      `hydro_build`); this script enables them via RUST_LOG and captures the exact final
+#      `cargo rustc` command and per-phase span timings (`time.busy` on span close).
+#   2. "Measure" phase: replays each captured final-compile command directly, N times, touching
+#      the generated example sources before each run to force a recompile (this mimics CI, where
+#      every commit produces fresh generated sources but the dependency cache is warm).
+#
+# Usage:
+#   ./scripts/bench_trybuild.sh                 # warm (if needed) + measure
+#   ./scripts/bench_trybuild.sh --rewarm        # force re-running the warm phase
+#   ./scripts/bench_trybuild.sh --nextest       # measure end-to-end via nextest instead of replay
+#
+# Env knobs:
+#   ITERS=5                    number of measured iterations per test (default 5)
+#   LIB_METADATA=0             unset __CARGO_DEFAULT_LIB_METADATA (defaults to 1, matching CI)
+#   BENCH_TESTS='...'          space-separated test-name regexes for nextest (default: two sim tests)
+#   EXTRA_RUSTC_FLAGS='...'    extra flags appended to the replayed command (after `--`, so they
+#                              are passed to rustc for the example target, e.g. '-Cdebuginfo=0')
+#   EXTRA_CARGO_FLAGS='...'    extra cargo flags inserted right after `rustc` (e.g. '--timings')
+#
+# Examples:
+#   ITERS=3 ./scripts/bench_trybuild.sh
+#   EXTRA_RUSTC_FLAGS='-Clink-arg=-fuse-ld=lld' ./scripts/bench_trybuild.sh
+#   EXTRA_CARGO_FLAGS='--timings' ITERS=1 ./scripts/bench_trybuild.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Match CI (.github/workflows/ci.yml). Set LIB_METADATA=0 to benchmark without
+# __CARGO_DEFAULT_LIB_METADATA (normal local-dev configuration).
+if [[ "${LIB_METADATA:-1}" == 0 ]]; then
+    unset __CARGO_DEFAULT_LIB_METADATA
+else
+    export __CARGO_DEFAULT_LIB_METADATA="${__CARGO_DEFAULT_LIB_METADATA:-1}"
+fi
+
+ITERS="${ITERS:-5}"
+BENCH_TESTS="${BENCH_TESTS:-sim_collect_waits_for_all_ticks sim_cluster_e2m_m2e}"
+EXTRA_RUSTC_FLAGS="${EXTRA_RUSTC_FLAGS:-}"
+EXTRA_CARGO_FLAGS="${EXTRA_CARGO_FLAGS:-}"
+
+TARGET_DIR="$(cargo metadata --format-version 1 --no-deps | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])')"
+BENCH_DIR="$TARGET_DIR/bench-trybuild"
+WARM_LOG="$BENCH_DIR/warm.log"
+mkdir -p "$BENCH_DIR"
+
+MODE="replay"
+REWARM=0
+for arg in "$@"; do
+    case "$arg" in
+        --nextest) MODE="nextest" ;;
+        --rewarm) REWARM=1 ;;
+        *) echo "unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
+
+filter_expr() {
+    local expr="" t
+    for t in $BENCH_TESTS; do
+        if [[ -n "$expr" ]]; then expr+=" or "; fi
+        expr+="test(/${t}\$/)"
+    done
+    echo "$expr"
+}
+
+run_tests() {
+    # --no-capture: we need the `hydro_build` tracing spans on stderr; also serializes tests so
+    # per-test timings are not polluted by concurrent builds. RUST_LOG enables the spans
+    # (subscriber is installed by hydro_lang's test init ctor).
+    RUST_LOG='error,hydro_build=debug' cargo nextest run -p hydro_lang --features sim,deploy \
+        --no-capture -E "$(filter_expr)" 2>&1
+}
+
+warm() {
+    echo "==> warm phase: building test binary + prebuilds (this can take a while on a cold cache)"
+    run_tests > "$BENCH_DIR/warm-pass1.log" || {
+        tail -50 "$BENCH_DIR/warm-pass1.log"
+        echo "warm pass 1 failed; see $BENCH_DIR/warm-pass1.log" >&2
+        exit 1
+    }
+    echo "==> warm phase: capturing final-compile commands with a hot cache"
+    # Touch generated examples so the final compiles re-run and get logged.
+    touch_examples
+    run_tests > "$WARM_LOG" || {
+        tail -50 "$WARM_LOG"
+        echo "warm pass 2 failed; see $WARM_LOG" >&2
+        exit 1
+    }
+}
+
+touch_examples() {
+    local d
+    for d in "$TARGET_DIR"/hydro_trybuild/*/dylib-examples/examples "$TARGET_DIR"/hydro_trybuild/*/examples; do
+        [[ -d "$d" ]] && find "$d" -name '*.rs' -exec touch {} + || true
+    done
+}
+
+strip_ansi() {
+    sed 's/\x1b\[[0-9;]*m//g'
+}
+
+stats() {
+    # stdin: one duration-in-ms per line
+    awk '{ a[NR]=$1; s+=$1 } END {
+        if (NR==0) { print "no data"; exit 1 }
+        asort_n = NR; for (i=1;i<asort_n;i++) for (j=i+1;j<=asort_n;j++) if (a[j]<a[i]) { t=a[i]; a[i]=a[j]; a[j]=t }
+        med = (NR%2==1) ? a[(NR+1)/2] : (a[NR/2]+a[NR/2+1])/2
+        printf "n=%d  mean=%.0fms  median=%.0fms  min=%.0fms  max=%.0fms\n", NR, s/NR, med, a[1], a[NR]
+    }'
+}
+
+if [[ "$REWARM" == 1 || ! -s "$WARM_LOG" ]] || ! grep -q "final build command" "$WARM_LOG" 2>/dev/null; then
+    warm
+fi
+
+if [[ "$MODE" == "nextest" ]]; then
+    echo "==> measuring end-to-end via nextest ($ITERS iterations)"
+    : > "$BENCH_DIR/nextest-times.txt"
+    for ((i=1; i<=ITERS; i++)); do
+        touch_examples
+        run_tests > "$BENCH_DIR/nextest-run$i.log" || {
+            tail -50 "$BENCH_DIR/nextest-run$i.log"; exit 1
+        }
+        # Span-close lines look like: `... final_build{bin_name=XXXX}: ... time.busy=1.23s time.idle=...`
+        # (strip ANSI styling emitted by the tracing formatter before parsing)
+        strip_ansi < "$BENCH_DIR/nextest-run$i.log" \
+            | grep -o 'final_build{bin_name=[^}]*}.*time\.busy=[^ ]*' \
+            | awk '{
+                bin=$0; sub(/.*bin_name=/, "", bin); sub(/}.*/, "", bin)
+                busy=$0; sub(/.*time\.busy=/, "", busy)
+                print bin, busy
+              }' | tee -a "$BENCH_DIR/nextest-times.txt"
+    done
+    echo "==> final-build stats (all tests pooled, time.busy of the final_build span):"
+    awk '{
+        v=$2; match(v, /^[0-9.]+/); num=substr(v, RSTART, RLENGTH)+0
+        if (v ~ /ns$/) ms=num/1000000
+        else if (v ~ /µs$/ || v ~ /us$/) ms=num/1000
+        else if (v ~ /ms$/) ms=num
+        else ms=num*1000
+        print ms
+    }' "$BENCH_DIR/nextest-times.txt" | stats
+    exit 0
+fi
+
+# --- replay mode ---
+# Extract the captured final-compile commands from the `hydro_build` tracing events. Each
+# event's message looks like:
+#   final build command (cwd=/path/to/dylib-examples): VAR="1" ... "cargo" "rustc" ...
+mapfile -t CMD_LINES < <(strip_ansi < "$WARM_LOG" | grep -o 'final build command (cwd=[^)]*): .*' | sort -u)
+if [[ ${#CMD_LINES[@]} -eq 0 ]]; then
+    echo "no final-compile commands captured in $WARM_LOG; try --rewarm" >&2
+    exit 1
+fi
+
+echo "==> replaying ${#CMD_LINES[@]} final-compile command(s), $ITERS iterations each"
+[[ -n "$EXTRA_RUSTC_FLAGS" ]] && echo "    EXTRA_RUSTC_FLAGS: $EXTRA_RUSTC_FLAGS"
+[[ -n "$EXTRA_CARGO_FLAGS" ]] && echo "    EXTRA_CARGO_FLAGS: $EXTRA_CARGO_FLAGS"
+
+overall_times="$BENCH_DIR/replay-times.txt"
+: > "$overall_times"
+
+idx=0
+for line in "${CMD_LINES[@]}"; do
+    idx=$((idx+1))
+    cwd="${line#final build command (cwd=}"
+    cwd="${cwd%%)*}"
+    cmd="${line#*): }"
+    # The Command debug output is already shell-compatible: env assignments like KEY="val"
+    # followed by quoted program+args. Prefix with `env` so the assignments are accepted.
+    if [[ -n "$EXTRA_CARGO_FLAGS" ]]; then
+        cmd="${cmd/\"rustc\"/\"rustc\" $EXTRA_CARGO_FLAGS}"
+    fi
+    if [[ -n "$EXTRA_RUSTC_FLAGS" ]]; then
+        cmd="$cmd $EXTRA_RUSTC_FLAGS"
+    fi
+
+    # Show which example this is (TRYBUILD_LIB_NAME for sim, --example otherwise)
+    label="$(echo "$line" | grep -o 'TRYBUILD_LIB_NAME="[^"]*"' | head -1 || true)"
+    [[ -z "$label" ]] && label="$(echo "$line" | grep -o '"--example" "[^"]*"' | head -1 || true)"
+    echo "--- command $idx ($label) in $cwd"
+
+    times_file="$BENCH_DIR/replay-cmd$idx.txt"
+    : > "$times_file"
+    for ((i=1; i<=ITERS; i++)); do
+        touch_examples
+        start=$(date +%s%N)
+        if ! (cd "$cwd" && eval "env $cmd") > "$BENCH_DIR/replay-cmd$idx-run$i.out" 2> "$BENCH_DIR/replay-cmd$idx-run$i.err"; then
+            echo "replay failed; stderr:" >&2
+            cat "$BENCH_DIR/replay-cmd$idx-run$i.err" >&2
+            exit 1
+        fi
+        end=$(date +%s%N)
+        ms=$(( (end - start) / 1000000 ))
+        echo "$ms" | tee -a "$times_file" >> "$overall_times"
+        echo "    iter $i: ${ms}ms"
+    done
+    echo -n "    stats: "; stats < "$times_file"
+done
+
+echo "==> overall stats (all commands pooled):"
+stats < "$overall_times"


### PR DESCRIPTION
Adds `scripts/bench_trybuild.sh` to benchmark the per-test "final compile" of
trybuild-generated examples (the ~6s-per-test cost in CI even with a fully warm
cache), and fixes two bugs that were silently defeating the dynamic-linking
design, cutting the final compile from ~4.2s to ~1.25s locally (3.3x).

Root causes found via the benchmark:

1. Generated examples statically linked the entire dependency graph. The
   `dylib-examples` crate had *both* the base trybuild crate and the dylib as
   dev-dependencies. Since generated examples reference the base crate by name
   (`use {crate}_hydro_trybuild::...`), rustc linked the base rlib (and its
   ~286 transitive rlibs, ~420MB) statically into every example; the dylib was
   linked but then dropped by `--as-needed`. Fix: `dylib-examples` now depends
   *only* on the dylib crate, renamed to the base crate's package name
   (`{name} = { package = "{name}-dylib", path = "../dylib" }`), so the extern
   name resolves to the dylib and the final link pulls in just
   libhydro_..._dylib.so + shared libstd + compiler_builtins.

2. Prebuild "poisoned" the dylib with statically-linked libstd. Cargo passes
   `-C prefer-dynamic` to dylib crates only when they are built as
   *dependencies*, not as the primary build target — and both variants share a
   cargo fingerprint. The prebuild built the dylib crate directly, caching a
   static-libstd variant that fails to link into examples ("cannot satisfy
   dependencies so `std` only shows up once"). Fix (both in
   hydro_lang::compile::trybuild::generate and hydro_deploy rust_crate/build.rs):
   prebuild `dylib-examples --lib` instead, which builds the dylib transitively
   as a dependency. A version comment in the generated dylib `lib.rs` busts the
   fingerprint of existing caches holding the poisoned variant.

Supporting changes:
- Since examples are now genuinely dynamic, bake additional rpath entries
  (debug/deps for the dylib, `rustc --print target-libdir` for shared libstd)
  into sim/maelstrom artifacts, and extend rpath handling to macOS. On macOS
  the rpaths use raw ld64 syntax (`-rpath <path>` as two link-args) because
  rustc may invoke `rust-lld -flavor darwin` directly, which rejects
  `-Wl,`-wrapped arguments; the clang driver also forwards this form.
- Include the dylib/dylib-examples manifests in the trybuild cache-invalidation
  hash so existing target dirs regenerate their Cargo.lock (dep graph changed).
- Instrument `compile_trybuild_example` with `tracing` spans (target
  `hydro_build`: prebuild / populate_job_dir / final_build, plus a debug event
  with the exact final cargo command). hydro_lang's test-init ctor now installs
  the telemetry tracing subscriber, so the spans are opt-in via RUST_LOG
  (silent by default). All ad-hoc `[hydro-build]` eprintln logging is removed
  (hydro_lang, hydro_deploy, hydro_concurrent_cargo); the build-coordination.log
  mechanism is unchanged.
- `scripts/bench_trybuild.sh`: warms via two hydro_lang sim tests with
  RUST_LOG=hydro_build=debug, captures the exact final `cargo rustc` commands,
  and replays them N times (touching generated sources to force recompiles,
  mimicking CI). Knobs: ITERS, BENCH_TESTS, LIB_METADATA=0, EXTRA_RUSTC_FLAGS,
  EXTRA_CARGO_FLAGS; `--nextest` mode measures end-to-end through the test
  harness using the span-close timings.

Measured (32-core Linux, warm cache): baseline 4.23s mean per final compile;
after fixes 1.25s (~0.35s cargo freshness check, ~0.45s rustc
frontend+codegen of the generated example, ~0.44s link). lld and
`-Cdebuginfo=0` were also benchmarked and showed no further gain. Results are
identical with and without `__CARGO_DEFAULT_LIB_METADATA=1`.

Validated: full hydro_lang nextest suite (184 passed, incl. sim fuzzer),
hydro_lang doctests (199 passed), hydro_test simple_cluster localhost deploy
(binaries now 2.7MB, dynamically linked, run via existing LD_LIBRARY_PATH
mechanism), and executables running via baked rpath without LD_LIBRARY_PATH
(the maelstrom configuration).