### PR TITLE
feat(hydro_lang, hydro_deploy): replay captured rustc commands for final test builds, skipping cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2584,6 +2584,8 @@ name = "hydro_concurrent_cargo"
 version = "0.1.0-alpha.0"
 dependencies = [
  "parking_lot",
+ "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/hydro_concurrent_cargo/Cargo.toml
+++ b/hydro_concurrent_cargo/Cargo.toml
@@ -12,3 +12,5 @@ all-features = true
 
 [dependencies]
 parking_lot = "0.12"
+serde_json = "1"
+tracing = "0.1"

--- a/hydro_concurrent_cargo/src/final_rustc.rs
+++ b/hydro_concurrent_cargo/src/final_rustc.rs
@@ -1,0 +1,435 @@
+//! Capture-and-replay of the final `rustc` invocation for generated example builds.
+//!
+//! The final per-test build compiles a single generated example crate against a fully
+//! prebuilt dependency graph, so the `cargo` invocation wrapping it does no useful work
+//! beyond computing the rustc command line — but costs a fixed ~300ms per invocation
+//! (config/lockfile/fingerprint bookkeeping) plus per-job target dir population and
+//! cross-process cargo locking. Since the command line is identical for every test modulo
+//! a few substitutions (output dir, symbol metadata, crate name/source path, and env
+//! vars), the first cargo build after each prebuild is run with `-v` and the rustc
+//! invocation cargo prints is captured as a *template* with placeholders. All subsequent
+//! builds replay the template with plain rustc.
+//!
+//! Templates are keyed to the prebuild stamp (`features_hash:timestamp`), which changes
+//! whenever the prebuild reruns, so staleness tracking is exactly as strong as the
+//! prebuild's own. Any capture or replay anomaly makes callers fall back to the cargo
+//! path (deleting the template), so this is strictly a fast path.
+
+use std::path::{Path, PathBuf};
+use std::{fs, io};
+
+/// Placeholder for the example's crate name (`-` replaced by `_`).
+pub const TPL_CRATE_NAME: &str = "{{__hydro_crate_name__}}";
+/// Placeholder for the example's source path, relative to the template's cwd.
+pub const TPL_SOURCE_PATH: &str = "{{__hydro_source_path__}}";
+/// Placeholder for the per-test output directory.
+pub const TPL_OUT_DIR: &str = "{{__hydro_out_dir__}}";
+/// Placeholder for the per-test `-C metadata` / `-C extra-filename` value.
+pub const TPL_METADATA: &str = "{{__hydro_metadata__}}";
+
+/// A captured rustc invocation for the final example build, with per-test
+/// values replaced by placeholders.
+pub struct RustcTemplate {
+    /// The prebuild stamp this template was captured under.
+    pub stamp: String,
+    /// The working directory of the rustc invocation (the trybuild project dir).
+    pub cwd: PathBuf,
+    /// argv (program + args), with placeholders for per-test values.
+    pub argv: Vec<String>,
+}
+
+/// The template file path associated with a prebuild lock file.
+pub fn template_path(prebuild_lock_path: &Path) -> PathBuf {
+    let mut path = prebuild_lock_path.as_os_str().to_owned();
+    path.push(".rustc-cmd");
+    PathBuf::from(path)
+}
+
+/// Load the template if it exists and matches the current prebuild stamp.
+pub fn load(path: &Path, expected_stamp: &str) -> Option<RustcTemplate> {
+    let contents = fs::read_to_string(path).ok()?;
+    let mut lines = contents.lines();
+    let stamp = lines.next()?;
+    if stamp != expected_stamp {
+        return None;
+    }
+    let cwd = PathBuf::from(lines.next()?);
+    let argv: Vec<String> = lines.map(str::to_owned).collect();
+    if argv.len() < 2 {
+        return None;
+    }
+    Some(RustcTemplate {
+        stamp: stamp.to_owned(),
+        cwd,
+        argv,
+    })
+}
+
+/// Atomically persist the template (write to a temp file, then rename).
+pub fn store(path: &Path, template: &RustcTemplate) -> io::Result<()> {
+    let mut contents = String::new();
+    contents.push_str(&template.stamp);
+    contents.push('\n');
+    contents.push_str(template.cwd.to_str().ok_or(io::ErrorKind::InvalidData)?);
+    contents.push('\n');
+    for arg in &template.argv {
+        contents.push_str(arg);
+        contents.push('\n');
+    }
+    let tmp = path.with_extension(format!("tmp-{}", std::process::id()));
+    fs::write(&tmp, contents)?;
+    fs::rename(&tmp, path)
+}
+
+/// Extract the rustc invocation for `crate_name` from the stderr of a `cargo ... -v` build.
+///
+/// Cargo's verbose output contains lines like:
+///
+/// ```text
+///      Running `/path/to/rustc --crate-name foo --edition=2024 src/foo.rs ...`
+/// ```
+///
+/// (possibly prefixed by a `RUSTC_WRAPPER` such as sccache). Returns the tokenized argv of
+/// the *last* such line whose `--crate-name` value equals `crate_name`, or `None` if no
+/// matching line is found or the line cannot be tokenized unambiguously.
+pub fn extract_rustc_command(stderr: &str, crate_name: &str) -> Option<Vec<String>> {
+    let mut result = None;
+    for line in stderr.lines() {
+        let Some(start) = line.find("Running `") else {
+            continue;
+        };
+        let rest = &line[start + "Running `".len()..];
+        let Some(end) = rest.rfind('`') else {
+            continue;
+        };
+        let Some(argv) = shell_tokenize(&rest[..end]) else {
+            continue;
+        };
+        let names_crate = argv
+            .iter()
+            .zip(argv.iter().skip(1))
+            .any(|(flag, value)| flag == "--crate-name" && value == crate_name);
+        if names_crate {
+            result = Some(argv);
+        }
+    }
+    result
+}
+
+/// Tokenize a shell-escaped command line (as printed by cargo's verbose output) into argv.
+///
+/// Handles POSIX single quotes (used by cargo on unix), double quotes (used on windows),
+/// and backslash escapes outside single quotes. Returns `None` on unbalanced quotes so
+/// callers can fall back rather than misparse.
+fn shell_tokenize(line: &str) -> Option<Vec<String>> {
+    let mut argv = Vec::new();
+    let mut cur = String::new();
+    let mut in_token = false;
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            ' ' | '\t' => {
+                if in_token {
+                    argv.push(std::mem::take(&mut cur));
+                    in_token = false;
+                }
+            }
+            '\'' => {
+                in_token = true;
+                loop {
+                    match chars.next() {
+                        Some('\'') => break,
+                        Some(c) => cur.push(c),
+                        None => return None,
+                    }
+                }
+            }
+            '"' => {
+                in_token = true;
+                loop {
+                    match chars.next() {
+                        Some('"') => break,
+                        Some('\\') => {
+                            // Only `\"` is an escape inside double quotes (Windows-style
+                            // quoting); a lone backslash (e.g. in paths) is literal.
+                            if chars.peek() == Some(&'"') {
+                                cur.push(chars.next()?);
+                            } else {
+                                cur.push('\\');
+                            }
+                        }
+                        Some(c) => cur.push(c),
+                        None => return None,
+                    }
+                }
+            }
+            '\\' => {
+                in_token = true;
+                cur.push(chars.next()?);
+            }
+            c => {
+                in_token = true;
+                cur.push(c);
+            }
+        }
+    }
+    if in_token {
+        argv.push(cur);
+    }
+    Some(argv)
+}
+
+/// Turn a captured rustc argv into a reusable template by replacing the
+/// per-test values with placeholders and redirecting the per-job target dir
+/// paths (whose `deps`/`.fingerprint`/`build` entries are symlinks into the
+/// shared target dir) to the shared target dir itself.
+///
+/// Returns `None` (no template; callers keep using cargo) unless every
+/// expected substitution is found exactly once and nothing suspicious
+/// (incremental compilation, leftover job-dir paths, embedded newlines)
+/// remains.
+pub fn build_template(
+    argv: Vec<String>,
+    crate_name: &str,
+    example_name: &str,
+    job_target_dir: &Path,
+    shared_target_dir: &Path,
+) -> Option<Vec<String>> {
+    let job_str = job_target_dir.to_str()?;
+    let shared_str = shared_target_dir.to_str()?;
+    let source_suffixes = [
+        format!("examples/{example_name}.rs"),
+        format!("examples\\{example_name}.rs"),
+    ];
+
+    let (mut saw_crate_name, mut saw_source, mut saw_out_dir) = (0u32, 0u32, 0u32);
+    let (mut saw_metadata, mut saw_extra_filename) = (0u32, 0u32);
+
+    let mut out = Vec::with_capacity(argv.len());
+    let mut prev: Option<&str> = None;
+    for arg in &argv {
+        if arg.contains('\n') || arg.contains("incremental") {
+            return None;
+        }
+        let templated = if prev == Some("--crate-name") {
+            if arg != crate_name {
+                return None;
+            }
+            saw_crate_name += 1;
+            TPL_CRATE_NAME.to_owned()
+        } else if prev == Some("--out-dir") {
+            saw_out_dir += 1;
+            TPL_OUT_DIR.to_owned()
+        } else if source_suffixes.iter().any(|s| arg.ends_with(&**s)) {
+            saw_source += 1;
+            TPL_SOURCE_PATH.to_owned()
+        } else if prev == Some("-C") && arg.starts_with("metadata=") {
+            saw_metadata += 1;
+            format!("metadata={TPL_METADATA}")
+        } else if prev == Some("-C") && arg.starts_with("extra-filename=") {
+            saw_extra_filename += 1;
+            format!("extra-filename=-{TPL_METADATA}")
+        } else {
+            arg.replace(job_str, shared_str)
+        };
+        if templated.contains(job_str) {
+            return None;
+        }
+        out.push(templated);
+        prev = Some(arg);
+    }
+
+    ([
+        saw_crate_name,
+        saw_source,
+        saw_out_dir,
+        saw_metadata,
+        saw_extra_filename,
+    ] == [1; 5])
+        .then_some(out)
+}
+
+/// Per-test substitutions applied to a template at replay time.
+pub struct ReplayParams<'a> {
+    /// The example's crate name (`-` replaced by `_`).
+    pub crate_name: &'a str,
+    /// The example's source path, relative to the template's cwd.
+    pub source_path: &'a str,
+    /// Directory to place the built artifact in (per-test).
+    pub out_dir: &'a Path,
+    /// Unique `-C metadata` / `-C extra-filename` value (disambiguates symbols
+    /// when multiple compiled examples are loaded into one process).
+    pub metadata: &'a str,
+    /// Extra environment variables (e.g. `TRYBUILD_LIB_NAME`).
+    pub envs: Vec<(String, std::ffi::OsString)>,
+}
+
+/// Replay a captured template with per-test substitutions. Returns the path to
+/// the linked artifact on success; on any failure returns a description (the
+/// caller falls back to the cargo path, which reports errors with full fidelity).
+pub fn replay(template: &RustcTemplate, params: ReplayParams<'_>) -> Result<PathBuf, String> {
+    use std::process::{Command, Stdio};
+
+    if !template.cwd.join(params.source_path).exists() {
+        return Err(format!(
+            "example source {} not found under {}",
+            params.source_path,
+            template.cwd.display()
+        ));
+    }
+    fs::create_dir_all(params.out_dir).map_err(|e| e.to_string())?;
+    let out_dir_str = params.out_dir.to_str().ok_or("non-utf8 out dir")?;
+
+    let substituted: Vec<String> = template
+        .argv
+        .iter()
+        .map(|arg| {
+            arg.replace(TPL_CRATE_NAME, params.crate_name)
+                .replace(TPL_SOURCE_PATH, params.source_path)
+                .replace(TPL_OUT_DIR, out_dir_str)
+                .replace(TPL_METADATA, params.metadata)
+        })
+        .collect();
+
+    let mut command = Command::new(&substituted[0]);
+    command.args(&substituted[1..]);
+    command.current_dir(&template.cwd);
+    for (key, value) in &params.envs {
+        command.env(key, value);
+    }
+
+    tracing::debug!(
+        target: "hydro_build",
+        "final rustc command (cwd={}): {:?}",
+        template.cwd.display(),
+        command
+    );
+
+    let output = command
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|e| format!("failed to spawn rustc: {e}"))?;
+
+    // rustc emits JSON messages (diagnostics + artifact notifications) on stderr.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let mut artifact = None;
+    let mut rendered_diagnostics = Vec::new();
+    for line in stderr.lines() {
+        let Ok(msg) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        match msg.get("$message_type").and_then(|t| t.as_str()) {
+            Some("artifact") => {
+                if msg.get("emit").and_then(|e| e.as_str()) == Some("link") {
+                    artifact = msg
+                        .get("artifact")
+                        .and_then(|a| a.as_str())
+                        .map(PathBuf::from);
+                }
+            }
+            Some("diagnostic") => {
+                if let Some(rendered) = msg.get("rendered").and_then(|r| r.as_str()) {
+                    rendered_diagnostics.push(rendered.to_owned());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if !output.status.success() {
+        return Err(format!(
+            "rustc exited with {}:\n{}",
+            output.status,
+            rendered_diagnostics.join("\n")
+        ));
+    }
+    // Surface warnings just like the cargo path does.
+    for rendered in &rendered_diagnostics {
+        eprint!("{rendered}");
+    }
+    artifact.ok_or_else(|| "rustc succeeded but emitted no linked artifact".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_shell_tokenize() {
+        assert_eq!(
+            shell_tokenize(r#"rustc --cfg 'feature="build"' --emit=link"#).unwrap(),
+            vec!["rustc", "--cfg", r#"feature="build""#, "--emit=link"]
+        );
+        assert_eq!(
+            shell_tokenize(r#""C:\path with space\rustc" --crate-name foo"#).unwrap(),
+            vec![r"C:\path with space\rustc", "--crate-name", "foo"]
+        );
+        assert_eq!(shell_tokenize("unbalanced 'quote"), None);
+    }
+
+    #[test]
+    fn test_extract_rustc_command() {
+        let stderr = "   Compiling foo v0.1.0\n     Running `/usr/bin/rustc --crate-name foo --edition=2024 src/lib.rs`\n     Running `/usr/bin/rustc --crate-name bar --edition=2024 examples/bar.rs --cfg 'feature=\"x\"'`\n    Finished dev\n";
+        assert_eq!(
+            extract_rustc_command(stderr, "bar").unwrap(),
+            vec![
+                "/usr/bin/rustc",
+                "--crate-name",
+                "bar",
+                "--edition=2024",
+                "examples/bar.rs",
+                "--cfg",
+                r#"feature="x""#
+            ]
+        );
+        assert_eq!(extract_rustc_command(stderr, "baz"), None);
+    }
+
+    #[test]
+    fn test_build_template_and_roundtrip() {
+        let job = Path::new("/t/jobs/ABCD1234");
+        let shared = Path::new("/t");
+        let argv: Vec<String> = [
+            "/wrap/sccache",
+            "/bin/rustc",
+            "--crate-name",
+            "sim_dylib",
+            "--edition=2024",
+            "dylib-examples/examples/sim-dylib.rs",
+            "--crate-type",
+            "cdylib",
+            "--emit=dep-info,link",
+            "-C",
+            "metadata=69bac1f35c17e10b",
+            "-C",
+            "extra-filename=-036b96e057adb47a",
+            "--out-dir",
+            "/t/jobs/ABCD1234/debug/examples",
+            "-L",
+            "dependency=/t/jobs/ABCD1234/debug/deps",
+            "--extern",
+            "dep=/t/jobs/ABCD1234/debug/deps/libdep.so",
+            "-Clink-arg=-Wl,-rpath,/t/jobs/ABCD1234/debug",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
+
+        let template = build_template(argv.clone(), "sim_dylib", "sim-dylib", job, shared).unwrap();
+        assert_eq!(template[2..4], ["--crate-name", TPL_CRATE_NAME]);
+        assert_eq!(template[5], TPL_SOURCE_PATH);
+        assert_eq!(template[10], format!("metadata={TPL_METADATA}"));
+        assert_eq!(template[12], format!("extra-filename=-{TPL_METADATA}"));
+        assert_eq!(template[14], TPL_OUT_DIR);
+        assert_eq!(template[16], "dependency=/t/debug/deps");
+        assert_eq!(template[18], "dep=/t/debug/deps/libdep.so");
+        assert_eq!(template[19], "-Clink-arg=-Wl,-rpath,/t/debug");
+
+        // A mismatched crate name must not produce a template.
+        assert!(build_template(argv.clone(), "other", "sim-dylib", job, shared).is_none());
+        // Incremental compilation args must not produce a template.
+        let mut with_incr = argv.clone();
+        with_incr.push("-Cincremental=/t/incr".to_owned());
+        assert!(build_template(with_incr, "sim_dylib", "sim-dylib", job, shared).is_none());
+    }
+}

--- a/hydro_concurrent_cargo/src/lib.rs
+++ b/hydro_concurrent_cargo/src/lib.rs
@@ -4,6 +4,8 @@
 //! builds concurrently against a shared target directory using per-job symlinked
 //! directories.
 
+pub mod final_rustc;
+
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write as _;
@@ -99,6 +101,7 @@ pub struct PrebuildGuard {
     _global_file: Option<fs::File>,
     _file: fs::File,
     lock_dir: PathBuf,
+    lock_path: PathBuf,
 }
 
 #[expect(
@@ -131,6 +134,7 @@ impl PrebuildGuard {
             _global_file: None,
             _file: file,
             lock_dir,
+            lock_path: lock_path.to_owned(),
         }
     }
 
@@ -160,6 +164,7 @@ impl PrebuildGuard {
             _global_file: Some(global_file),
             _file: file,
             lock_dir: self.lock_dir,
+            lock_path: self.lock_path,
         }
     }
 
@@ -180,12 +185,32 @@ impl PrebuildGuard {
             _global_file: None,
             _file: file,
             lock_dir: self.lock_dir,
+            lock_path: self.lock_path,
         }
     }
 
     /// Get mutable access to the underlying file (for writing timestamps).
     pub fn file_mut(&mut self) -> &mut fs::File {
         &mut self._file
+    }
+
+    /// The path of the prebuild lock/stamp file this guard holds.
+    pub fn lock_path(&self) -> &Path {
+        &self.lock_path
+    }
+
+    /// Read the current prebuild stamp (`features_hash:timestamp`) from the lock file.
+    ///
+    /// The stamp changes every time the prebuild is (re)run, so it can be used as a
+    /// freshness key for artifacts derived from a particular prebuild (e.g. captured
+    /// rustc command templates). Must be called while the guard is held.
+    pub fn read_stamp(&mut self) -> String {
+        use std::io::{Read, Seek};
+        let file = &mut self._file;
+        file.seek(std::io::SeekFrom::Start(0)).unwrap();
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).unwrap();
+        contents.trim().to_owned()
     }
 }
 
@@ -245,6 +270,28 @@ pub fn symlink_prebuild_build_dir(prebuild_target: &Path, shared_debug: &Path) {
 pub struct JobBuildGuard {
     _mutex_guard: std::sync::MutexGuard<'static, ()>,
     _file: fs::File,
+}
+
+/// Acquire the per-job lock (in-process mutex + cross-process file lock) for a job
+/// directory, without populating anything. Used by the direct-rustc replay path, which
+/// doesn't need the symlinked cargo target dir but still must serialize concurrent
+/// builds of the same job (e.g. two tests compiling an identical flow).
+pub fn lock_job_dir(jobs_dir: &Path, name: &str) -> JobBuildGuard {
+    let job_dir = jobs_dir.join(name);
+    let mutex_guard = get_job_dir_lock(&job_dir).lock().unwrap();
+    fs::create_dir_all(&job_dir).unwrap();
+    let job_lock_file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(job_dir.join(".job.lock"))
+        .unwrap();
+    job_lock_file.lock().unwrap();
+    JobBuildGuard {
+        _mutex_guard: mutex_guard,
+        _file: job_lock_file,
+    }
 }
 
 /// Populate the per-job build/ directory from the shared build/ directory.

--- a/hydro_deploy/core/src/rust_crate/build.rs
+++ b/hydro_deploy/core/src/rust_crate/build.rs
@@ -6,6 +6,7 @@ use std::process::{Command, ExitStatus, Stdio};
 use std::sync::OnceLock;
 
 use cargo_metadata::diagnostic::Diagnostic;
+use hydro_concurrent_cargo::final_rustc;
 use memo_map::MemoMap;
 use tokio::sync::OnceCell;
 
@@ -136,7 +137,7 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
 
                     // Only use prebuild + per-job target dirs for dylib mode.
                     // Without dylib, build directly into the base target dir.
-                    let (per_job_target_dir, _prebuild_guard, _cargo_lock) = if params.is_dylib {
+                    let (per_job_target_dir, mut prebuild_guard, _cargo_lock) = if params.is_dylib {
                         let shared_debug = base_target_dir.join("debug");
                         let jobs_dir = base_target_dir.join("jobs");
                         let per_job = hydro_concurrent_cargo::setup_job_dir(&jobs_dir, job_name, &shared_debug);
@@ -223,6 +224,106 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
 
                     hydro_concurrent_cargo::log_build_event(&base_target_dir, "deploy: starting final build");
 
+                    // Fast path: replay the rustc invocation captured from a previous cargo
+                    // final build against this same prebuild, skipping cargo entirely (see
+                    // `hydro_concurrent_cargo::final_rustc`). Only for local dylib example
+                    // builds with default profile/rustflags — the same conditions under
+                    // which deploy_graph enables dynamic linking for trybuild crates.
+                    let use_final_rustc_template = params.is_dylib
+                        && params.example.is_some()
+                        && params.profile.is_none()
+                        && params.rustflags.is_none()
+                        && matches!(params.target_type, HostTargetType::Local);
+
+                    let (prebuild_stamp, template_path) = if use_final_rustc_template {
+                        let guard = prebuild_guard.as_mut().unwrap();
+                        (
+                            Some(guard.read_stamp()),
+                            Some(final_rustc::template_path(guard.lock_path())),
+                        )
+                    } else {
+                        (None, None)
+                    };
+
+                    let example_crate_name = params.example.as_deref().map(|e| e.replace('-', "_"));
+                    let example_source_path = params.example.as_deref().map(|example| {
+                        format!(
+                            "{}/examples/{}.rs",
+                            params
+                                .src
+                                .strip_prefix(&params.workspace_root)
+                                .ok()
+                                .and_then(|p| p.to_str())
+                                .unwrap_or_default(),
+                            example
+                        )
+                        .trim_start_matches('/')
+                        .to_owned()
+                    });
+
+                    if let (Some(stamp), Some(template_path)) = (&prebuild_stamp, &template_path)
+                        && let Some(template) = final_rustc::load(template_path, stamp)
+                    {
+                        // Serialize concurrent builds of the same job without populating the
+                        // per-job cargo target dir.
+                        let jobs_dir = base_target_dir.join("jobs");
+                        let _job_guard = hydro_concurrent_cargo::lock_job_dir(&jobs_dir, job_name);
+
+                        // Unique symbol metadata per example (multiple built examples may be
+                        // loaded/run side by side).
+                        let metadata = format!("{}", blake3::hash(job_name.as_bytes()).to_hex())
+                            .chars()
+                            .take(16)
+                            .collect::<String>();
+
+                        let mut envs: Vec<(String, std::ffi::OsString)> = params
+                            .build_env
+                            .iter()
+                            .map(|(k, v)| (k.clone(), std::ffi::OsString::from(v)))
+                            .collect();
+                        // Override the cargo-set vars inherited from the *test binary's* build
+                        // so compile-time env lookups in the example see its own crate.
+                        envs.push((
+                            "CARGO_MANIFEST_DIR".to_owned(),
+                            params.src.clone().into_os_string(),
+                        ));
+                        envs.push((
+                            "CARGO_CRATE_NAME".to_owned(),
+                            std::ffi::OsString::from(example_crate_name.as_deref().unwrap()),
+                        ));
+
+                        let replayed = final_rustc::replay(
+                            &template,
+                            final_rustc::ReplayParams {
+                                crate_name: example_crate_name.as_deref().unwrap(),
+                                source_path: example_source_path.as_deref().unwrap(),
+                                out_dir: &jobs_dir.join(job_name).join("out"),
+                                metadata: &metadata,
+                                envs,
+                            },
+                        );
+
+                        match replayed {
+                            Ok(artifact) => {
+                                let data = std::fs::read(&artifact).unwrap();
+                                return Ok(BuildOutput {
+                                    bin_data: data,
+                                    bin_path: artifact,
+                                    shared_library_path: Some(
+                                        base_target_dir.join("debug").join("deps"),
+                                    ),
+                                });
+                            }
+                            Err(message) => {
+                                hydro_concurrent_cargo::log_build_event(
+                                    &base_target_dir,
+                                    &format!("deploy: final rustc replay failed, falling back to cargo: {message}"),
+                                );
+                                let _ = std::fs::remove_file(template_path);
+                            }
+                        }
+                    }
+
                     // Populate per-job build/ dir. Hold guard for entire final build.
                     let _job_build_guard = if params.is_dylib {
                         let shared_debug = base_target_dir.join("debug");
@@ -233,6 +334,9 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
 
                     let mut command = Command::new("cargo");
                     command.args(["build", if params.is_dylib { "--frozen" } else { "--locked" }]);
+                    // Verbose output includes the exact rustc invocation, which we capture as
+                    // a template so subsequent builds can replay it without cargo.
+                    command.arg("-v");
 
                     if let Some(profile) = params.profile.as_ref() {
                         command.args(["--profile", profile]);
@@ -335,6 +439,32 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
                                     }
 
                                     assert!(exit_status.success(), "deploy final build failed:\n{}", stderr_lines.join("\n"));
+
+                                    // Capture the rustc invocation cargo just used as a replay
+                                    // template for subsequent final builds against this prebuild.
+                                    if let (Some(stamp), Some(template_path)) =
+                                        (&prebuild_stamp, &template_path)
+                                        && let Some(argv) = final_rustc::extract_rustc_command(
+                                            &stderr_lines.join("\n"),
+                                            example_crate_name.as_deref().unwrap(),
+                                        )
+                                        && let Some(argv) = final_rustc::build_template(
+                                            argv,
+                                            example_crate_name.as_deref().unwrap(),
+                                            params.example.as_deref().unwrap(),
+                                            &per_job_target_dir,
+                                            &base_target_dir,
+                                        )
+                                    {
+                                        let _ = final_rustc::store(
+                                            template_path,
+                                            &final_rustc::RustcTemplate {
+                                                stamp: stamp.clone(),
+                                                cwd: params.workspace_root.clone(),
+                                                argv,
+                                            },
+                                        );
+                                    }
 
                                     return Ok(BuildOutput {
                                         bin_data: data,

--- a/hydro_lang/src/compile/trybuild/generate.rs
+++ b/hydro_lang/src/compile/trybuild/generate.rs
@@ -6,6 +6,8 @@ use std::path::{Path, PathBuf};
 use dfir_lang::diagnostic::Diagnostics;
 #[cfg(any(feature = "deploy", feature = "maelstrom"))]
 use dfir_lang::graph::DfirGraph;
+#[cfg(any(feature = "sim", feature = "maelstrom"))]
+use hydro_concurrent_cargo::final_rustc;
 use sha2::{Digest, Sha256};
 #[cfg(any(feature = "deploy", feature = "maelstrom"))]
 use stageleft::internal::quote;
@@ -379,6 +381,12 @@ fn rustc_target_libdir() -> Option<String> {
 /// using the shared parallel-compilation machinery (per-job target dirs with
 /// symlinked shared artifacts, plus a prebuild of the dylib dependencies).
 ///
+/// The first build after a prebuild goes through `cargo rustc` and captures the exact
+/// rustc invocation cargo issues for the example (see [`build_rustc_template`]). Later
+/// builds replay that invocation directly with per-test substitutions, skipping cargo's
+/// fixed per-invocation overhead (lockfile/fingerprint work, target-dir locking) and the
+/// per-job target dir population entirely.
+///
 /// Returns the path to a temporary copy of the built artifact (a `cdylib` for
 /// the simulator, or an executable for Maelstrom). The copy allows the caller
 /// to hold onto the artifact independently of the shared target directory.
@@ -408,12 +416,9 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
         path!(trybuild.project_dir / "dylib-examples")
     };
 
-    let (final_target_dir, _prebuild_guard, _cargo_lock) = if !has_custom_rustflags {
+    let (mut prebuild_guard, _cargo_lock) = if !has_custom_rustflags {
         let prebuild_span =
             tracing::debug_span!(target: "hydro_build", "prebuild", bin_name = %bin_name).entered();
-        let shared_debug = trybuild.target_dir.join("debug");
-        let jobs_dir = trybuild.target_dir.join("jobs");
-        let per_job = hydro_concurrent_cargo::setup_job_dir(&jobs_dir, &bin_name, &shared_debug);
 
         let mut features: Vec<String> = trybuild.features.clone().unwrap_or_default();
         features.push(runtime_feature.to_owned());
@@ -471,9 +476,116 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
         // entire final build, but the prebuild phase (freshness check + possible dep build)
         // ends here.
         drop(prebuild_span);
-        (per_job, Some(guard), Some(cargo_lock))
+        (Some(guard), Some(cargo_lock))
     } else {
-        (trybuild.target_dir.clone(), None, None)
+        (None, None)
+    };
+
+    // The crate name and (cwd-relative) source path of the example to compile, as cargo
+    // passes them to rustc. rustc runs from the compiled crate's *workspace* root, which
+    // for both the dylib-examples crate and the base trybuild crate is the project dir.
+    let example_crate_name = example_name.replace('-', "_");
+    let example_source_path = format!(
+        "{}/examples/{}.rs",
+        crate_to_compile
+            .strip_prefix(&trybuild.project_dir)
+            .ok()
+            .and_then(|p| p.to_str())
+            .unwrap_or_default(),
+        example_name
+    )
+    .trim_start_matches('/')
+    .to_owned();
+
+    // Fast path: replay the rustc invocation captured from a previous cargo final build
+    // against this same prebuild, skipping cargo entirely (see the `final_rustc` module
+    // in `hydro_concurrent_cargo`). Skipped in fuzz mode, which uses a different crate
+    // layout and extra linker flags.
+    let (prebuild_stamp, template_path) = match (&mut prebuild_guard, is_fuzz) {
+        (Some(guard), false) => (
+            Some(guard.read_stamp()),
+            Some(final_rustc::template_path(guard.lock_path())),
+        ),
+        _ => (None, None),
+    };
+
+    if let (Some(stamp), Some(template_path)) = (&prebuild_stamp, &template_path)
+        && let Some(template) = final_rustc::load(template_path, stamp)
+    {
+        // Serialize concurrent builds of the same job (e.g. two tests compiling an
+        // identical flow) without populating the per-job cargo target dir.
+        let jobs_dir = trybuild.target_dir.join("jobs");
+        let _job_guard = hydro_concurrent_cargo::lock_job_dir(&jobs_dir, &bin_name);
+
+        let final_rustc_span =
+            tracing::debug_span!(target: "hydro_build", "final_rustc", bin_name = %bin_name)
+                .entered();
+
+        // Unique symbol metadata per (test, runtime feature): multiple compiled examples
+        // can be dlopen'ed into a single process, so their symbol hashes must differ.
+        let metadata = format!(
+            "{:X}",
+            Sha256::digest(format!("{bin_name}\t{runtime_feature}"))
+        )
+        .chars()
+        .take(16)
+        .collect::<String>();
+
+        let mut envs = vec![(
+            "STAGELEFT_TRYBUILD_BUILD_STAGED".to_owned(),
+            std::ffi::OsString::from("1"),
+        )];
+        // Override the cargo-set vars inherited from the *test binary's* build so
+        // compile-time env lookups in the example see its own crate, not ours.
+        envs.push((
+            "CARGO_MANIFEST_DIR".to_owned(),
+            crate_to_compile.clone().into_os_string(),
+        ));
+        envs.push((
+            "CARGO_CRATE_NAME".to_owned(),
+            std::ffi::OsString::from(&example_crate_name),
+        ));
+        if set_trybuild_lib_name {
+            envs.push((
+                "TRYBUILD_LIB_NAME".to_owned(),
+                std::ffi::OsString::from(&bin_name),
+            ));
+        }
+
+        let replayed = final_rustc::replay(
+            &template,
+            final_rustc::ReplayParams {
+                crate_name: &example_crate_name,
+                source_path: &example_source_path,
+                out_dir: &path!(jobs_dir / bin_name / "out"),
+                metadata: &metadata,
+                envs,
+            },
+        );
+        drop(final_rustc_span);
+
+        match replayed {
+            Ok(artifact) => {
+                let out_file = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+                fs::copy(&artifact, &out_file).unwrap();
+                return Ok(out_file);
+            }
+            Err(message) => {
+                tracing::debug!(
+                    target: "hydro_build",
+                    "final rustc replay failed, falling back to cargo: {message}"
+                );
+                let _ = fs::remove_file(template_path);
+            }
+        }
+    }
+
+    let final_target_dir = if !has_custom_rustflags {
+        let shared_debug = trybuild.target_dir.join("debug");
+        let jobs_dir = trybuild.target_dir.join("jobs");
+        hydro_concurrent_cargo::setup_job_dir(&jobs_dir, &bin_name, &shared_debug)
+    } else {
+        trybuild.target_dir.clone()
     };
 
     // Populate per-job build/ dir right before final build. Hold guard for entire build.
@@ -505,6 +617,9 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
         } else {
             "--frozen"
         },
+        // Verbose output includes the exact rustc invocation, which we capture as a
+        // template so subsequent builds can replay it without cargo (see `final_rustc`).
+        "-v",
     ]);
     command.args(["--example", &example_name]);
     command.args(["--target-dir", final_target_dir.to_str().unwrap()]);
@@ -673,6 +788,28 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
 
     if out.is_err() {
         panic!("final build failed to produce binary.\nstderr:\n{stderr_output}");
+    }
+
+    // Capture the rustc invocation cargo just used as a replay template for subsequent
+    // final builds against this same prebuild.
+    if let (Some(stamp), Some(template_path)) = (&prebuild_stamp, &template_path)
+        && let Some(argv) = final_rustc::extract_rustc_command(&stderr_output, &example_crate_name)
+        && let Some(argv) = final_rustc::build_template(
+            argv,
+            &example_crate_name,
+            &example_name,
+            &final_target_dir,
+            &trybuild.target_dir,
+        )
+    {
+        let _ = final_rustc::store(
+            template_path,
+            &final_rustc::RustcTemplate {
+                stamp: stamp.clone(),
+                cwd: trybuild.project_dir.clone(),
+                argv,
+            },
+        );
     }
 
     let out_file = tempfile::NamedTempFile::new().unwrap().into_temp_path();

--- a/scripts/bench_trybuild.sh
+++ b/scripts/bench_trybuild.sh
@@ -9,6 +9,11 @@
 # generated example is the dominant remaining per-test cost. This script measures exactly that
 # step so we can iterate on flags / linking strategies without rerunning the tests themselves.
 #
+# Note: in the steady state only the *first* final build after a prebuild goes through cargo;
+# subsequent tests replay the captured rustc invocation directly (see the `final_rustc` module
+# in hydro_concurrent_cargo). This script measures the cargo variant, which is also where the
+# rustc command template gets captured from.
+#
 # For a breakdown of *all* per-test phases (staged codegen, cargo metadata, prebuild, final
 # build, sim execution, ...), use scripts/profile_test_phases.sh instead.
 #
@@ -107,6 +112,9 @@ touch_examples() {
     for d in "$TARGET_DIR"/hydro_trybuild/*/dylib-examples/examples "$TARGET_DIR"/hydro_trybuild/*/examples; do
         [[ -d "$d" ]] && find "$d" -name '*.rs' -exec touch {} + || true
     done
+    # Remove captured rustc templates so tests take the cargo path (which logs the
+    # "final build command" lines this script replays) instead of direct-rustc replay.
+    rm -f "$TARGET_DIR"/.prebuild*.lock.rustc-cmd
 }
 
 strip_ansi() {

--- a/scripts/profile_test_phases.sh
+++ b/scripts/profile_test_phases.sh
@@ -18,8 +18,11 @@
 #   update_lockfile     Cargo.lock regen (only when manifests change)
 #   write_generated_sources  writing the example + __staged.rs
 #   prebuild            freshness check (+ dep build when stale)
-#   populate_job_dir    symlinking the per-job build dir
-#   final_build         the final `cargo rustc` of the generated example
+#   populate_job_dir    symlinking the per-job build dir (cargo-path builds only)
+#   final_build         the final `cargo rustc` of the generated example (first build after
+#                       a prebuild; captures a rustc command template)
+#   final_rustc         direct rustc replay of the captured template (all later builds;
+#                       skips cargo and the per-job dir population entirely)
 #   load_dylib          dlopen of the built cdylib
 #   sim_compiled        total of all of the above (sim only)
 #   sim_exhaustive      running the exhaustive simulation itself


### PR DESCRIPTION
Continuing the per-test CI cost investigation: with warm caches, per-phase
profiling showed the final `cargo rustc` of each generated example dominating at
~1.35s of a ~1.8s test (serial, 32-core). Decomposition of that 1.35s:
~320ms fixed cargo overhead (a no-op `cargo rustc` with nothing dirty),
~180ms rustc frontend, ~240ms codegen, ~430ms link (already on rust-lld),
plus ~30ms per-job build-dir population and cargo's cross-process target-dir
locking (a likely contention source under nextest parallelism in CI that serial
profiling doesn't even see). sccache can't help: the example links a dylib, so
the compile is never cacheable.

Since every final build against a given prebuild runs an identical rustc
command modulo a few per-test values, capture it once and replay it directly:

- New `hydro_concurrent_cargo::final_rustc` module (shared so both hydro_lang
  and hydro_deploy use it): the first final build after a prebuild runs cargo
  with `-v`, and the printed rustc invocation is parsed (shell-tokenizer
  handling cargo's unix/windows quoting), validated, and stored as a template
  with placeholders for the per-test values: crate name, source path, out dir,
  and `-C metadata`/`-C extra-filename` (unique per test so multiple dlopen'ed
  cdylibs don't collide). Per-job target dir paths are rewritten to the shared
  target dir (their deps/.fingerprint/build entries are symlinks into it
  anyway). Templates live next to the prebuild lock file and are keyed to the
  prebuild stamp (`features_hash:timestamp`), so any prebuild rerun invalidates
  them — staleness tracking is exactly as strong as the prebuild's own.
- Replay invokes rustc directly (no cargo): substitutes the per-test values,
  parses rustc's `--json=artifacts` stderr for the linked artifact, and
  surfaces rendered diagnostics. Any anomaly (parse failure, missing files,
  compile error) deletes the template and falls back to the unchanged cargo
  path, which remains the source of truth for command construction and error
  reporting.
- Replay still takes the per-job lock via new
  `hydro_concurrent_cargo::lock_job_dir` (serializing concurrent builds of an
  identical flow) but skips job-dir population entirely; no cargo also means
  no cargo target-dir lock contention. New `PrebuildGuard::read_stamp()` /
  `lock_path()` expose the stamp for template keying.
- `hydro_lang::compile_trybuild_example` (sim + maelstrom tests): replay is
  used for all non-fuzz builds; fuzz mode keeps the cargo path (different
  crate layout + linker flags).
- `hydro_deploy` `build_crate_memoized` (localhost deploy tests): replay is
  used for local dylib example builds with default profile/rustflags — the
  same conditions under which deploy_graph enables dynamic linking; the
  replayed artifact keeps `shared_library_path` pointing at the shared
  `debug/deps`.

Measured (32-core local, serial, warm): sim test mean 1814ms -> 1391ms (-23%);
final compile phase 1347ms (`final_build`) -> 954ms (`final_rustc`), and
populate_job_dir (~30ms) disappears from the steady state. The cargo capture
build itself is unchanged in cost and happens once per prebuild per feature
set. Full `hydro_lang` suite (188 tests incl. sim_fuzzer) and `hydro_test`
localhost deploy suite (18 tests) pass, with all steady-state builds confirmed
replaying; clippy and fmt clean.

Scripts updated: profile_test_phases.sh documents the new `final_rustc` phase;
bench_trybuild.sh removes captured templates when touching examples so its
warm phase still exercises (and measures) the cargo capture path.

Considered and rejected for now: deriving the rustc command from the prebuild's
lib invocation (the example target differs in crate-type/emit/externs/link
args, so it would mean reimplementing cargo's argv construction) and
constructing the command from first principles (fragile against profile
settings like `debug = "line-tables-only"` that trybuild copies into the
generated workspace). Remaining per-test costs, in case of follow-up: ~430ms
link + ~240ms codegen (biggest lever: `-Zlink-native-libraries=no` saved
~175ms but is nightly-only), ~180ms flow_build, ~65ms sim_codegen, ~26ms
cargo_metadata.