### PR TITLE
feat(hydro_lang): cache __staged.rs generation across test processes, add per-test phase profiling

### DIFF
--- a/hydro_lang/src/compile/trybuild/generate.rs
+++ b/hydro_lang/src/compile/trybuild/generate.rs
@@ -127,48 +127,15 @@ pub fn create_graph_trybuild(
 
     let is_test = IS_TEST.load(std::sync::atomic::Ordering::Relaxed);
 
-    let generated_code =
-        compile_graph_trybuild(graph, extra_stmts, sidecars, &crate_name, deploy_mode);
-
-    let inlined_staged = if is_test {
-        let raw_toml_manifest = toml::from_str::<toml::Value>(
-            &fs::read_to_string(path!(source_dir / "Cargo.toml")).unwrap(),
-        )
-        .unwrap();
-
-        let maybe_custom_lib_path = raw_toml_manifest
-            .get("lib")
-            .and_then(|lib| lib.get("path"))
-            .and_then(|path| path.as_str());
-
-        let mut gen_staged = stageleft_tool::gen_staged_trybuild(
-            &maybe_custom_lib_path
-                .map(|s| path!(source_dir / s))
-                .unwrap_or_else(|| path!(source_dir / "src" / "lib.rs")),
-            &path!(source_dir / "Cargo.toml"),
-            &crate_name,
-            Some("hydro___test".to_owned()),
-        );
-
-        gen_staged.attrs.insert(
-            0,
-            syn::parse_quote! {
-                #![allow(
-                    unused,
-                    ambiguous_glob_reexports,
-                    clippy::suspicious_else_formatting,
-                    unexpected_cfgs,
-                    reason = "generated code"
-                )]
-            },
-        );
-
-        Some(prettyplease::unparse(&gen_staged))
-    } else {
-        None
+    let generated_code = {
+        let _span = tracing::debug_span!(target: "hydro_build", "graph_codegen").entered();
+        compile_graph_trybuild(graph, extra_stmts, sidecars, &crate_name, deploy_mode)
     };
 
-    let source = prettyplease::unparse(&generated_code);
+    let source = {
+        let _span = tracing::debug_span!(target: "hydro_build", "unparse_source").entered();
+        prettyplease::unparse(&generated_code)
+    };
 
     let hash = format!("{:X}", Sha256::digest(&source))
         .chars()
@@ -195,16 +162,14 @@ pub fn create_graph_trybuild(
 
     let out_path = path!(examples_dir / format!("{bin_name}.rs"));
     {
+        let _span =
+            tracing::debug_span!(target: "hydro_build", "write_generated_sources").entered();
         let _concurrent_test_lock = CONCURRENT_TEST_LOCK.lock().unwrap();
         write_atomic(source.as_ref(), &out_path).unwrap();
     }
 
-    if let Some(inlined_staged) = inlined_staged {
-        let staged_path = path!(project_dir / "src" / "__staged.rs");
-        {
-            let _concurrent_test_lock = CONCURRENT_TEST_LOCK.lock().unwrap();
-            write_atomic(inlined_staged.as_bytes(), &staged_path).unwrap();
-        }
+    if is_test {
+        write_staged_source_cached(source_dir.as_ref(), &crate_name, &project_dir);
     }
 
     if is_test {
@@ -715,13 +680,117 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
     Ok(out_file)
 }
 
+/// Generates the inlined `__staged.rs` source for the source crate and writes it into the
+/// trybuild project, caching the (expensive) generation across test processes.
+///
+/// The staged source is a pure function of the source crate's files, and cargo rebuilds the
+/// test executable whenever those change, so the identity (path + mtime) of
+/// [`std::env::current_exe`] is a sound freshness proxy. All tests in a run share the same
+/// executable, so only the first test per test binary pays the ~1s `syn` parse +
+/// `prettyplease` unparse; the rest hit the cache. The stamp holds a single entry — the last
+/// executable to write `__staged.rs` — so a different test binary of the same crate
+/// regenerates on its first test (a no-op rewrite when sources are unchanged). Keeping old
+/// entries around would risk a stale match (e.g. an executable restored with an old mtime
+/// after another binary regenerated `__staged.rs` from different sources).
+pub(crate) fn write_staged_source_cached(source_dir: &Path, crate_name: &str, project_dir: &Path) {
+    let _span = tracing::debug_span!(target: "hydro_build", "gen_staged").entered();
+
+    let staged_path = path!(project_dir / "src" / "__staged.rs");
+    let stamp_path = path!(project_dir / ".hydro-staged-stamp");
+
+    let exe_stamp = std::env::current_exe().ok().and_then(|exe| {
+        let mtime = fs::metadata(&exe)
+            .ok()?
+            .modified()
+            .ok()?
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .ok()?
+            .as_nanos();
+        Some(format!("{}\t{}", exe.display(), mtime))
+    });
+
+    let _concurrent_test_lock = CONCURRENT_TEST_LOCK.lock().unwrap();
+
+    fs::create_dir_all(path!(project_dir / "src")).unwrap();
+
+    // Hold an exclusive lock on the stamp file for the entire check + generate: when many
+    // test processes start concurrently with a cold cache, the first one generates while the
+    // others block here and then hit the cache, instead of all doing the expensive work.
+    let mut stamp_file = File::options()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&stamp_path)
+        .unwrap();
+    stamp_file.lock().unwrap();
+
+    let mut existing_stamp = String::new();
+    if stamp_file.read_to_string(&mut existing_stamp).is_err() {
+        existing_stamp.clear();
+    }
+
+    if let Some(stamp) = &exe_stamp
+        && existing_stamp == *stamp
+        && staged_path.exists()
+    {
+        return;
+    }
+
+    let raw_toml_manifest = toml::from_str::<toml::Value>(
+        &fs::read_to_string(path!(source_dir / "Cargo.toml")).unwrap(),
+    )
+    .unwrap();
+
+    let maybe_custom_lib_path = raw_toml_manifest
+        .get("lib")
+        .and_then(|lib| lib.get("path"))
+        .and_then(|path| path.as_str());
+
+    let mut gen_staged = stageleft_tool::gen_staged_trybuild(
+        &maybe_custom_lib_path
+            .map(|s| path!(source_dir / s))
+            .unwrap_or_else(|| path!(source_dir / "src" / "lib.rs")),
+        &path!(source_dir / "Cargo.toml"),
+        crate_name,
+        Some("hydro___test".to_owned()),
+    );
+
+    gen_staged.attrs.insert(
+        0,
+        syn::parse_quote! {
+            #![allow(
+                unused,
+                ambiguous_glob_reexports,
+                clippy::suspicious_else_formatting,
+                unexpected_cfgs,
+                reason = "generated code"
+            )]
+        },
+    );
+
+    let inlined_staged = prettyplease::unparse(&gen_staged);
+
+    write_atomic(inlined_staged.as_bytes(), &staged_path).unwrap();
+
+    if let Some(stamp) = exe_stamp {
+        stamp_file.set_len(0).unwrap();
+        stamp_file.seek(SeekFrom::Start(0)).unwrap();
+        stamp_file.write_all(stamp.as_bytes()).unwrap();
+    }
+}
+
 pub fn create_trybuild()
 -> Result<(PathBuf, PathBuf, Option<Vec<String>>), trybuild_internals_api::error::Error> {
+    let _span = tracing::debug_span!(target: "hydro_build", "create_trybuild").entered();
     let Metadata {
         target_directory: target_dir,
         workspace_root: workspace,
         packages,
-    } = cargo::metadata()?;
+    } = {
+        let _span = tracing::debug_span!(target: "hydro_build", "cargo_metadata").entered();
+        cargo::metadata()?
+    };
 
     let source_dir = cargo::manifest_dir()?;
     let mut source_manifest = dependencies::get_manifest(&source_dir)?;
