### PR TITLE
feat(hydro_lang): add `sim::continue_if!` macro for discarding simulation instances in sim tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "bolero-engine-hydro"
-version = "0.13.5"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691790fb2d24fe4984eebd9ef3eb0afc8598a0530471f4d5de499d379e504fc5"
+checksum = "19657f169ff31a26958c45c29e8ec379c303bb9d04a4418b6cecbfb49984a3df"
 dependencies = [
  "anyhow",
  "bolero-generator-hydro",
@@ -966,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "bolero-hydro"
-version = "0.13.5"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef7956e385b91a5aee997d23d40c65ff65af698e71f49ba5f3d87ee99ea4b6f5"
+checksum = "0db4ec15d8e0d09f866480eb4efb1c5b944b5304f545cc69f889507c3b75f2fa"
 dependencies = [
  "bolero-afl",
  "bolero-engine-hydro",

--- a/docs/docs/hydro/reference/simulation/writing.mdx
+++ b/docs/docs/hydro/reference/simulation/writing.mdx
@@ -44,6 +44,33 @@ For ordered streams, use `send()` to send a single message or `send_many()` to s
 
 The `exhaustive()` method explores *all* possible executions. This is feasible when the inputs are finite and the number of `nondet!` decision points is manageable. For complex protocols, use `fuzz()` instead (see [Coverage-Guided Simulation](./fuzzing.mdx) for details).
 
+### Restricting Explored Executions with `continue_if!`
+
+Sometimes an assertion only makes sense for a subset of executions—for example, when the property you want to check only holds if certain messages happened to arrive in the same batch. The `hydro_lang::sim::continue_if!` macro lets you express such preconditions: if the condition is false, the current simulation instance is stopped and discarded (it is *not* a test failure), and exploration moves on to the next execution. This is the same concept as `assume` in verification tools and property-based testing libraries (e.g. `kani::assume` or proptest's `prop_assume!`).
+
+```rust,no_run
+# use hydro_lang::prelude::*;
+# use hydro_lang::sim::continue_if;
+# let mut flow = FlowBuilder::new();
+# let process = flow.process::<()>();
+# let tick = process.tick();
+# let (in_send, input) = process.sim_input::<u32, _, _>();
+# let out_recv = input
+#     .batch(&tick, nondet!(/** batch boundaries are arbitrary */))
+#     .count()
+#     .all_ticks()
+#     .sim_output();
+flow.sim().fuzz(async || {
+    in_send.send_many([1, 2]);
+    let batch_sizes: Vec<usize> = out_recv.collect().await;
+    // only check executions where both messages landed in the first batch
+    continue_if!(batch_sizes.first() == Some(&2), "first batch was {:?}", batch_sizes);
+    // ... assertions that rely on the assumption ...
+});
+```
+
+Like `assert!`, `continue_if!` accepts an optional message with format arguments. Discarded instances are never recorded as fuzzing reproducers, and when logging is enabled (`HYDRO_SIM_LOG=1` or during replays), the failed assumption is logged along with its location. Take care not to make the condition too restrictive—if most executions are discarded, the simulator wastes time exploring executions that are never checked.
+
 When a test fails, the simulator prints a trace showing the decisions it made:
 
 ```text

--- a/hydro_lang/Cargo.toml
+++ b/hydro_lang/Cargo.toml
@@ -184,7 +184,7 @@ base64 = { version = "0.21.0", optional = true }
 regex = { version = "1.12.2", optional = true }
 
 # For the simulator
-bolero = { package = "bolero-hydro", version = "0.13.5", optional = true }
+bolero = { package = "bolero-hydro", version = "0.13.7", optional = true }
 cargo_metadata = { version = "0.18.0", optional = true }
 indenter = { version = "0.3", optional = true }
 libloading = { version = "0.8", optional = true }

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -92,6 +92,84 @@ struct SimConnections {
         HashMap<SimExternalPort, HashMap<u32, Rc<Mutex<UnboundedReceiverStream<Bytes>>>>>,
     external_registered: HashMap<ExternalPortId, SimExternalPort>,
     quiescence: Rc<QuiescenceState>,
+    log: bool,
+}
+
+/// Implementation detail of [`crate::sim::continue_if!`](crate::continue_if); do not call directly.
+///
+/// If `condition` is false, aborts the current simulation instance by panicking with a special
+/// payload ([`bolero::generator::bolero_generator::any::Error`]) that bolero recognizes as an
+/// "invalid input" marker: the instance is discarded (not treated as a test failure, and never
+/// recorded as a reproducer) and exploration moves on to the next instance. If logging is
+/// enabled for the current instance, the failed assumption is logged first.
+#[doc(hidden)]
+#[track_caller]
+pub fn continue_if_impl(condition: bool, message: fmt::Arguments<'_>) {
+    if condition {
+        return;
+    }
+
+    let log = CURRENT_SIM_CONNECTIONS
+        .try_with(|connections| connections.borrow().log)
+        .unwrap_or(true);
+    if log {
+        eprintln!(
+            "{}",
+            render_continue_if_failure(std::panic::Location::caller(), message)
+        );
+    }
+
+    // Panics with `bolero_generator::any::Error`, which bolero's engines treat as an invalid
+    // input rather than a test failure. Both this function and bolero's `assume` are
+    // `#[track_caller]`, so the recorded location is the user's `continue_if!` call site.
+    bolero::generator::bolero_generator::any::assume(false, "simulation assumption failed");
+}
+
+/// Renders the log message for a failed assumption, echoing the source line with a caret
+/// pointing at the `continue_if!` call site, in the same style as the other simulator logs.
+fn render_continue_if_failure(
+    location: &std::panic::Location<'_>,
+    message: fmt::Arguments<'_>,
+) -> String {
+    use std::fmt::Write;
+
+    // `Location::file()` is relative to the directory the crate was compiled from (e.g. the
+    // workspace root), which may not match the current working directory (e.g. the crate
+    // root when running `cargo test`), so walk up from the current directory to find it.
+    let source_line = std::env::current_dir()
+        .ok()
+        .and_then(|cwd| {
+            cwd.ancestors()
+                .find_map(|base| std::fs::read_to_string(base.join(location.file())).ok())
+        })
+        .and_then(|content| {
+            content
+                .lines()
+                .nth((location.line() as usize).saturating_sub(1))
+                .map(|line| line.to_owned())
+        })
+        .unwrap_or_default();
+
+    let caret_indent = " ".repeat((location.column() as usize).saturating_sub(1));
+
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "\n{}",
+        "Condition failed (discarding simulation instance):"
+            .color(colored::Color::Yellow)
+            .bold()
+    );
+    let _ = writeln!(out, "{} {}", "-->".color(colored::Color::Blue), location);
+    let _ = writeln!(out, " {}{}", "|".color(colored::Color::Blue), source_line);
+    let _ = write!(
+        out,
+        " {}{}{}",
+        "|".color(colored::Color::Blue),
+        caret_indent,
+        format!("^ {}", message).color(colored::Color::Yellow)
+    );
+    out
 }
 
 tokio::task_local! {
@@ -187,7 +265,7 @@ impl CompiledSim {
     /// When running the test with `cargo test` (such as in CI), if a reproducer is found it will
     /// be executed, and if no reproducer is found a small number of random executions will be
     /// performed.
-    pub fn fuzz(&self, mut thunk: impl AsyncFn() + RefUnwindSafe) {
+    pub fn fuzz(&self, mut thunk: impl AsyncFnMut() + RefUnwindSafe) {
         let caller_fn = crate::compile::ir::backtrace::Backtrace::get_backtrace(0)
             .elements()
             .into_iter()
@@ -310,19 +388,40 @@ impl CompiledSim {
         bytes: Vec<u8>,
         thunk: impl AsyncFnOnce(CompiledSimInstance) + RefUnwindSafe,
     ) {
-        self.with_instance(|instance| {
-            bolero::bolero_engine::any::scope::with(
-                Box::new(bolero::bolero_engine::driver::object::Object(
-                    bolero::bolero_engine::driver::bytes::Driver::new(bytes, &Default::default()),
-                )),
-                || {
-                    tokio::runtime::Builder::new_current_thread()
-                        .build()
-                        .unwrap()
-                        .block_on(async { instance.run_without_launching(thunk).await })
-                },
-            )
-        });
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.with_instance(|instance| {
+                bolero::bolero_engine::any::scope::with(
+                    Box::new(bolero::bolero_engine::driver::object::Object(
+                        bolero::bolero_engine::driver::bytes::Driver::new(
+                            bytes,
+                            &Default::default(),
+                        ),
+                    )),
+                    || {
+                        tokio::runtime::Builder::new_current_thread()
+                            .build()
+                            .unwrap()
+                            .block_on(async { instance.run_without_launching(thunk).await })
+                    },
+                )
+            })
+        }));
+
+        if let Err(payload) = result {
+            if payload
+                .downcast_ref::<bolero::generator::bolero_generator::any::Error>()
+                .is_some()
+            {
+                // A `continue_if!` failed (or the driver ran out of entropy) while replaying the
+                // recorded bytes. Instances that fail an assumption are never recorded as
+                // failures, so this means the reproducer is stale or does not correspond to
+                // this program.
+                panic!(
+                    "simulation assumption failed while replaying recorded fuzz decisions; the reproducer may be stale or may not correspond to this program"
+                );
+            }
+            std::panic::resume_unwind(payload);
+        }
     }
 
     /// Exhaustively searches all possible executions of the simulation. The provided
@@ -504,6 +603,7 @@ impl<'a> CompiledSimInstance<'a> {
                     cluster_output_receivers,
                     external_registered: self.externals_port_registry.registered.clone(),
                     quiescence: quiescence.clone(),
+                    log: self.log,
                 }),
                 async move {
                     thunk(self).await;

--- a/hydro_lang/src/sim/flow.rs
+++ b/hydro_lang/src/sim/flow.rs
@@ -110,7 +110,7 @@ impl<'a> SimFlow<'a> {
     /// When running the test with `cargo test` (such as in CI), if a reproducer is found it will
     /// be executed, and if no reproducer is found a small number of random executions will be
     /// performed.
-    pub fn fuzz(self, thunk: impl AsyncFn() + RefUnwindSafe) {
+    pub fn fuzz(self, thunk: impl AsyncFnMut() + RefUnwindSafe) {
         self.compiled().fuzz(thunk)
     }
 

--- a/hydro_lang/src/sim/mod.rs
+++ b/hydro_lang/src/sim/mod.rs
@@ -59,5 +59,51 @@ pub(crate) mod versioned_network;
 #[doc(hidden)]
 pub mod runtime;
 
+#[cfg(stageleft_runtime)]
+#[doc(hidden)]
+pub use compiled::continue_if_impl;
+
+/// Continues the current simulation instance only if the given condition holds, otherwise
+/// stopping and discarding the instance.
+///
+/// This is the same concept as `assume` in verification tools and property-based testing
+/// libraries (e.g. `kani::assume` or proptest's `prop_assume!`). It is useful inside
+/// simulation tests ([`crate::sim::flow::SimFlow::fuzz`],
+/// [`crate::sim::flow::SimFlow::exhaustive`], and the corresponding
+/// [`crate::sim::compiled::CompiledSim`] APIs) to restrict exploration to executions that
+/// satisfy some precondition. When the condition is false, the current instance is stopped
+/// and discarded: it is **not** treated as a test failure (and will never be recorded as a
+/// fuzzing reproducer), and the fuzzer / exhaustive search simply moves on to the next
+/// instance. If logging is enabled (always during replays, or when `HYDRO_SIM_LOG=1`), the
+/// failed assumption is logged.
+///
+/// Like the standard `assert!` macro, an optional custom message with format arguments can be
+/// provided.
+///
+/// ```rust,ignore
+/// flow.sim().fuzz(async || {
+///     in_send.send_many([1, 2]);
+///     let all: Vec<u32> = out_recv.collect().await;
+///     hydro_lang::sim::continue_if!(all.len() == 2, "expected both values in one batch, got {:?}", all);
+///     // ... assertions that only make sense when the assumption holds ...
+/// });
+/// ```
+#[doc(hidden)]
+#[macro_export]
+macro_rules! continue_if {
+    ($cond:expr $(,)?) => {
+        $crate::sim::continue_if_impl(
+            $cond,
+            ::core::format_args!("{}", ::core::stringify!($cond)),
+        )
+    };
+    ($cond:expr, $($arg:tt)+) => {
+        $crate::sim::continue_if_impl($cond, ::core::format_args!($($arg)+))
+    };
+}
+
+#[doc(inline)]
+pub use crate::continue_if;
+
 #[cfg(test)]
 mod tests;

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -881,3 +881,171 @@ fn sim_unbounded_optional_rejected_snapshot() {
 
     hydro_build_utils::assert_snapshot!(panic_msg);
 }
+
+/// `continue_if!` should discard instances that fail the assumption (rather than failing the test),
+/// while instances that satisfy it continue executing. Covers the exhaustive engine.
+#[test]
+fn sim_continue_if_discards_instances_exhaustive() {
+    let mut flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+
+    let (in_send, input) = node.sim_input();
+    let tick = node.tick();
+    let out_recv = input
+        .batch(&tick, nondet!(/** test */))
+        .count()
+        .all_ticks()
+        .sim_output();
+
+    let mut accepted = 0;
+    let total = flow.sim().exhaustive(async || {
+        in_send.send(1);
+        in_send.send(2);
+        let counts: Vec<usize> = out_recv.collect().await;
+        // Only consider executions where both values landed in the first batch.
+        crate::sim::continue_if!(counts.first() == Some(&2), "first batch was {:?}", counts);
+        accepted += 1;
+        assert_eq!(counts, vec![2]);
+    });
+
+    assert!(
+        accepted >= 1,
+        "at least one execution should satisfy the assumption"
+    );
+    assert!(
+        accepted < total,
+        "some executions should be discarded by the assumption (accepted: {}, total: {})",
+        accepted,
+        total
+    );
+}
+
+/// Same as above, but covers the RNG-based fuzz engine used by `cargo test`.
+#[test]
+fn sim_continue_if_discards_instances_fuzz() {
+    let mut flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+
+    let (in_send, input) = node.sim_input();
+    let tick = node.tick();
+    let out_recv = input
+        .batch(&tick, nondet!(/** test */))
+        .count()
+        .all_ticks()
+        .sim_output();
+
+    let mut accepted = 0;
+    let mut discarded = 0;
+    flow.sim().fuzz(async || {
+        in_send.send(1);
+        in_send.send(2);
+        let counts: Vec<usize> = out_recv.collect().await;
+        if counts.first() != Some(&2) {
+            discarded += 1;
+        }
+        crate::sim::continue_if!(counts.first() == Some(&2), "first batch was {:?}", counts);
+        accepted += 1;
+        assert_eq!(counts, vec![2]);
+    });
+
+    assert!(
+        accepted >= 1,
+        "at least one execution should satisfy the assumption"
+    );
+    assert!(
+        discarded >= 1,
+        "some executions should be discarded by the assumption"
+    );
+}
+
+/// A failing assertion after a passing `continue_if!` must still fail the test, and discarded
+/// instances must not mask it (or pollute its error message).
+#[test]
+#[should_panic]
+fn sim_continue_if_does_not_mask_failures() {
+    let mut flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+
+    let (in_send, input) = node.sim_input();
+    let tick = node.tick();
+    let out_recv = input
+        .batch(&tick, nondet!(/** test */))
+        .count()
+        .all_ticks()
+        .sim_output();
+
+    flow.sim().exhaustive(async || {
+        in_send.send(1);
+        in_send.send(2);
+        let counts: Vec<usize> = out_recv.collect().await;
+        crate::sim::continue_if!(counts.first() == Some(&2), "first batch was {:?}", counts);
+        panic!("boom");
+    });
+}
+
+/// A crash that is only reachable behind a passing `continue_if!`. Used by the
+/// `fuzz_with_cargo_sim_continue_if` harness test (in `tests/sim_fuzzer.rs`) to verify that under
+/// the libfuzzer engine, instances failing the assumption are discarded (counted as invalid)
+/// without stopping the fuzzer, which must still find the real crash behind the assumption.
+#[test]
+#[should_panic]
+fn sim_crash_behind_continue_if() {
+    // run as PATH="$PATH:." cargo sim -p hydro_lang --features sim -- sim_crash_behind_continue_if
+    let mut flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+
+    let (in_send, input) = node.sim_input();
+    let tick = node.tick();
+    let out_recv = input
+        .batch(&tick, nondet!(/** test */))
+        .count()
+        .all_ticks()
+        .sim_output();
+
+    flow.sim().fuzz(async || {
+        in_send.send(1);
+        in_send.send(2);
+        in_send.send(3);
+        let counts: Vec<usize> = out_recv.collect().await;
+        // Discard instances where the first batch is a singleton; roughly half of random
+        // batchings will fail this, exercising the discard path under the fuzzer. The message
+        // is deterministic so that `fuzz_with_cargo_sim_continue_if` can snapshot the logged output.
+        crate::sim::continue_if!(
+            counts.first().is_some_and(|c| *c >= 2),
+            "first batch was a singleton"
+        );
+        if counts.first() == Some(&3) {
+            // Only reachable in instances that passed the assumption.
+            panic!("boom");
+        }
+    });
+}
+
+/// An `continue_if!` failure during `fuzz_repro` indicates a stale reproducer and should produce a
+/// clear error message.
+#[test]
+#[should_panic(expected = "assumption failed while replaying")]
+fn sim_continue_if_failure_in_fuzz_repro_is_reported() {
+    let mut flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+
+    let (in_send, input) = node.sim_input::<i32, _, _>();
+    let out_recv = input.sim_output();
+
+    flow.sim()
+        .compiled()
+        .fuzz_repro(vec![0; 64], async |compiled| {
+            let schedule = compiled.schedule_with_logger(std::io::sink());
+            let rest = async move {
+                in_send.send(1);
+                let _: Vec<i32> = out_recv.collect().await;
+                crate::sim::continue_if!(false, "always fails");
+            };
+
+            tokio::select! {
+                biased;
+                _ = rest => {},
+                _ = schedule => {},
+            };
+        });
+}

--- a/hydro_lang/tests/sim_fuzzer.rs
+++ b/hydro_lang/tests/sim_fuzzer.rs
@@ -45,3 +45,58 @@ fn fuzz_with_cargo_sim() {
 
     assert!(stderr_text.contains("releasing items: [100, 23]"));
 }
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // `cargo-sim` script is currently Unix only
+fn fuzz_with_cargo_sim_continue_if() {
+    let command = std::process::Command::new("cargo")
+        .args([
+            "sim",
+            "-p",
+            "hydro_lang",
+            "--features",
+            "sim",
+            "--",
+            "sim::tests::sim_crash_behind_continue_if",
+        ])
+        .env(
+            "PATH",
+            join_paths(
+                std::env::split_paths(&std::env::var("PATH").unwrap())
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .chain([std::env::current_dir()
+                        .unwrap()
+                        .parent()
+                        .unwrap()
+                        .to_path_buf()]),
+            )
+            .unwrap(),
+        )
+        .env("NO_COLOR", "1")
+        .env("HYDRO_NO_FAILURE_OUTPUT", "1")
+        // enable sim logging so failed assumptions are logged
+        .env("HYDRO_SIM_LOG", "1")
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let out = command.wait_with_output().unwrap();
+    let stderr_text = String::from_utf8(out.stderr).unwrap();
+
+    eprintln!("stderr:\n{}", stderr_text);
+
+    // Instances that fail the `continue_if!` must be discarded (logged, not treated as failures),
+    // while the fuzzer continues and still finds the real crash behind the assumption.
+    assert!(stderr_text.contains("test failed; shrinking input..."));
+    assert!(stderr_text.contains("boom\nstack backtrace:"));
+
+    // Snapshot the assumption-failure log block (header + location + source line + caret) to
+    // verify the `continue_if!` call site is properly reported.
+    let lines: Vec<&str> = stderr_text.lines().collect();
+    let block_start = lines
+        .iter()
+        .position(|line| line.starts_with("Condition failed (discarding simulation instance):"))
+        .expect("no assumption failure was logged");
+    hydro_build_utils::assert_snapshot!(lines[block_start..block_start + 4].join("\n"));
+}

--- a/hydro_lang/tests/snapshots-nightly/sim_fuzzer__fuzz_with_cargo_sim_continue_if.snap
+++ b/hydro_lang/tests/snapshots-nightly/sim_fuzzer__fuzz_with_cargo_sim_continue_if.snap
@@ -1,0 +1,8 @@
+---
+source: hydro_lang/tests/sim_fuzzer.rs
+expression: "lines[block_start..block_start + 4].join(\"\\n\")"
+---
+Condition failed (discarding simulation instance):
+--> hydro_lang/src/sim/tests/mod.rs:1013:9
+ |        crate::sim::continue_if!(
+ |        ^ first batch was a singleton

--- a/hydro_lang/tests/snapshots/sim_fuzzer__fuzz_with_cargo_sim_continue_if.snap
+++ b/hydro_lang/tests/snapshots/sim_fuzzer__fuzz_with_cargo_sim_continue_if.snap
@@ -1,0 +1,8 @@
+---
+source: hydro_lang/tests/sim_fuzzer.rs
+expression: "lines[block_start..block_start + 4].join(\"\\n\")"
+---
+Condition failed (discarding simulation instance):
+--> hydro_lang/src/sim/tests/mod.rs:1013:9
+ |        crate::sim::continue_if!(
+ |        ^ first batch was a singleton


### PR DESCRIPTION
Fixes #2176

Adds `hydro_lang::sim::continue_if!(cond, ...)`, which can be invoked inside sim test
closures (`fuzz`, `exhaustive`, `fuzz_repro`). If the condition fails, the current
simulation instance is stopped and discarded — it is *not* a test failure, is never
recorded as a fuzzing reproducer, and exploration moves on to the next instance. This is
the same concept as `assume` in verification tools and property-based testing libraries
(e.g. `kani::assume`, proptest's `prop_assume!`). If sim logging is enabled
(`HYDRO_SIM_LOG=1` or during replays), the failed condition is logged in the same style
as other simulator logs: the call-site location (via `#[track_caller]`) with the source
line echoed and a caret pointing at the `continue_if!` invocation:

```
Condition failed (discarding simulation instance):
--> hydro_lang/src/sim/tests/mod.rs:1013:9
 |        crate::sim::continue_if!(
 |        ^ first batch was a singleton
```

Mechanism: instead of a custom panic-catch layer, the macro reuses bolero's built-in
`any::assume`, which panics with the special `bolero_generator::any::Error` payload that
bolero's engines classify as an "invalid input" (`Ok(false)`), so all three engines
(exhaustive, RNG fuzz under `cargo test`, libfuzzer under `cargo sim`) skip the instance
uniformly and never replay/shrink onto failing inputs.

This relies on a fix in bolero-hydro 0.13.7 (hydro-project/bolero@9f03f8f): `panic::catch`
previously consulted the panic hook's stored error (`take_panic()`) before checking for
the `any::Error` payload, and since the engines' panic hook stores every panic, assume
failures were misclassified as test failures (which would also have incorrectly triggered
replay-on-failure). The check is now reordered, and the hook-stored error for the assume
panic is discarded so it cannot leak into a later, unrelated failure's report.

Changes:
- `sim/mod.rs`: new `continue_if!` macro (`#[macro_export]` + `#[doc(hidden)]` at the
  crate root, documented canonically as `hydro_lang::sim::continue_if!` via an inlined
  re-export).
- `sim/compiled.rs`:
  - `continue_if_impl` helper: logs the failed condition to stderr (respecting the
    instance's log flag, now threaded into `SimConnections`) and triggers bolero's
    assume panic; `render_continue_if_failure` locates the source file (walking up from
    the cwd since `Location::file()` is workspace-relative) and echoes the offending
    line with a caret.
  - `fuzz_repro` now catches `any::Error` panics and reports a clear "reproducer may be
    stale" error instead of an opaque `Box<dyn Any>` panic.
  - `CompiledSim::fuzz` / `SimFlow::fuzz` relaxed from `AsyncFn` to `AsyncFnMut`
    (matching `exhaustive`), so tests can mutate captured state without atomics.
- `hydro_lang/Cargo.toml`: bump bolero-hydro to 0.13.7 (contains the classification fix).
- Tests covering all engine modes and the log format:
  - `sim_continue_if_discards_instances_exhaustive`: accepted < total, ≥1 accepted.
  - `sim_continue_if_discards_instances_fuzz`: RNG fuzz mode discards + accepts.
  - `sim_continue_if_does_not_mask_failures` (`#[should_panic]`): real failure behind a
    passing condition still fails (and stale hook errors from discarded instances can't
    pollute it).
  - `sim_continue_if_failure_in_fuzz_repro_is_reported` (`#[should_panic]`): stale-repro
    message.
  - `sim_crash_behind_continue_if` (`#[should_panic]`): crash only reachable behind a
    passing condition, found in RNG mode (uses a fixed message so its log is
    snapshot-stable).
  - `tests/sim_fuzzer.rs::fuzz_with_cargo_sim_continue_if`: end-to-end libfuzzer run via
    `cargo sim` that snapshots the condition-failure log block extracted from the
    fuzzer's stderr (verifying the reported location, echoed `continue_if!` source line,
    and caret — proving `#[track_caller]` propagation through the macro), and asserts
    the fuzzer still finds the real crash behind the condition. Snapshot stored in
    `tests/snapshots{,-nightly}/`.
- Docs: new "Restricting Explored Executions with `continue_if!`" section in
  `docs/docs/hydro/reference/simulation/writing.mdx`, noting the equivalence to `assume`
  in verification / property-testing libraries. The example is a compile-checked doctest
  (`rust,no_run` with hidden setup lines, since the sim's staged compilation cannot run
  inside a doctest).