### PR TITLE
fix(hydro_lang): still materialize handoff refs when only captured by for_each closures

### DIFF
--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -1633,21 +1633,32 @@ impl HydroRoot {
 
                 let stmt_id = next_stmt_id.get_and_increment();
 
+                // Emit each captured handoff reference (deduplicated via `built_tees` in the
+                // `HydroNode::Reference` arm), so that references captured *only* by this
+                // `for_each` closure are still materialized. This mirrors how node-level
+                // operators (e.g. `map`) emit their closures' captured references as part of
+                // their bottom-up traversal. This is done in both the Builders and Callback
+                // paths so that statement IDs stay consistent between them.
+                let mut ref_idents = Vec::new();
+                for (ref_node, _is_mut) in f.singleton_refs.iter_mut() {
+                    assert!(
+                        matches!(ref_node, HydroNode::Reference { .. }),
+                        "singleton_refs should only contain HydroNode::Reference"
+                    );
+                    ref_idents.push(ref_node.emit_core(
+                        builders_or_callback,
+                        seen_tees,
+                        built_tees,
+                        next_stmt_id,
+                        fold_hooked_idents,
+                    ));
+                }
+
                 match builders_or_callback {
                     BuildersOrCallback::Builders(graph_builders) => {
-                        let mut ident_stack: Vec<syn::Ident> = Vec::new();
-
-                        // Look up each captured ref's ident from built_tees
-                        for (ref_node, _is_mut) in f.singleton_refs.iter() {
-                            let HydroNode::Reference { inner, .. } = ref_node else {
-                                panic!("singleton_refs should only contain HydroNode::Reference");
-                            };
-                            let ptr = inner.0.as_ref() as *const RefCell<HydroNode>;
-                            let idents = built_tees.get(&ptr).expect(
-                                "ForEach singleton ref not found in built_tees — ref node was not emitted",
-                            );
-                            ident_stack.push(idents[0].clone());
-                        }
+                        // The refs' idents are in `singleton_refs` order, matching what
+                        // `emit_tokens` expects on the ident stack.
+                        let mut ident_stack: Vec<syn::Ident> = ref_idents;
 
                         let f_tokens = f.emit_tokens(&mut ident_stack);
 

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -1631,8 +1631,6 @@ impl HydroRoot {
                     input_ident
                 };
 
-                let stmt_id = next_stmt_id.get_and_increment();
-
                 // Emit each captured handoff reference (deduplicated via `built_tees` in the
                 // `HydroNode::Reference` arm), so that references captured *only* by this
                 // `for_each` closure are still materialized. This mirrors how node-level
@@ -1653,6 +1651,12 @@ impl HydroRoot {
                         fold_hooked_idents,
                     ));
                 }
+
+                // Mint the root's statement ID only after emitting the captured refs, so that
+                // statement IDs follow emission order and (in the Callback path) the callback
+                // observes this root's ID as the most recently allocated one, consistent with
+                // the other `HydroRoot` variants.
+                let stmt_id = next_stmt_id.get_and_increment();
 
                 match builders_or_callback {
                     BuildersOrCallback::Builders(graph_builders) => {

--- a/hydro_lang/src/handoff_ref.rs
+++ b/hydro_lang/src/handoff_ref.rs
@@ -554,23 +554,26 @@ mod tests {
     #[cfg(feature = "deploy")]
     #[test]
     fn singleton_by_ref_for_each_sole_consumer_emits() {
+        use crate::live_collections::sliced::sliced;
         use crate::nondet::nondet;
 
         let mut flow = FlowBuilder::new();
         let node = flow.process::<P1>();
-        let tick = node.tick();
 
-        let my_count = node
-            .source_iter(q!(0..5i32))
-            .batch(&tick, nondet!(/** test */))
-            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
-        let count_ref = my_count.by_ref();
+        let items = node.source_iter(q!(1..=3i32));
 
-        // The for_each closure is the ONLY consumer of `my_count` — no other operator
-        // emits the reference node before this root is processed.
-        node.source_iter(q!(1..=3i32))
-            .batch(&tick, nondet!(/** test */))
-            .for_each(q!(|x| println!("{}", x + *count_ref)));
+        sliced! {
+            let items = use(items, nondet!(/** test */));
+            let my_count = items
+                .location()
+                .source_iter(q!(0..5i32))
+                .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+            let count_ref = my_count.by_ref();
+
+            // The for_each closure is the ONLY consumer of `my_count` — no other operator
+            // emits the reference node before this root is processed.
+            items.for_each(q!(|x| println!("{}", x + *count_ref)));
+        };
 
         let _ = flow
             .finalize()
@@ -584,24 +587,27 @@ mod tests {
     #[cfg(feature = "deploy")]
     #[test]
     fn singleton_by_mut_for_each_sole_consumer_emits() {
+        use crate::live_collections::sliced::sliced;
         use crate::nondet::nondet;
 
         let mut flow = FlowBuilder::new();
         let node = flow.process::<P1>();
-        let tick = node.tick();
 
-        let my_count = node
-            .source_iter(q!(0..5i32))
-            .batch(&tick, nondet!(/** test */))
-            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
-        let count_mut = my_count.by_mut();
+        let items = node.source_iter(q!(1..=3i32));
 
-        // The for_each closure is the ONLY consumer of `my_count`.
-        node.source_iter(q!(1..=3i32))
-            .batch(&tick, nondet!(/** test */))
-            .for_each(q!(|x| {
+        sliced! {
+            let items = use(items, nondet!(/** test */));
+            let my_count = items
+                .location()
+                .source_iter(q!(0..5i32))
+                .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+            let count_mut = my_count.by_mut();
+
+            // The for_each closure is the ONLY consumer of `my_count`.
+            items.for_each(q!(|x| {
                 *count_mut += x;
             }));
+        };
 
         let _ = flow
             .finalize()

--- a/hydro_lang/src/handoff_ref.rs
+++ b/hydro_lang/src/handoff_ref.rs
@@ -543,6 +543,72 @@ mod tests {
         let _built = flow.finalize();
     }
 
+    /// Regression test: a handoff reference whose *only* consumer is a `for_each` closure
+    /// must still be materialized during DFIR emission.
+    ///
+    /// `HydroRoot::ForEach` used to only *look up* captured refs in `built_tees`, assuming
+    /// some node-level operator had already emitted them, and panicked with "ForEach
+    /// singleton ref not found in built_tees" when the `for_each` closure was the sole
+    /// capturer. This test drives the flow through full DFIR emission (which
+    /// `flow.finalize()` alone does not) to cover that path.
+    #[cfg(feature = "deploy")]
+    #[test]
+    fn singleton_by_ref_for_each_sole_consumer_emits() {
+        use crate::nondet::nondet;
+
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<P1>();
+        let tick = node.tick();
+
+        let my_count = node
+            .source_iter(q!(0..5i32))
+            .batch(&tick, nondet!(/** test */))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let count_ref = my_count.by_ref();
+
+        // The for_each closure is the ONLY consumer of `my_count` — no other operator
+        // emits the reference node before this root is processed.
+        node.source_iter(q!(1..=3i32))
+            .batch(&tick, nondet!(/** test */))
+            .for_each(q!(|x| println!("{}", x + *count_ref)));
+
+        let _ = flow
+            .finalize()
+            .with_default_optimize::<crate::deploy::HydroDeploy>()
+            .preview_compile();
+    }
+
+    /// Regression test: same as [`singleton_by_ref_for_each_sole_consumer_emits`], but for
+    /// a mutable reference (`by_mut`) — the common accumulator pattern
+    /// `stream.for_each(q!(|x| *acc_mut += x))`.
+    #[cfg(feature = "deploy")]
+    #[test]
+    fn singleton_by_mut_for_each_sole_consumer_emits() {
+        use crate::nondet::nondet;
+
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<P1>();
+        let tick = node.tick();
+
+        let my_count = node
+            .source_iter(q!(0..5i32))
+            .batch(&tick, nondet!(/** test */))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let count_mut = my_count.by_mut();
+
+        // The for_each closure is the ONLY consumer of `my_count`.
+        node.source_iter(q!(1..=3i32))
+            .batch(&tick, nondet!(/** test */))
+            .for_each(q!(|x| {
+                *count_mut += x;
+            }));
+
+        let _ = flow
+            .finalize()
+            .with_default_optimize::<crate::deploy::HydroDeploy>()
+            .preview_compile();
+    }
+
     /// Compile-only test: singleton by_ref inside scan closures.
     #[test]
     fn singleton_by_ref_scan() {


### PR DESCRIPTION
`HydroRoot::ForEach`'s DFIR emission only *looked up* captured handoff references
(by_ref/by_mut) in `built_tees`, assuming some node-level operator had already
emitted the reference node. When a `for_each` closure was the sole consumer of a
reference — e.g. the common accumulator pattern
`stream.for_each(q!(|x| *acc_mut += x))` — graph compilation panicked with
"ForEach singleton ref not found in built_tees — ref node was not emitted".

This path was never validated end-to-end: the original commit adding for_each
ref-capture support only included compile-only tests that stop at `flow.finalize()`,
which does not emit DFIR.

Fix: `ForEach` now emits each captured `Reference` node via `emit_core`
(deduplicated through `built_tees` by the `Reference` arm), mirroring how
node-level operators (map/filter/etc.) materialize their closures' captured
references during their bottom-up traversal. The emission runs in both the
Builders and Callback paths so statement IDs stay consistent between them.
Statement-ID assignment is unchanged for programs without ref-capturing
for_each (the loop is a no-op when `singleton_refs` is empty).

Tests: added two focused regression tests in handoff_ref.rs
(`singleton_by_ref_for_each_sole_consumer_emits`,
`singleton_by_mut_for_each_sole_consumer_emits`) where the for_each closure is
the only consumer of the reference. They drive the flow through full DFIR
emission via `DeployFlow::preview_compile()` (which `flow.finalize()` alone does
not reach). Both fail with the built_tees panic before the fix and pass after.
The tests use tick-scoped references so they remain valid if top-level bounded
references are later restricted (see #3010).

Verified: full hydro_lang suite 187/187 pass (deploy+sim), clippy clean,
cargo +nightly fmt applied.