### PR TITLE
fix(dfir_lang): order loop-ingress senders before the whole loop block, fix #3048

### DIFF
--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -11,7 +11,7 @@ use super::{
     Color, GraphEdgeId, GraphLoopId, GraphNode, GraphNodeId, GraphSubgraphId, HandoffKind,
 };
 use crate::diagnostic::{Diagnostic, Level};
-use crate::graph::graph_algorithms::SubgraphMerge;
+use crate::graph::graph_algorithms::{SubgraphMerge, validate_topo_sort};
 
 /// Find edge barriers: edges whose destination operator declares an input delay type.
 ///
@@ -120,6 +120,7 @@ fn find_subgraph_unionfind(
     }
 
     // Loop-ingress ordering constraints.
+    // Fix https://github.com/hydro-project/hydro/issues/3048
     //
     // `make_loops_contiguous` (run later) gathers *all* of a loop's subgraphs to the
     // flat-order position of the loop's *first* subgraph. That is only sound if every
@@ -130,51 +131,23 @@ fn find_subgraph_unionfind(
     //
     // To guarantee this, we require: for each forward (non-tick) edge `src -> dst` where
     // `dst` lies inside a loop that does not contain `src`, `src` must precede *every*
-    // node inside the outermost such loop (i.e. the whole top-level loop block that will
-    // be gathered). If the loop also has a dependency running the other way
-    // (`loop -> external -> loop`), the loop genuinely cannot be made contiguous and this
-    // manifests as a cycle, which is reported like any other intra-tick cycle.
+    // node directly inside such loop.
     {
-        let node_loop_ancestors = |node: GraphNodeId| -> Vec<GraphLoopId> {
-            // Innermost -> outermost.
-            let mut ancestors = Vec::new();
-            let mut current = partitioned_graph.node_loop(node);
-            while let Some(loop_id) = current {
-                ancestors.push(loop_id);
-                current = partitioned_graph.loop_parent(loop_id);
-            }
-            ancestors
-        };
-
-        // Transitive loop membership: loop -> all nodes nested within it (at any depth).
-        let mut loop_members: std::collections::HashMap<GraphLoopId, Vec<GraphNodeId>> =
-            std::collections::HashMap::new();
-        for node_id in partitioned_graph.node_ids() {
-            for loop_id in node_loop_ancestors(node_id) {
-                loop_members.entry(loop_id).or_default().push(node_id);
-            }
-        }
-
-        for (edge_id, (src, dst)) in partitioned_graph.edges() {
-            // Skip cross-tick / back-edges — they are not forward ingress.
+        for (edge_id, (src_id, dst_id)) in partitioned_graph.edges() {
             if tick_edges.contains_key(edge_id) {
                 continue;
             }
-            let src_ancestors = node_loop_ancestors(src);
-            // Outermost loop ancestor of `dst` that does *not* contain `src`.
-            let Some(&target_loop) = node_loop_ancestors(dst)
-                .iter()
-                .rev()
-                .find(|loop_id| !src_ancestors.contains(loop_id))
-            else {
-                // `dst` is in the same loop context as `src` (or `src` is deeper): not
-                // loop ingress from outside.
-                continue;
-            };
-            // `src` must precede every node inside the gathered loop block.
-            for &member in loop_members.get(&target_loop).into_iter().flatten() {
-                if member != src {
-                    all_preds.entry(member).unwrap().or_default().push(src);
+            let src_loop = partitioned_graph.node_loop(src_id);
+            let dst_loop = partitioned_graph.node_loop(dst_id);
+            if let Some(dst_loop_some) = dst_loop
+                && src_loop == partitioned_graph.loop_parent(dst_loop_some)
+            {
+                for &inside_dst_id in partitioned_graph.loop_nodes(dst_loop_some) {
+                    all_preds
+                        .entry(inside_dst_id)
+                        .unwrap()
+                        .or_default()
+                        .push(src_id);
                 }
             }
         }
@@ -276,14 +249,6 @@ fn make_subgraphs(
     edge_barrier_pairs: &[(GraphNodeId, GraphNodeId)],
     access_group_pairs: &[(GraphNodeId, GraphNodeId)],
 ) -> Result<(), Diagnostic> {
-    // Algorithm:
-    // 1. Each node begins as its own subgraph.
-    // 2. Collect edges. (Future optimization: sort so edges which should not be split across a handoff come first).
-    // 3. For each edge, try to join `(to, from)` into the same subgraph.
-
-    // TODO(mingwei):
-    // self.partitioned_graph.assert_valid();
-
     let (subgraph_merge, handoff_edges) = find_subgraph_unionfind(
         partitioned_graph,
         tick_edges,
@@ -317,7 +282,7 @@ fn make_subgraphs(
         }
     }
 
-    // Register subgraphs. SubgraphMerge maintains operators in topo-sorted order per subgraph.
+    // Register subgraphs. `SubgraphMerge` maintains operators in topo-sorted order per subgraph.
     // Filter out handoff nodes — they are not part of any subgraph.
     // Collect subgraph IDs in flat topological order.
     let mut flat_toposort = Vec::new();
@@ -339,12 +304,35 @@ fn make_subgraphs(
     // Rearrange the flat toposort to make loop subgraphs contiguous.
     let subgraph_toposort = make_loops_contiguous(partitioned_graph, &flat_toposort);
 
-    // Defensive check: the contiguous order must still respect every forward (non-tick)
-    // handoff edge, i.e. each handoff's producer subgraph precedes its consumer subgraph.
+    // Defensive check: the toposort must still be valid after making loops contiguous.
     // A violation here indicates a bug in the ordering/contiguity logic.
-    debug_assert!(
-        subgraph_toposort_respects_handoffs(partitioned_graph, &subgraph_toposort, tick_edges),
-        "subgraph toposort violates a forward handoff dependency (loop-contiguity bug)"
+    assert!(
+        validate_topo_sort(
+            subgraph_toposort
+                .iter()
+                .flat_map(|&sg_id| partitioned_graph.subgraph(sg_id))
+                .copied(),
+            |succ_id| {
+                partitioned_graph
+                    .node_predecessors(succ_id)
+                    .filter_map(|(edge_id, pred_id)| {
+                        (!tick_edges.contains_key(edge_id)).then_some(pred_id)
+                    })
+                    .map(|pred_id| {
+                        // Jump over handoff nodes.
+                        if matches!(partitioned_graph.node(pred_id), GraphNode::Handoff { .. }) {
+                            partitioned_graph
+                                .node_predecessor_nodes(pred_id)
+                                .next()
+                                .unwrap()
+                        } else {
+                            pred_id
+                        }
+                    })
+            }
+        )
+        .is_ok(),
+        "bug: toposort is invalid after `make_loop_contiguous`.",
     );
 
     partitioned_graph.set_subgraph_toposort(subgraph_toposort);
@@ -352,63 +340,15 @@ fn make_subgraphs(
     Ok(())
 }
 
-/// Checks that `subgraph_toposort` places each forward (non-tick) handoff's producer
-/// subgraph before its consumer subgraph. Used as a defensive assertion after
-/// [`make_loops_contiguous`].
-fn subgraph_toposort_respects_handoffs(
-    graph: &DfirGraph,
-    subgraph_toposort: &[GraphSubgraphId],
-    tick_edges: &SecondaryMap<GraphEdgeId, DelayType>,
-) -> bool {
-    let position: SparseSecondaryMap<GraphSubgraphId, usize> = subgraph_toposort
-        .iter()
-        .enumerate()
-        .map(|(i, &sg)| (sg, i))
-        .collect();
-
-    for (hoff_id, node) in graph.nodes() {
-        if !matches!(node, GraphNode::Handoff { .. }) {
-            continue;
-        }
-        let Some((succ_edge, consumer)) = graph.node_successors(hoff_id).next() else {
-            continue;
-        };
-        // Skip cross-tick / back-edge handoffs, which may point "backwards".
-        if tick_edges.contains_key(succ_edge) {
-            continue;
-        }
-        let Some((_, producer)) = graph.node_predecessors(hoff_id).next() else {
-            continue;
-        };
-        let (Some(producer_sg), Some(consumer_sg)) =
-            (graph.node_subgraph(producer), graph.node_subgraph(consumer))
-        else {
-            continue;
-        };
-        let (Some(&producer_pos), Some(&consumer_pos)) =
-            (position.get(producer_sg), position.get(consumer_sg))
-        else {
-            continue;
-        };
-        if producer_pos > consumer_pos {
-            return false;
-        }
-    }
-    true
-}
-
-/// Rearranges a flat topological order of subgraphs so that all subgraphs within
-/// a loop are contiguous, while preserving the relative topological order.
+/// Rearranges a flat topological order of subgraphs so that all subgraphs within a loop are contiguous, while
+/// preserving the relative topological order.
 ///
-/// Pre-computes for each loop the set of descendant subgraphs (in flat-order),
-/// then recurses through the loop hierarchy. At each level, subgraphs directly
-/// at that level are emitted in place; when a child loop is first encountered,
-/// all of its descendants are emitted recursively.
+/// PRECONDITION: The first member of a loop MUST COME AFTER all outer subgraphs which send into the loop. Subgraphs
+/// from different loop contexts that appear interleaved in the flat order have no dependency between them **EXCEPT**
+/// ingress (from outer to inner loop) or egress (from inner to outer). This method hoists all members of a loop to the
+/// **first** subgraph of the loop in the flat order, hense the correctness requirement only on the ingress side.
 ///
-/// Correctness: subgraphs from different loop contexts that appear interleaved in
-/// the flat order have no dependency between them (data can only enter/exit a loop
-/// via windowing/unwindowing operators, never between siblings), so reordering them
-/// for contiguity preserves the topological invariant.
+/// https://github.com/hydro-project/hydro/issues/3048
 fn make_loops_contiguous(
     graph: &DfirGraph,
     flat_order: &[GraphSubgraphId],
@@ -595,6 +535,7 @@ mod tests {
     use crate::graph::GraphNode;
 
     /// Regression test for a loop-contiguity toposort bug.
+    /// https://github.com/hydro-project/hydro/issues/3048
     ///
     /// [`make_loops_contiguous`] gathers every subgraph of a loop at the position of the
     /// loop's *first* subgraph in the flat order. If an external subgraph that *feeds into*

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -332,7 +332,7 @@ fn make_subgraphs(
             }
         )
         .is_ok(),
-        "bug: toposort is invalid after `make_loop_contiguous`.",
+        "bug: toposort is invalid after `make_loops_contiguous`.",
     );
 
     partitioned_graph.set_subgraph_toposort(subgraph_toposort);
@@ -346,7 +346,7 @@ fn make_subgraphs(
 /// PRECONDITION: The first member of a loop MUST COME AFTER all outer subgraphs which send into the loop. Subgraphs
 /// from different loop contexts that appear interleaved in the flat order have no dependency between them **EXCEPT**
 /// ingress (from outer to inner loop) or egress (from inner to outer). This method hoists all members of a loop to the
-/// **first** subgraph of the loop in the flat order, hense the correctness requirement only on the ingress side.
+/// **first** subgraph of the loop in the flat order, hence the correctness requirement only on the ingress side.
 ///
 /// https://github.com/hydro-project/hydro/issues/3048
 fn make_loops_contiguous(

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -119,6 +119,67 @@ fn find_subgraph_unionfind(
         all_preds.entry(dst).unwrap().or_default().push(src);
     }
 
+    // Loop-ingress ordering constraints.
+    //
+    // `make_loops_contiguous` (run later) gathers *all* of a loop's subgraphs to the
+    // flat-order position of the loop's *first* subgraph. That is only sound if every
+    // subgraph feeding into the loop from *outside* is already ordered before the loop's
+    // earliest subgraph. Otherwise an ingress "receiver" inside the loop can be hoisted
+    // ahead of its external "sender", violating topological order (which then produces a
+    // handoff-buffer "use before declaration" compile error downstream).
+    //
+    // To guarantee this, we require: for each forward (non-tick) edge `src -> dst` where
+    // `dst` lies inside a loop that does not contain `src`, `src` must precede *every*
+    // node inside the outermost such loop (i.e. the whole top-level loop block that will
+    // be gathered). If the loop also has a dependency running the other way
+    // (`loop -> external -> loop`), the loop genuinely cannot be made contiguous and this
+    // manifests as a cycle, which is reported like any other intra-tick cycle.
+    {
+        let node_loop_ancestors = |node: GraphNodeId| -> Vec<GraphLoopId> {
+            // Innermost -> outermost.
+            let mut ancestors = Vec::new();
+            let mut current = partitioned_graph.node_loop(node);
+            while let Some(loop_id) = current {
+                ancestors.push(loop_id);
+                current = partitioned_graph.loop_parent(loop_id);
+            }
+            ancestors
+        };
+
+        // Transitive loop membership: loop -> all nodes nested within it (at any depth).
+        let mut loop_members: std::collections::HashMap<GraphLoopId, Vec<GraphNodeId>> =
+            std::collections::HashMap::new();
+        for node_id in partitioned_graph.node_ids() {
+            for loop_id in node_loop_ancestors(node_id) {
+                loop_members.entry(loop_id).or_default().push(node_id);
+            }
+        }
+
+        for (edge_id, (src, dst)) in partitioned_graph.edges() {
+            // Skip cross-tick / back-edges — they are not forward ingress.
+            if tick_edges.contains_key(edge_id) {
+                continue;
+            }
+            let src_ancestors = node_loop_ancestors(src);
+            // Outermost loop ancestor of `dst` that does *not* contain `src`.
+            let Some(&target_loop) = node_loop_ancestors(dst)
+                .iter()
+                .rev()
+                .find(|loop_id| !src_ancestors.contains(loop_id))
+            else {
+                // `dst` is in the same loop context as `src` (or `src` is deeper): not
+                // loop ingress from outside.
+                continue;
+            };
+            // `src` must precede every node inside the gathered loop block.
+            for &member in loop_members.get(&target_loop).into_iter().flatten() {
+                if member != src {
+                    all_preds.entry(member).unwrap().or_default().push(src);
+                }
+            }
+        }
+    }
+
     // Build enemies: all node pairs that must not be in the same subgraph.
     let enemies = edge_barrier_pairs
         .iter()
@@ -277,9 +338,63 @@ fn make_subgraphs(
 
     // Rearrange the flat toposort to make loop subgraphs contiguous.
     let subgraph_toposort = make_loops_contiguous(partitioned_graph, &flat_toposort);
+
+    // Defensive check: the contiguous order must still respect every forward (non-tick)
+    // handoff edge, i.e. each handoff's producer subgraph precedes its consumer subgraph.
+    // A violation here indicates a bug in the ordering/contiguity logic.
+    debug_assert!(
+        subgraph_toposort_respects_handoffs(partitioned_graph, &subgraph_toposort, tick_edges),
+        "subgraph toposort violates a forward handoff dependency (loop-contiguity bug)"
+    );
+
     partitioned_graph.set_subgraph_toposort(subgraph_toposort);
 
     Ok(())
+}
+
+/// Checks that `subgraph_toposort` places each forward (non-tick) handoff's producer
+/// subgraph before its consumer subgraph. Used as a defensive assertion after
+/// [`make_loops_contiguous`].
+fn subgraph_toposort_respects_handoffs(
+    graph: &DfirGraph,
+    subgraph_toposort: &[GraphSubgraphId],
+    tick_edges: &SecondaryMap<GraphEdgeId, DelayType>,
+) -> bool {
+    let position: SparseSecondaryMap<GraphSubgraphId, usize> = subgraph_toposort
+        .iter()
+        .enumerate()
+        .map(|(i, &sg)| (sg, i))
+        .collect();
+
+    for (hoff_id, node) in graph.nodes() {
+        if !matches!(node, GraphNode::Handoff { .. }) {
+            continue;
+        }
+        let Some((succ_edge, consumer)) = graph.node_successors(hoff_id).next() else {
+            continue;
+        };
+        // Skip cross-tick / back-edge handoffs, which may point "backwards".
+        if tick_edges.contains_key(succ_edge) {
+            continue;
+        }
+        let Some((_, producer)) = graph.node_predecessors(hoff_id).next() else {
+            continue;
+        };
+        let (Some(producer_sg), Some(consumer_sg)) =
+            (graph.node_subgraph(producer), graph.node_subgraph(consumer))
+        else {
+            continue;
+        };
+        let (Some(&producer_pos), Some(&consumer_pos)) =
+            (position.get(producer_sg), position.get(consumer_sg))
+        else {
+            continue;
+        };
+        if producer_pos > consumer_pos {
+            return false;
+        }
+    }
+    true
 }
 
 /// Rearranges a flat topological order of subgraphs so that all subgraphs within
@@ -478,6 +593,104 @@ pub fn partition_graph(flat_graph: DfirGraph) -> Result<DfirGraph, Diagnostic> {
 mod tests {
     use super::*;
     use crate::graph::GraphNode;
+
+    /// Regression test for a loop-contiguity toposort bug.
+    ///
+    /// [`make_loops_contiguous`] gathers every subgraph of a loop at the position of the
+    /// loop's *first* subgraph in the flat order. If an external subgraph that *feeds into*
+    /// the loop (loop ingress) happens to sit — in the flat topological order — after the
+    /// loop's first subgraph but before a later loop subgraph, then gathering the loop
+    /// pulls that later (ingress-receiving) subgraph *ahead* of its producer.
+    ///
+    /// Concretely, the flat order `[S1, loopA, S2, loopB]` (valid, since `S2 -> loopB`)
+    /// would become `[S1, loopA, loopB, S2]`, so the loop-ingress *receiver* `loopB` would
+    /// be emitted before its *sender* `S2`. Downstream this produces a handoff-buffer "use
+    /// before declaration" compile error (and, logically, a drained-but-never-filled
+    /// buffer).
+    ///
+    /// The fix adds loop-ingress ordering constraints so every ingress sender precedes the
+    /// entire loop block, keeping gather-at-first sound.
+    #[test]
+    fn test_make_loops_contiguous_ingress_toposort() {
+        use crate::graph::{FlatGraphBuilder, FlatGraphBuilderOutput};
+
+        let mut builder = FlatGraphBuilder::new();
+        // External source #1 (feeds the loop's first ingress).
+        builder.add_dfir(
+            syn::parse_quote! {
+                inp1 = source_iter([1, 2, 3]);
+            },
+            None,
+            None,
+        );
+        let loop_id = builder.insert_loop(None);
+        // Loop ingress A — independent of `inp2`, so the flat toposort can place it before
+        // `inp2`.
+        builder.add_dfir(
+            syn::parse_quote! {
+                inp1 -> batch() -> for_each(std::mem::drop);
+            },
+            Some(loop_id),
+            None,
+        );
+        // External source #2 — the loop-ingress "sender", defined after loop ingress A so
+        // the flat toposort interleaves it: `[inp1, loopA, inp2, loopB]`.
+        builder.add_dfir(
+            syn::parse_quote! {
+                inp2 = source_iter([4, 5, 6]);
+            },
+            None,
+            None,
+        );
+        // Loop ingress B — the "receiver" of `inp2`.
+        builder.add_dfir(
+            syn::parse_quote! {
+                inp2 -> batch() -> for_each(std::mem::drop);
+            },
+            Some(loop_id),
+            None,
+        );
+
+        let FlatGraphBuilderOutput { flat_graph, .. } =
+            builder.build().expect("should build without errors");
+        let partitioned = partition_graph(flat_graph).expect("should partition without errors");
+
+        // Verify: every forward (non-delay) handoff has its producer subgraph *before* its
+        // consumer subgraph in the final `subgraph_toposort`.
+        let order = partitioned.subgraph_toposort();
+        let pos: std::collections::HashMap<_, _> =
+            order.iter().enumerate().map(|(i, &sg)| (sg, i)).collect();
+
+        for (hoff_id, node) in partitioned.nodes() {
+            if !matches!(node, GraphNode::Handoff { .. }) {
+                continue;
+            }
+            // Skip delay (back-edge) handoffs, which are allowed to point "backwards".
+            if partitioned.handoff_delay_type(hoff_id).is_some() {
+                continue;
+            }
+            let Some((_, pred)) = partitioned.node_predecessors(hoff_id).next() else {
+                continue;
+            };
+            let Some((_, succ)) = partitioned.node_successors(hoff_id).next() else {
+                continue;
+            };
+            let (Some(pred_sg), Some(succ_sg)) = (
+                partitioned.node_subgraph(pred),
+                partitioned.node_subgraph(succ),
+            ) else {
+                continue;
+            };
+            let (Some(&pp), Some(&sp)) = (pos.get(&pred_sg), pos.get(&succ_sg)) else {
+                continue;
+            };
+            assert!(
+                pp < sp,
+                "toposort violated: producer subgraph {pred_sg:?} (pos {pp}) emitted after \
+                 consumer subgraph {succ_sg:?} (pos {sp}) via handoff {hoff_id:?}; order = {order:?}",
+            );
+        }
+    }
 
     fn make_op_node(graph: &mut DfirGraph, loop_ctx: Option<GraphLoopId>) -> GraphNodeId {
         let operator: crate::parse::Operator = syn::parse_quote! { identity() };

--- a/dfir_lang/src/graph/graph_algorithms.rs
+++ b/dfir_lang/src/graph/graph_algorithms.rs
@@ -1,6 +1,6 @@
 //! General graph algorithm utility functions
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::Hash;
 
 use slotmap::{Key, SecondaryMap, SparseSecondaryMap};
@@ -69,6 +69,37 @@ where
     }
 
     Ok(order)
+}
+
+/// Validates the topo sort.
+///
+/// Returns `Ok(())` if it is valid. Returns `Err((pred, succ))` where `pred` comes after `succ` when the sort is
+/// invalid. Panics if a node returned by the `pred_fn` is missing from the sort.
+pub fn validate_topo_sort<Id, PredsIter>(
+    topo_sort: impl IntoIterator<Item = Id>,
+    mut preds_fn: impl FnMut(Id) -> PredsIter,
+) -> Result<(), (Id, Id)>
+where
+    Id: Copy + Eq + Ord,
+    PredsIter: IntoIterator<Item = Id>,
+{
+    let indexed = topo_sort
+        .into_iter()
+        .enumerate()
+        .map(|(i, n)| (n, i))
+        .collect::<BTreeMap<_, _>>();
+    for (&succ, &succ_idx) in indexed.iter() {
+        for pred in (preds_fn)(succ) {
+            let Some(&pred_idx) = indexed.get(&pred) else {
+                panic!("predecessor not in topo sort");
+            };
+            if succ_idx <= pred_idx {
+                // Violation in topo sort.
+                return Err((pred, succ));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Datastructure for merging subgraphs while maintaining topological sort order.
@@ -437,6 +468,74 @@ mod test {
                 permutation
             );
         }
+    }
+
+    #[test]
+    pub fn test_validate_topo_sort_valid() {
+        // Simple linear chain: A -> B -> C -> D
+        // Valid topo sort: [A, B, C, D]
+        let edges: &[(i32, i32)] = &[(1, 2), (2, 3), (3, 4)];
+
+        let result = validate_topo_sort([1, 2, 3, 4], |v| {
+            edges
+                .iter()
+                .filter(move |&&(_src, dst)| v == dst)
+                .map(|&(src, _)| src)
+        });
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    pub fn test_validate_topo_sort_invalid() {
+        // Edges: A -> B -> C -> D
+        // Invalid topo sort: [A, C, B, D] (C appears before B, but B is a predecessor of C)
+        let edges: &[(i32, i32)] = &[(1, 2), (2, 3), (3, 4)];
+
+        let result = validate_topo_sort([1, 3, 2, 4], |v| {
+            edges
+                .iter()
+                .filter(move |&&(_src, dst)| v == dst)
+                .map(|&(src, _)| src)
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    pub fn test_validate_topo_sort_diamond() {
+        // Diamond graph:
+        //     1
+        //    / \
+        //   2   3
+        //    \ /
+        //     4
+        let edges: &[(i32, i32)] = &[(1, 2), (1, 3), (2, 4), (3, 4)];
+
+        // Valid sort: [1, 2, 3, 4]
+        let result = validate_topo_sort([1, 2, 3, 4], |v| {
+            edges
+                .iter()
+                .filter(move |&&(_src, dst)| v == dst)
+                .map(|&(src, _)| src)
+        });
+        assert_eq!(result, Ok(()));
+
+        // Also valid: [1, 3, 2, 4]
+        let result = validate_topo_sort([1, 3, 2, 4], |v| {
+            edges
+                .iter()
+                .filter(move |&&(_src, dst)| v == dst)
+                .map(|&(src, _)| src)
+        });
+        assert_eq!(result, Ok(()));
+
+        // Invalid: [4, 1, 2, 3] (4 appears before its predecessors)
+        let result = validate_topo_sort([4, 1, 2, 3], |v| {
+            edges
+                .iter()
+                .filter(move |&&(_src, dst)| v == dst)
+                .map(|&(src, _)| src)
+        });
+        assert!(result.is_err());
     }
 
     #[test]

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -2616,6 +2616,11 @@ impl DfirGraph {
         self.loop_nodes.iter()
     }
 
+    /// Get a loop's member nodes.
+    pub fn loop_nodes(&self, loop_id: GraphLoopId) -> &[GraphNodeId] {
+        self.loop_nodes.get(loop_id).unwrap()
+    }
+
     /// Create a new loop context, with the given parent loop (or `None`).
     pub fn insert_loop(&mut self, parent_loop: Option<GraphLoopId>) -> GraphLoopId {
         let loop_id = self.loop_nodes.insert(Vec::new());

--- a/dfir_rs/tests/surface_loop.rs
+++ b/dfir_rs/tests/surface_loop.rs
@@ -34,6 +34,7 @@ pub fn test_loop_gating_basic() {
 }
 
 /// Regression test for a loop-contiguity toposort bug.
+/// https://github.com/hydro-project/hydro/issues/3048
 ///
 /// A single loop has two ingress points, but the sources feeding them are declared
 /// *after* the loop (forward references). This causes the source that feeds the second

--- a/dfir_rs/tests/surface_loop.rs
+++ b/dfir_rs/tests/surface_loop.rs
@@ -33,6 +33,52 @@ pub fn test_loop_gating_basic() {
     assert_eq!(out, Vec::<i32>::new());
 }
 
+/// Regression test for a loop-contiguity toposort bug.
+///
+/// A single loop has two ingress points, but the sources feeding them are declared
+/// *after* the loop (forward references). This causes the source that feeds the second
+/// ingress to be inserted late, so the flat toposort interleaves as
+/// `[source1, loopA, source2, loopB]`. Previously `make_loops_contiguous` would gather
+/// the loop to `loopA`'s position (`[source1, loopA, loopB, source2]`), hoisting the
+/// ingress *receiver* `loopB` ahead of its *sender* `source2` — producing a
+/// handoff-buffer "use before declaration" compile error (and, if it compiled, an
+/// empty/stale batch).
+///
+/// With the fix, ingress senders are ordered before the whole loop block, so this both
+/// compiles and delivers all data.
+#[multiplatform_test(test, wasm, env_tracing)]
+pub fn test_loop_ingress_forward_ref_sources() {
+    let (in1_send, in1_recv) = dfir_rs::util::unbounded_channel::<i32>();
+    let (in2_send, in2_recv) = dfir_rs::util::unbounded_channel::<i32>();
+    let (out1_send, mut out1_recv) = dfir_rs::util::unbounded_channel::<i32>();
+    let (out2_send, mut out2_recv) = dfir_rs::util::unbounded_channel::<i32>();
+
+    let mut df = dfir_syntax! {
+        loop {
+            inp1 -> batch() -> for_each(|x| out1_send.send(x).unwrap());
+            inp2 -> batch() -> for_each(|x| out2_send.send(x).unwrap());
+        };
+        // Sources declared *after* the loop, so their nodes are inserted late.
+        inp1 = source_stream(in1_recv);
+        inp2 = source_stream(in2_recv);
+    };
+
+    in1_send.send(1).unwrap();
+    in1_send.send(2).unwrap();
+    in2_send.send(10).unwrap();
+    in2_send.send(20).unwrap();
+    df.run_tick_sync();
+
+    let mut out1: Vec<i32> = dfir_rs::util::collect_ready(&mut out1_recv);
+    let mut out2: Vec<i32> = dfir_rs::util::collect_ready(&mut out2_recv);
+    out1.sort_unstable();
+    out2.sort_unstable();
+
+    // Both ingress points must receive their data (no stale/empty batches).
+    assert_eq!(out1, vec![1, 2]);
+    assert_eq!(out2, vec![10, 20]);
+}
+
 /// Test that two independent loops do not trigger each other.
 /// Data arriving for loop A should not cause loop B to fire.
 #[multiplatform_test(test, wasm, env_tracing)]


### PR DESCRIPTION
`make_loops_contiguous` gathers every subgraph of a loop to the flat-order
position of the loop's *first* subgraph. This is only sound if every subgraph
feeding the loop from outside (loop ingress) is already ordered before the
loop's earliest subgraph. Otherwise gathering hoists an ingress *receiver*
inside the loop ahead of its external *sender*, violating topological order.
Downstream this produced a handoff-buffer "use before declaration" compile
error (and, logically, a drained-but-never-filled batch).

Fix: in `find_subgraph_unionfind`, add loop-ingress ordering constraints to the
predecessor set that feeds the (existing, unified) topological sort. For each
forward (non-tick) edge `src -> dst` where `dst` lies inside a loop that does
not contain `src`, require `src` to precede *every* node inside the outermost
such loop — i.e. the whole top-level loop block that will be gathered. Because
this reuses the same toposort, all other ordering constraints (handoff
references, access groups) are respected automatically, and non-loop programs
are entirely unaffected (no constraints are added). A genuine
`loop -> external -> loop` dependency (which cannot be made contiguous) now
surfaces as the usual intra-tick cycle error.

Also adds a defensive assertion after `make_loops_contiguous` that verifies the
toposort is still valid.

Tests:
- `dfir_lang`: `test_make_loops_contiguous_ingress_toposort` (previously
  `#[ignore]`d as a repro) now asserts a valid toposort and passes.
- `dfir_rs` `surface_loop`: adds `test_loop_ingress_forward_ref_sources`, an
  end-to-end surface-syntax repro (two ingress points with sources declared
  after the loop) that both compiles and delivers all data. Both tests were
  confirmed to fail without the fix (the integration test fails at macro
  expansion via the new debug assertion).