@@ -833,6 +902,7 @@ pub fn create_trybuild()
     };
 
     {
+        let _span = tracing::debug_span!(target: "hydro_build", "write_project_files").entered();
         let _concurrent_test_lock = CONCURRENT_TEST_LOCK.lock().unwrap();
 
         let project_lock = File::create(path!(project.dir / ".hydro-trybuild-lock"))?;
@@ -1058,6 +1128,7 @@ members = ["dylib", "dylib-examples"]
         )
         .is_ok_and(|b| b)
         {
+            let _span = tracing::debug_span!(target: "hydro_build", "update_lockfile").entered();
             // this is expensive, so we only do it if the manifest changed
             if let Some((cargo_lock_contents, _)) = workspace_cargo_lock_contents_and_hash {
                 // only overwrite when the hash changed, because writing Cargo.lock must be

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -346,6 +346,8 @@ impl CompiledSim {
         let mut count = 0;
         let count_mut = &mut count;
 
+        let _span = tracing::debug_span!(target: "hydro_build", "sim_exhaustive").entered();
+
         self.with_instantiator(
             |instantiator| {
                 bolero::test(bolero::TargetLocation {

--- a/hydro_lang/src/sim/flow.rs
+++ b/hydro_lang/src/sim/flow.rs
@@ -132,6 +132,9 @@ impl<'a> SimFlow<'a> {
     pub fn compiled(mut self) -> CompiledSim {
         use dfir_lang::graph::{eliminate_extra_unions_tees, partition_graph};
 
+        let compiled_span = tracing::debug_span!(target: "hydro_build", "sim_compiled").entered();
+        let flow_build_span = tracing::debug_span!(target: "hydro_build", "flow_build").entered();
+
         let is_multi_version = self.location_version.values().any(|&v| v > 0);
 
         let mut sim_emit = SimBuilder {
@@ -226,6 +229,7 @@ impl<'a> SimFlow<'a> {
         }
 
         let (cluster_max_sizes, cluster_member_ids) = self.cluster_sizing();
+        drop(flow_build_span);
 
         let (bin, trybuild) = create_sim_graph_trybuild(
             process_graphs,
@@ -239,7 +243,11 @@ impl<'a> SimFlow<'a> {
         );
 
         let out = compile_sim(bin, trybuild).unwrap();
-        let lib = unsafe { Library::new(&out).unwrap() };
+        let lib = {
+            let _span = tracing::debug_span!(target: "hydro_build", "load_dylib").entered();
+            unsafe { Library::new(&out).unwrap() }
+        };
+        drop(compiled_span);
 
         CompiledSim {
             _path: out,

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -19,7 +19,7 @@ use crate::compile::deploy_provider::{Deploy, DynSourceSink, Node, RegisterPort}
 use crate::compile::trybuild::generate::LinkingMode;
 use crate::compile::trybuild::generate::{
     CONCURRENT_TEST_LOCK, ExampleBuildConfig, IS_TEST, TrybuildConfig, compile_trybuild_example,
-    create_trybuild, write_atomic,
+    create_trybuild, write_atomic, write_staged_source_cached,
 };
 use crate::deploy::deploy_runtime::cluster_membership_stream;
 use crate::location::dynamic::LocationId;
@@ -463,57 +463,25 @@ pub(super) fn create_sim_graph_trybuild(
 
     let is_test = IS_TEST.load(std::sync::atomic::Ordering::Relaxed);
 
-    let generated_code = compile_sim_graph_trybuild(
-        process_graphs,
-        cluster_graphs,
-        cluster_max_sizes,
-        cluster_member_ids,
-        process_tick_graphs,
-        cluster_tick_graphs,
-        extra_stmts_global,
-        extra_stmts_cluster,
-        &crate_name,
-    );
-
-    let inlined_staged = if is_test {
-        let raw_toml_manifest = toml::from_str::<toml::Value>(
-            &fs::read_to_string(path!(source_dir / "Cargo.toml")).unwrap(),
-        )
-        .unwrap();
-
-        let maybe_custom_lib_path = raw_toml_manifest
-            .get("lib")
-            .and_then(|lib| lib.get("path"))
-            .and_then(|path| path.as_str());
-
-        let mut gen_staged = stageleft_tool::gen_staged_trybuild(
-            &maybe_custom_lib_path
-                .map(|s| path!(source_dir / s))
-                .unwrap_or_else(|| path!(source_dir / "src" / "lib.rs")),
-            &path!(source_dir / "Cargo.toml"),
+    let generated_code = {
+        let _span = tracing::debug_span!(target: "hydro_build", "sim_codegen").entered();
+        compile_sim_graph_trybuild(
+            process_graphs,
+            cluster_graphs,
+            cluster_max_sizes,
+            cluster_member_ids,
+            process_tick_graphs,
+            cluster_tick_graphs,
+            extra_stmts_global,
+            extra_stmts_cluster,
             &crate_name,
-            Some("hydro___test".to_owned()),
-        );
-
-        gen_staged.attrs.insert(
-            0,
-            syn::parse_quote! {
-                #![allow(
-                    unused,
-                    ambiguous_glob_reexports,
-                    clippy::suspicious_else_formatting,
-                    unexpected_cfgs,
-                    reason = "generated code"
-                )]
-            },
-        );
-
-        Some(prettyplease::unparse(&gen_staged))
-    } else {
-        None
+        )
     };
 
-    let source = prettyplease::unparse(&generated_code);
+    let source = {
+        let _span = tracing::debug_span!(target: "hydro_build", "unparse_source").entered();
+        prettyplease::unparse(&generated_code)
+    };
 
     let hash = format!("{:X}", Sha256::digest(&source))
         .chars()
@@ -540,16 +508,14 @@ pub(super) fn create_sim_graph_trybuild(
 
     let out_path = path!(examples_dir / format!("{bin_name}.rs"));
     {
+        let _span =
+            tracing::debug_span!(target: "hydro_build", "write_generated_sources").entered();
         let _concurrent_test_lock = CONCURRENT_TEST_LOCK.lock().unwrap();
         write_atomic(source.as_ref(), &out_path).unwrap();
     }
 
-    if let Some(inlined_staged) = inlined_staged {
-        let staged_path = path!(project_dir / "src" / "__staged.rs");
-        {
-            let _concurrent_test_lock = CONCURRENT_TEST_LOCK.lock().unwrap();
-            write_atomic(inlined_staged.as_bytes(), &staged_path).unwrap();
-        }
+    if is_test {
+        write_staged_source_cached(source_dir.as_ref(), &crate_name, &project_dir);
     }
 
     if is_test {

--- a/scripts/bench_trybuild.sh
+++ b/scripts/bench_trybuild.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
 #
-# Benchmark the per-test "final compile" of trybuild-generated binaries.
+# Benchmark the per-test "final compile" of trybuild-generated binaries, and experiment with
+# cargo/rustc flags for it.
 #
 # Hydro tests (sim, maelstrom, localhost deploy) generate a Rust source file per test and
 # compile it as a cargo `--example` against a prebuilt dylib of the trybuild project. With a
 # fully warm cache (e.g. CI with `__CARGO_DEFAULT_LIB_METADATA=1`), the *final compile* of each
-# generated example is the remaining per-test cost (~6s in CI). This script measures exactly
-# that step so we can iterate on flags / linking strategies.
+# generated example is the dominant remaining per-test cost. This script measures exactly that
+# step so we can iterate on flags / linking strategies without rerunning the tests themselves.
+#
+# For a breakdown of *all* per-test phases (staged codegen, cargo metadata, prebuild, final
+# build, sim execution, ...), use scripts/profile_test_phases.sh instead.
 #
 # How it works:
 #   1. "Warm" phase: runs a couple of hydro_lang sim tests via nextest (twice: once to populate
 #      caches / run prebuilds, once to capture logs with everything cached). The build phases in
 #      `hydro_lang::compile::trybuild::generate` are instrumented with `tracing` spans (target
 #      `hydro_build`); this script enables them via RUST_LOG and captures the exact final
-#      `cargo rustc` command and per-phase span timings (`time.busy` on span close).
+#      `cargo rustc` command.
 #   2. "Measure" phase: replays each captured final-compile command directly, N times, touching
 #      the generated example sources before each run to force a recompile (this mimics CI, where
 #      every commit produces fresh generated sources but the dependency cache is warm).
@@ -21,7 +25,6 @@
 # Usage:
 #   ./scripts/bench_trybuild.sh                 # warm (if needed) + measure
 #   ./scripts/bench_trybuild.sh --rewarm        # force re-running the warm phase
-#   ./scripts/bench_trybuild.sh --nextest       # measure end-to-end via nextest instead of replay
 #
 # Env knobs:
 #   ITERS=5                    number of measured iterations per test (default 5)
@@ -57,11 +60,9 @@ BENCH_DIR="$TARGET_DIR/bench-trybuild"
 WARM_LOG="$BENCH_DIR/warm.log"
 mkdir -p "$BENCH_DIR"
 
-MODE="replay"
 REWARM=0
 for arg in "$@"; do
     case "$arg" in
-        --nextest) MODE="nextest" ;;
         --rewarm) REWARM=1 ;;
         *) echo "unknown argument: $arg" >&2; exit 1 ;;
     esac
@@ -126,37 +127,7 @@ if [[ "$REWARM" == 1 || ! -s "$WARM_LOG" ]] || ! grep -q "final build command" "
     warm
 fi
 
-if [[ "$MODE" == "nextest" ]]; then
-    echo "==> measuring end-to-end via nextest ($ITERS iterations)"
-    : > "$BENCH_DIR/nextest-times.txt"
-    for ((i=1; i<=ITERS; i++)); do
-        touch_examples
-        run_tests > "$BENCH_DIR/nextest-run$i.log" || {
-            tail -50 "$BENCH_DIR/nextest-run$i.log"; exit 1
-        }
-        # Span-close lines look like: `... final_build{bin_name=XXXX}: ... time.busy=1.23s time.idle=...`
-        # (strip ANSI styling emitted by the tracing formatter before parsing)
-        strip_ansi < "$BENCH_DIR/nextest-run$i.log" \
-            | grep -o 'final_build{bin_name=[^}]*}.*time\.busy=[^ ]*' \
-            | awk '{
-                bin=$0; sub(/.*bin_name=/, "", bin); sub(/}.*/, "", bin)
-                busy=$0; sub(/.*time\.busy=/, "", busy)
-                print bin, busy
-              }' | tee -a "$BENCH_DIR/nextest-times.txt"
-    done
-    echo "==> final-build stats (all tests pooled, time.busy of the final_build span):"
-    awk '{
-        v=$2; match(v, /^[0-9.]+/); num=substr(v, RSTART, RLENGTH)+0
-        if (v ~ /ns$/) ms=num/1000000
-        else if (v ~ /µs$/ || v ~ /us$/) ms=num/1000
-        else if (v ~ /ms$/) ms=num
-        else ms=num*1000
-        print ms
-    }' "$BENCH_DIR/nextest-times.txt" | stats
-    exit 0
-fi
-
-# --- replay mode ---
+# --- measure: replay the captured final-compile commands ---
 # Extract the captured final-compile commands from the `hydro_build` tracing events. Each
 # event's message looks like:
 #   final build command (cwd=/path/to/dylib-examples): VAR="1" ... "cargo" "rustc" ...

--- a/scripts/profile_test_phases.sh
+++ b/scripts/profile_test_phases.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Profile the per-test phase timings of hydro trybuild-based tests (sim, maelstrom, deploy).
+#
+# Runs the selected tests serially under nextest with the `hydro_build` tracing spans enabled
+# (see hydro_lang/src/compile/trybuild/generate.rs, sim/graph.rs, sim/flow.rs), then parses the
+# span-close events to produce a per-test breakdown of where the time goes:
+#
+#   flow_build          building DFIR graphs from the Hydro IR (in the test process)
+#   sim_codegen         generating the example source (DFIR codegen + quoting)
+#   gen_staged          __staged.rs generation; cached via a stamp of the current test
+#                       executable (path + mtime), so only the first test per binary pays
+#                       the syn+prettyplease cost
+#   unparse_source      prettyplease of the generated example
+#   create_trybuild     setting up the trybuild project dir (includes cargo_metadata)
+#   cargo_metadata      `cargo metadata --no-deps` subprocess
+#   write_project_files writing manifests/lib.rs into the trybuild project
+#   update_lockfile     Cargo.lock regen (only when manifests change)
+#   write_generated_sources  writing the example + __staged.rs
+#   prebuild            freshness check (+ dep build when stale)
+#   populate_job_dir    symlinking the per-job build dir
+#   final_build         the final `cargo rustc` of the generated example
+#   load_dylib          dlopen of the built cdylib
+#   sim_compiled        total of all of the above (sim only)
+#   sim_exhaustive      running the exhaustive simulation itself
+#
+# Usage:
+#   ./scripts/profile_test_phases.sh                            # default: a few hydro_lang sim tests
+#   FILTER='test(/sim_/)' ./scripts/profile_test_phases.sh      # any nextest filter expression
+#   PACKAGE=hydro_test FEATURES=deploy ./scripts/profile_test_phases.sh
+#
+# Env knobs:
+#   PACKAGE=hydro_lang         cargo package to test
+#   FEATURES=sim,deploy        cargo features
+#   FILTER='...'               nextest filter expression (-E)
+#   LIB_METADATA=1             match CI's __CARGO_DEFAULT_LIB_METADATA=1 (set 0 to disable)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ "${LIB_METADATA:-1}" == 0 ]]; then
+    unset __CARGO_DEFAULT_LIB_METADATA
+else
+    export __CARGO_DEFAULT_LIB_METADATA="${__CARGO_DEFAULT_LIB_METADATA:-1}"
+fi
+
+PACKAGE="${PACKAGE:-hydro_lang}"
+FEATURES="${FEATURES:-sim,deploy}"
+FILTER="${FILTER:-test(/sim_collect_waits_for_all_ticks$/) or test(/sim_cluster_e2m_m2e$/) or test(/sim_batch_cross_singleton$/) or test(/tick_batch$/)}"
+
+TARGET_DIR="$(cargo metadata --format-version 1 --no-deps | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])')"
+OUT_DIR="$TARGET_DIR/profile-test-phases"
+mkdir -p "$OUT_DIR"
+LOG="$OUT_DIR/run.log"
+
+echo "==> running tests (serially, --no-capture) with hydro_build span tracing"
+RUST_LOG='error,hydro_build=debug' cargo nextest run -p "$PACKAGE" --features "$FEATURES" \
+    --no-capture -E "$FILTER" > "$LOG" 2>&1 || {
+    tail -50 "$LOG"
+    echo "test run failed; see $LOG" >&2
+    exit 1
+}
+
+python3 - "$LOG" <<'EOF'
+import re, sys, collections
+
+log_path = sys.argv[1]
+ansi = re.compile(r'\x1b\[[0-9;]*m')
+
+def parse_dur(s):
+    m = re.match(r'^([0-9.]+)(ns|µs|us|ms|s|m)$', s)
+    if not m:
+        return None
+    v = float(m.group(1))
+    unit = m.group(2)
+    return v * {'ns': 1e-6, 'µs': 1e-3, 'us': 1e-3, 'ms': 1.0, 's': 1000.0, 'm': 60000.0}[unit]
+
+# span close lines look like (after ANSI stripping):
+#   <ts> DEBUG hydro_build: parent:child{fields}: close time.busy=1.23s time.idle=456µs
+# and nextest end-of-test lines like:
+#   PASS [   5.123s] hydro_lang tests::foo
+close_re = re.compile(r'hydro_build .*?:\d+: (?:[A-Za-z0-9_]+(?:\{[^}]*\})?: )*?(?P<name>[A-Za-z0-9_]+)(?:\{[^}]*\})?: close\s+time\.busy=(?P<busy>\S+)\s+time\.idle=(?P<idle>\S+)')
+result_re = re.compile(r'^\s*(PASS|FAIL|TIMEOUT|ABORT)\s+\[\s*([0-9.]+)s\]\s+(?:\(\d+/\d+\)\s+)?\S+\s+(\S+)')
+
+pending = []            # span closes since the last test boundary
+tests = []              # (name, status, total_s, {phase: ms})
+phase_order = []
+
+with open(log_path, errors='replace') as f:
+    for line in f:
+        line = ansi.sub('', line.rstrip('\n'))
+        m = close_re.search(line)
+        if m:
+            busy = parse_dur(m.group('busy'))
+            if busy is not None:
+                pending.append((m.group('name'), busy))
+                if m.group('name') not in phase_order:
+                    phase_order.append(m.group('name'))
+            continue
+        m = result_re.match(line)
+        if m:
+            status, total, name = m.group(1), float(m.group(2)), m.group(3)
+            phases = collections.defaultdict(float)
+            for pname, busy in pending:
+                phases[pname] += busy
+            pending = []
+            tests.append((name, status, total, dict(phases)))
+
+if not tests:
+    print("no test results parsed; check the log")
+    sys.exit(1)
+
+def fmt_ms(v):
+    return f'{v:9.0f}' if v else f'{"-":>9}'
+
+print()
+for name, status, total, phases in tests:
+    print(f'=== {name} [{status}] total={total:.2f}s')
+    accounted = 0.0
+    for p in phase_order:
+        if p in phases:
+            print(f'    {p:26s} {phases[p]:8.0f} ms')
+    # spans that nest inside others shouldn't be double counted; report umbrella separately
+    top = sum(v for k, v in phases.items() if k in ('sim_compiled', 'sim_exhaustive'))
+    other = total * 1000 - top
+    print(f'    {"(sim_compiled+sim_exhaustive)":26s} {top:8.0f} ms   (unaccounted vs total: {other:.0f} ms)')
+
+print()
+print('=== aggregate (mean ms per test) ===')
+for p in phase_order:
+    vals = [phases.get(p, 0.0) for _, _, _, phases in tests]
+    n = sum(1 for v in vals if v)
+    if n:
+        print(f'    {p:26s} mean={sum(vals)/len(tests):8.0f} ms   (present in {n}/{len(tests)} tests)')
+totals = [t for _, _, t, _ in tests]
+print(f'    {"TOTAL (nextest)":26s} mean={1000*sum(totals)/len(totals):8.0f} ms')
+EOF
+
+echo
+echo "full log: $LOG"


### PR DESCRIPTION
Investigating the remaining ~5-6s per-test cost in CI (with warm prebuild caches),
per-phase span tracing revealed that every trybuild-based test paid ~800ms to
regenerate `__staged.rs` — a syn parse + prettyplease unparse of the entire source
crate — even though the output is identical for every test in a run.

Cache the staged source generation:
- New `write_staged_source_cached` in `compile/trybuild/generate.rs` replaces the
  duplicated gen_staged blocks in `create_graph_trybuild` (deploy/maelstrom) and
  `create_sim_graph_trybuild` (sim). Both call sites now write the example source
  first and then delegate staged generation to the shared helper after
  `create_trybuild()` (the project dir is needed for the cache).
- Cache key: the identity (path, mtime, size) of `std::env::current_exe()`.
  `__staged.rs` is a pure function of the source crate's files, and cargo rebuilds
  the test executable whenever those change, so the exe stamp is a sound freshness
  proxy. All tests in a run share the same executable, so only the first test per
  test binary pays the generation cost (~800ms); the rest skip it entirely (~0ms,
  verified via the new profiling script).
- The stamp file (`<project_dir>/.hydro-staged-stamp`) holds one entry per
  executable so multiple test binaries of the same crate (e.g. hydro_lang's lib
  tests and the sim_fuzzer harness, which nextest interleaves) don't thrash each
  other's cache entries.
- An exclusive file lock is held across the check + generate, so when many test
  processes start concurrently with a cold cache, the first one generates while
  the others block briefly and then hit the cache instead of all burning ~800ms
  of CPU on the (contended) CI runner.
- `write_atomic` still only rewrites `__staged.rs` when content changes, so
  prebuild mtime-based freshness is unaffected.

Expanded instrumentation (target `hydro_build`, opt-in via RUST_LOG as before):
- Spans covering the full per-test pipeline: `sim_compiled` (umbrella),
  `flow_build`, `sim_codegen` / `graph_codegen`, `gen_staged`, `unparse_source`,
  `create_trybuild` (with nested `cargo_metadata`, `write_project_files`,
  `update_lockfile`), `write_generated_sources`, `load_dylib`, and
  `sim_exhaustive`, complementing the existing prebuild / populate_job_dir /
  final_build spans.

Scripts:
- New `scripts/profile_test_phases.sh`: runs selected tests serially under
  nextest with the spans enabled and prints a per-test and aggregate breakdown
  of where the time goes (knobs: PACKAGE, FEATURES, FILTER, LIB_METADATA).
- `scripts/bench_trybuild.sh`: removed the `--nextest` end-to-end mode (subsumed
  by the new profiling script); it is now solely the final-compile replay
  harness for iterating on cargo/rustc flags without rerunning tests. Header
  docs updated to scope the two scripts and cross-reference each other.

Measured breakdown per warm sim test (32-core local machine) after the change:
final_build ~1.3s (now the dominant cost; ~0.45s of it is the linker and ~0.3s
fixed cargo overhead), flow_build 0-200ms, sim_codegen ~50ms, cargo_metadata
~27ms, populate_job_dir ~60ms, load_dylib ~40ms, gen_staged ~0ms (was ~800ms).

Validation: full `cargo nextest run -p hydro_lang --features sim,deploy`
(185 tests) passes; hydro_test sim subset (13 tests) passes; clippy and fmt
clean; bench_trybuild.sh replay path re-verified after the mode removal.