### PR TITLE
fix(hydro_lang)!: prevent sim quiescence observations from overrunning the simulation

### DIFF
--- a/docs/docs/hydro/reference/simulation/writing.mdx
+++ b/docs/docs/hydro/reference/simulation/writing.mdx
@@ -44,6 +44,16 @@ For ordered streams, use `send()` to send a single message or `send_many()` to s
 
 The `exhaustive()` method explores *all* possible executions. This is feasible when the inputs are finite and the number of `nondet!` decision points is manageable. For complex protocols, use `fuzz()` instead (see [Coverage-Guided Simulation](./fuzzing.mdx) for details).
 
+### Receiving Outputs and Quiescence
+
+Instead of asserting, you can also receive output messages directly. `next()` waits for and returns the next message (failing the test if no more messages can arrive), and `collect_n(n)` returns the next `n` messages. These are always safe to use in the middle of a test: waiting for a message only runs the simulation work needed to produce it.
+
+Observing the *absence* of messages is more delicate, because the simulator must run **all** pending work (such as ticks with buffered inputs) to prove that no more messages can arrive—potentially running work that a later assertion expected to observe in an unfinished state. The simulator handles this depending on the API and mode:
+
+- The assertion methods (`assert_no_more()`, the `assert_yields_only*` variants, and `collect_n_only(n)`) first let the simulation *settle*: if it reaches quiescence with only deterministic work, the check is free and the test continues. Otherwise, under `exhaustive()` the search **forks**: one instance performs the check and ends there (explored first, so failures are attributed to the right assertion), while sibling instances skip the check and continue.
+- `try_next()` (returns `Option`) and `collect()` drain the simulation to quiescence when needed, in every mode. Because this may overrun pending work, they should be the *last* observations of a test: after forcing quiescence this way, sending more input and then attempting to receive output will panic.
+- Multi-phase tests that *intentionally* let the system settle between rounds of input (e.g. modeling timers that fire long after messages propagate) can insert an explicit `hydro_lang::sim::quiesce().await` phase barrier. This forces the simulation to quiesce and declares that later observations are meant to see the settled state, so the test may continue sending and receiving afterwards — at the cost of never exploring executions where the phases interleave (pair with a barrier-free test if those matter).
+
 ### Restricting Explored Executions with `continue_if!`
 
 Sometimes an assertion only makes sense for a subset of executions—for example, when the property you want to check only holds if certain messages happened to arrive in the same batch. The `hydro_lang::sim::continue_if!` macro lets you express such preconditions: if the condition is false, the current simulation instance is stopped and discarded (it is *not* a test failure), and exploration moves on to the next execution. This is the same concept as `assume` in verification tools and property-based testing libraries (e.g. `kani::assume` or proptest's `prop_assume!`).

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -3348,6 +3348,8 @@ mod tests {
         });
 
         assert_eq!(instances, 8);
+        // (final quiescence checks are free here: the simulation settles deterministically
+        // once all expected messages have been observed, so no extra instances are explored)
         // - three cases: all three in a separate tick (pick where (2, 3) is)
         // - two cases: (1, 1) and (1, 2) together, (2, 3) before or after
         // - two cases: (1, 1) and (1, 2) separate, (2, 3) grouped with one of them

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -1692,7 +1692,7 @@ mod tests {
         let out_recv = batch.all_ticks().sim_output();
 
         flow.sim().exhaustive(async || {
-            assert_eq!(out_recv.next().await.unwrap(), 10);
+            assert_eq!(out_recv.next().await, 10);
         });
     }
 
@@ -1736,11 +1736,11 @@ mod tests {
         let out_recv = batch.all_ticks().sim_output();
 
         flow.sim().exhaustive(async || {
-            assert_eq!(out_recv.next().await.unwrap(), 0);
+            assert_eq!(out_recv.next().await, 0);
 
             in_port.send(123);
 
-            assert_eq!(out_recv.next().await.unwrap(), 123);
+            assert_eq!(out_recv.next().await, 123);
         });
     }
 
@@ -1764,8 +1764,7 @@ mod tests {
         let out_recv = batch.all_ticks().sim_output();
 
         flow.sim().exhaustive(async || {
-            if out_recv.next().await.unwrap() == (1, 3) && out_recv.next().await.unwrap() == (2, 3)
-            {
+            if out_recv.next().await == (1, 3) && out_recv.next().await == (2, 3) {
                 panic!("repeated snapshot");
             }
         });

--- a/hydro_lang/src/live_collections/sliced/mod.rs
+++ b/hydro_lang/src/live_collections/sliced/mod.rs
@@ -545,13 +545,13 @@ mod tests {
 
         flow.sim().exhaustive(async || {
             input_send.send(1);
-            assert_eq!(out_recv.next().await.unwrap(), 1);
+            assert_eq!(out_recv.next().await, 1);
 
             input_send.send(1);
-            assert_eq!(out_recv.next().await.unwrap(), 2);
+            assert_eq!(out_recv.next().await, 2);
 
             input_send.send(1);
-            assert_eq!(out_recv.next().await.unwrap(), 3);
+            assert_eq!(out_recv.next().await, 3);
         });
     }
 
@@ -583,15 +583,15 @@ mod tests {
         flow.sim().exhaustive(async || {
             input_send.send(10);
             // First tick: prev is None, so output is -1
-            assert_eq!(out_recv.next().await.unwrap(), -1);
+            assert_eq!(out_recv.next().await, -1);
 
             input_send.send(20);
             // Second tick: prev is Some(10), so output is 10
-            assert_eq!(out_recv.next().await.unwrap(), 10);
+            assert_eq!(out_recv.next().await, 10);
 
             input_send.send(30);
             // Third tick: prev is Some(20), so output is 20
-            assert_eq!(out_recv.next().await.unwrap(), 20);
+            assert_eq!(out_recv.next().await, 20);
         });
     }
 
@@ -620,18 +620,18 @@ mod tests {
             input_send.send(3);
             // First tick: items = initial [10, 20], output = [10, 20]
             let mut results = vec![];
-            results.push(out_recv.next().await.unwrap());
-            results.push(out_recv.next().await.unwrap());
+            results.push(out_recv.next().await);
+            results.push(out_recv.next().await);
             results.sort();
             assert_eq!(results, vec![10, 20]);
 
             input_send.send(4);
             // Second tick: items = [3] (from previous batch), output = [3]
-            assert_eq!(out_recv.next().await.unwrap(), 3);
+            assert_eq!(out_recv.next().await, 3);
 
             input_send.send(5);
             // Third tick: items = [4] (from previous batch), output = [4]
-            assert_eq!(out_recv.next().await.unwrap(), 4);
+            assert_eq!(out_recv.next().await, 4);
         });
     }
 
@@ -665,16 +665,16 @@ mod tests {
 
         flow.sim().exhaustive(async || {
             input_send.send((1, 1));
-            assert_eq!(out_recv.next().await.unwrap(), (1, 1));
+            assert_eq!(out_recv.next().await, (1, 1));
 
             input_send.send((1, 2));
-            assert_eq!(out_recv.next().await.unwrap(), (1, 3));
+            assert_eq!(out_recv.next().await, (1, 3));
 
             input_send.send((2, 1));
-            assert_eq!(out_recv.next().await.unwrap(), (2, 1));
+            assert_eq!(out_recv.next().await, (2, 1));
 
             input_send.send((1, 3));
-            assert_eq!(out_recv.next().await.unwrap(), (1, 6));
+            assert_eq!(out_recv.next().await, (1, 6));
         });
     }
 }

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -3742,7 +3742,7 @@ mod tests {
             in_send.send(());
             in_send.send(());
 
-            assert_eq!(out_recv.next().await.unwrap(), 3); // fails with nondet batching
+            assert_eq!(out_recv.next().await, 3); // fails with nondet batching
         });
     }
 

--- a/hydro_lang/src/location/tick.rs
+++ b/hydro_lang/src/location/tick.rs
@@ -394,7 +394,7 @@ mod tests {
             write_send.send(1);
             write_ack_recv.assert_yields([1]).await;
             read_send.send(());
-            assert!(read_response_recv.next().await.is_some_and(|(_, v)| v >= 1));
+            assert!(read_response_recv.next().await.1 >= 1);
         });
 
         assert_eq!(instances, 1);
@@ -441,9 +441,8 @@ mod tests {
             write_ack_recv.assert_yields([1]).await;
             read_send.send(());
 
-            if let Some((_, v)) = read_response_recv.next().await {
-                assert_eq!(v, 1);
-            }
+            let (_, v) = read_response_recv.next().await;
+            assert_eq!(v, 1);
         });
     }
 }

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -1,5 +1,61 @@
 //! Interfaces for compiled Hydro simulators and concrete simulation instances.
 //!
+//! # Quiescence and observation soundness
+//!
+//! The scheduler distinguishes two kinds of simulation work:
+//! - **Deterministic work**: running the top-level async dataflows, which simply propagate
+//!   whatever data is already in flight. This makes no `nondet!` decisions, so running it can
+//!   never change which executions are explored.
+//! - **Nondeterministic work**: running ticks and observations, whose behavior depends on
+//!   decisions drawn from the bolero driver (batch boundaries, snapshot versions, message
+//!   orderings). Each decision forks the space of possible executions.
+//!
+//! The simulation is **quiescent** when neither kind of work can make progress without new
+//! external input. Test-side observations (the methods on [`SimReceiver`] /
+//! [`SimClusterReceiver`]) interact with the scheduler while waiting, and the key soundness
+//! question is: *when is it okay for an observation to let nondeterministic work run?*
+//!
+//! **Waiting for a message is always sound.** If the message eventually arrives, the work
+//! that ran was necessary to produce it (schedules that run *extra* work are also valid
+//! executions and are explored separately). If the simulation instead quiesces without
+//! producing the message, the assertion fails and the instance ends, so nothing can observe
+//! the overrun. This is why [`SimReceiver::next`], [`SimReceiver::collect_n`], and the
+//! `assert_yields*` prefix checks are safe to use in the middle of a test.
+//!
+//! **Observing the *absence* of a message is dangerous.** Proving that "no more messages can
+//! arrive" requires driving the simulation all the way to quiescence, running *all* pending
+//! nondeterministic work. A later assertion may have needed to observe a state where that
+//! work had not yet run — e.g., `assert_yields_only([1, 2])` followed by reading a counter
+//! must be able to see the counter *before* the ticks that count `1` and `2` have fired.
+//! Forcing quiescence at the first assertion would make some executions unobservable, and
+//! extra messages produced by the forced work could surface at a *later* assertion,
+//! misattributing the failure. Absence-observing APIs therefore proceed in phases:
+//!
+//! 1. **Settle** (see `SettlePauseGuard::poll_settle`): the scheduler runs only deterministic work, pausing
+//!    just before nondeterministic work. If the simulation reaches quiescence this way, the
+//!    end-of-stream check is *free* — no decision was forced, no execution was cut off — and
+//!    the test simply continues.
+//! 2. If nondeterministic work is pending, the check would overrun. What happens next depends
+//!    on the API and engine:
+//!    - The assertion APIs ([`SimReceiver::assert_no_more`], `assert_yields_only*`,
+//!      `collect_n_only`) under [`CompiledSim::exhaustive`] **fork** the search on a bolero
+//!      decision: one instance performs the check and then ends (via a discard panic, like
+//!      `sim::continue_if!`), while sibling instances skip the check entirely and continue. The
+//!      exhaustive driver enumerates the checking instance *first*, so a failing check is
+//!      found before any instance runs past it — with a decision trace that leads exactly to
+//!      the failing assertion. Since nothing after the check runs in the checking instance,
+//!      the overrun it performs is unobservable, and the continuing instances never quiesce,
+//!      so every downstream state remains reachable.
+//!    - Otherwise (fuzz / RNG / replay engines, or the drain-everything APIs
+//!      [`SimReceiver::try_next`], [`SimReceiver::collect`], and `collect_sorted` in every
+//!      mode), the pending work runs and the instance is **tainted**
+//!      (`QuiescenceState::tainted`). Reads of the now-quiescent state remain sound (they
+//!      observe a fully-drained simulation that can no longer advance), so tests may drain
+//!      multiple output ports at the end. But once new input is sent, the instance is
+//!      **poisoned** (`QuiescenceState::poisoned`): any further receive panics (see
+//!      `guard_not_poisoned`), because a failure observed after the forced overrun could
+//!      have been caused by it and attributed to the wrong assertion.
+//!
 //! NOTE: This module runs inside bolero's `catch_unwind` scope, which silently
 //! swallows panics. Internal invariant checks should use `abort_assert!`
 //! rather than `panic!`/`assert!`.
@@ -27,13 +83,13 @@ use std::panic::RefUnwindSafe;
 use std::path::Path;
 use std::pin::{Pin, pin};
 use std::rc::Rc;
-use std::task::ready;
+use std::task::{Poll, ready};
 
 use bytes::Bytes;
 use colored::Colorize;
 use dfir_rs::scheduled::context::DfirErased;
 use dfir_rs::util::unsync::mpsc::{Receiver as UnsyncReceiver, Sender as UnsyncSender};
-use futures::{Stream, StreamExt};
+use futures::StreamExt;
 use libloading::Library;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -55,11 +111,34 @@ struct QuiescenceState {
     quiescence_notify: Notify,
     /// Notified when new input is sent, signaling the scheduler to resume.
     resume_notify: Notify,
+    /// When nonzero, the scheduler must not start nondeterministic work (ticks /
+    /// observations): once only such work remains, it sets `nondet_pending` and pauses until
+    /// resumed. Used by receivers to query whether the simulation can quiesce
+    /// deterministically. This is a count (not a bool) because multiple settling futures can
+    /// be in flight at once (e.g. `select!`/`join!` between two receiver awaits): the
+    /// scheduler must stay paused until *every* one of them has finished settling.
+    pause_nondet: Cell<usize>,
+    /// Set while the scheduler is paused because nondeterministic work is ready to run but
+    /// `pause_nondet` is set.
+    nondet_pending: Cell<bool>,
+    /// Wakers for test-side tasks waiting for the scheduler to settle (either quiesce or set
+    /// `nondet_pending`) while `pause_nondet` is set.
+    settle_wakers: RefCell<Vec<std::task::Waker>>,
+    /// Set when an observation *forced* the simulation to quiesce (running pending
+    /// nondeterministic work) outside of exhaustive mode's forking. Further observations of
+    /// the quiescent state remain sound, but once new input is sent (see `poisoned`), later
+    /// observations could misattribute failures caused by the forced overrun.
+    tainted: Cell<bool>,
+    /// Set when new input is sent after `tainted`; all further receives panic.
+    poisoned: Cell<bool>,
 }
 
 impl QuiescenceState {
     /// Signal that new input has been sent, waking the scheduler if it was quiescent.
     fn resume(&self) {
+        if self.tainted.get() {
+            self.poisoned.set(true);
+        }
         self.quiescent.set(false);
         self.resume_notify.notify_waiters();
     }
@@ -74,13 +153,209 @@ impl QuiescenceState {
         self.quiescence_notify.notified()
     }
 
+    /// Wakes test-side tasks waiting for the scheduler to settle.
+    fn wake_settled(&self) {
+        for waker in self.settle_wakers.borrow_mut().drain(..) {
+            waker.wake();
+        }
+    }
+
     /// Enter quiescence and wait for new input before continuing.
     async fn wait_for_resume(&self) {
         self.quiescent.set(true);
         self.quiescence_notify.notify_waiters();
+        self.wake_settled();
         self.resume_notify.notified().await;
         self.quiescent.set(false);
     }
+}
+
+/// Tracks a pending "settle" pause request to the scheduler (see
+/// [`QuiescenceState::pause_nondet`]), releasing it if the requesting future is dropped
+/// mid-settle (e.g. by `select!`) so the scheduler is not left paused forever. Pause
+/// requests are counted, so concurrent settling futures each hold their own request.
+struct SettlePauseGuard {
+    quiescence: Rc<QuiescenceState>,
+    active: bool,
+}
+
+impl SettlePauseGuard {
+    fn new(quiescence: Rc<QuiescenceState>) -> Self {
+        SettlePauseGuard {
+            quiescence,
+            active: false,
+        }
+    }
+
+    fn acquire(&mut self) {
+        abort_assert!(!self.active, "settle pause acquired twice");
+        self.quiescence
+            .pause_nondet
+            .set(self.quiescence.pause_nondet.get() + 1);
+        self.active = true;
+    }
+
+    fn release(&mut self) {
+        abort_assert!(self.active, "settle pause released without being acquired");
+        self.active = false;
+        self.quiescence
+            .pause_nondet
+            .set(self.quiescence.pause_nondet.get() - 1);
+    }
+
+    /// Polls the "settle" handshake with the scheduler: deterministic (non-tick) work is
+    /// allowed to run, but the scheduler pauses instead of starting nondeterministic work
+    /// (ticks / observations). Resolves to `true` if the simulation reached quiescence
+    /// deterministically, or `false` if nondeterministic work is pending (in which case the
+    /// scheduler is resumed).
+    fn poll_settle(&mut self, cx: &mut std::task::Context<'_>) -> Poll<bool> {
+        let quiescence = self.quiescence.clone();
+        if !self.active {
+            if quiescence.is_quiescent() {
+                return Poll::Ready(true);
+            }
+            self.acquire();
+        }
+
+        if quiescence.is_quiescent() {
+            self.release();
+            Poll::Ready(true)
+        } else if quiescence.nondet_pending.get() {
+            self.release();
+            quiescence.resume_notify.notify_waiters();
+            Poll::Ready(false)
+        } else {
+            // This may push a duplicate waker if we are re-polled without an intervening
+            // `wake_settled` (e.g. a `join!` sibling waking the shared task), but duplicates
+            // are harmless (waking is idempotent) and are cleared at the next `wake_settled`,
+            // so deduplicating here isn't worth the scan on every poll.
+            quiescence
+                .settle_wakers
+                .borrow_mut()
+                .push(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+impl Drop for SettlePauseGuard {
+    fn drop(&mut self) {
+        if self.active {
+            self.release();
+            // Resume the scheduler in case this was the last pause request (otherwise it
+            // would stay parked forever with nobody left to resume it). If other settlers
+            // still hold requests, this wakeup is spurious but harmless: the scheduler
+            // re-checks `pause_nondet > 0` before starting any nondeterministic work, so it
+            // immediately re-parks without running anything.
+            self.quiescence.resume_notify.notify_waiters();
+        }
+    }
+}
+
+/// Panics if the simulation has been poisoned: an earlier observation forced the simulation
+/// to quiesce (running pending nondeterministic work), and new input has been sent since, so
+/// further observations could misattribute failures caused by the forced overrun.
+fn guard_not_poisoned(quiescence: &QuiescenceState) {
+    if quiescence.poisoned.get() {
+        panic!(
+            "cannot receive more simulator output: an earlier observation (such as `try_next`, `collect`, or a quiescence assertion outside exhaustive mode) forced the simulation to quiesce by running pending nondeterministic work, and new input has been sent since. Failures observed now could be misattributed, so either restructure the test to make quiescence-forcing observations its last step, or insert an explicit `sim::quiesce().await` phase barrier before sending more input."
+        );
+    }
+}
+
+/// Runs the simulation to quiescence, as an explicit *phase barrier* between rounds of a
+/// multi-phase test.
+///
+/// All pending nondeterministic work (ticks / observations) is forced to run until no more
+/// progress is possible without new input. This deliberately narrows the explored executions:
+/// inputs sent after the barrier will never interleave with work from before it, modeling
+/// scenarios where new stimuli (such as timer ticks) arrive long after the system settles.
+/// Pair such tests with a separate barrier-free test if interleaved executions should also be
+/// explored.
+///
+/// Because the barrier is explicit, observations after it are *intended* to see the fully
+/// settled state, so — unlike [`SimReceiver::try_next`] / [`SimReceiver::collect`] forcing
+/// quiescence implicitly — it does not restrict what the test may do afterwards: receives
+/// after the barrier observe only buffered output (plus whatever later input produces), and
+/// failures cannot be misattributed across it.
+pub async fn quiesce() {
+    let quiescence =
+        CURRENT_SIM_CONNECTIONS.with(|connections| connections.borrow().quiescence.clone());
+    guard_not_poisoned(&quiescence);
+
+    let mut notified_fut = pin!(None);
+    std::future::poll_fn(|cx| {
+        if quiescence.is_quiescent() {
+            return Poll::Ready(());
+        }
+        // Registered before the scheduler can run (single-threaded), so the quiescence
+        // notification cannot be missed.
+        if notified_fut.is_none() {
+            notified_fut.set(Some(quiescence.notified()));
+        }
+        let () = ready!(notified_fut.as_mut().as_pin_mut().unwrap().poll(cx));
+        Poll::Ready(())
+    })
+    .await;
+
+    // The barrier subsumes any quiescence forced by earlier observations in this phase:
+    // everything before it has fully settled, and the test has explicitly opted into
+    // observing only post-quiescence states from here on.
+    quiescence.tainted.set(false);
+}
+
+/// Receives the next message from `receiver` while trying not to overrun the simulation:
+/// first the simulation *settles* (deterministic work runs, but the scheduler pauses before
+/// nondeterministic work). If a message arrives, it is returned; if the simulation settles to
+/// quiescence, returns `None` without having run any nondeterministic work. Otherwise the
+/// scheduler is resumed and pending nondeterministic work runs until a message arrives or the
+/// simulation quiesces; quiescing this way *taints* the simulation (see
+/// [`QuiescenceState::tainted`]).
+async fn try_next_bytes(
+    receiver: &Mutex<UnsyncReceiver<Bytes>>,
+    quiescence: &Rc<QuiescenceState>,
+) -> Option<Bytes> {
+    guard_not_poisoned(quiescence);
+
+    let mut receiver_stream = receiver.lock().await;
+    let mut settle_guard = SettlePauseGuard::new(quiescence.clone());
+    // `Some` once the settle phase has concluded that nondeterministic work is pending and
+    // we have started forcing it to run.
+    let mut notified_fut = pin!(None);
+
+    std::future::poll_fn(|cx| {
+        // A message may become available at any point (including from deterministic work
+        // while settling), so always check the stream first.
+        match receiver_stream.poll_next_unpin(cx) {
+            Poll::Ready(Some(bytes)) => return Poll::Ready(Some(bytes)),
+            Poll::Ready(None) => return Poll::Ready(None),
+            Poll::Pending => {}
+        }
+
+        if notified_fut.is_none() {
+            match settle_guard.poll_settle(cx) {
+                // Deterministically quiescent: no more messages, and nothing was overrun.
+                Poll::Ready(true) => return Poll::Ready(None),
+                // Nondeterministic work is pending; start forcing it to run. The `Notified`
+                // is created here and polled (registered) below in this same synchronous
+                // poll — before the scheduler can run — and the simulation is not currently
+                // quiescent, so the quiescence notification cannot be missed.
+                Poll::Ready(false) => notified_fut.set(Some(quiescence.notified())),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        // Let the scheduler run nondeterministic work until a message arrives or the
+        // simulation quiesces. Note that merely entering this phase does not taint: if a
+        // message arrives (the `Some` exit at the top), waiting was sound for the same
+        // reason as `SimReceiver::next` — the work that ran was needed to produce it. Only
+        // *observing quiescence* after forcing the pending work taints, since that is the
+        // overrun a later observation could misattribute.
+        let () = ready!(notified_fut.as_mut().as_pin_mut().unwrap().poll(cx));
+        quiescence.tainted.set(true);
+        Poll::Ready(None)
+    })
+    .await
 }
 
 struct SimConnections {
@@ -92,6 +367,10 @@ struct SimConnections {
     external_registered: HashMap<ExternalPortId, SimExternalPort>,
     quiescence: Rc<QuiescenceState>,
     log: bool,
+    /// Whether this instance is being executed by the exhaustive engine (see
+    /// [`CompiledSim::exhaustive`]), which affects how `assert_yields_only` explores
+    /// quiescence checks.
+    exhaustive: bool,
 }
 
 /// Implementation detail of [`crate::sim::continue_if!`](crate::continue_if); do not call directly.
@@ -250,6 +529,7 @@ impl CompiledSim {
                 externals_port_registry: self.externals_port_registry.clone(),
                 dylib_result: None,
                 log,
+                exhaustive: false,
             }),
         )
     }
@@ -476,6 +756,7 @@ impl CompiledSim {
                     *count_mut += 1;
 
                     let mut instance = instantiator();
+                    instance.exhaustive = true;
                     if instance.log {
                         eprintln!(
                             "{}",
@@ -517,6 +798,7 @@ pub struct CompiledSimInstance<'a> {
     externals_port_registry: SimExternalPortRegistry,
     dylib_result: Option<DylibResult>,
     log: bool,
+    exhaustive: bool,
 }
 
 impl<'a> CompiledSimInstance<'a> {
@@ -565,6 +847,11 @@ impl<'a> CompiledSimInstance<'a> {
             quiescent: Cell::new(false),
             quiescence_notify: Notify::new(),
             resume_notify: Notify::new(),
+            pause_nondet: Cell::new(0),
+            nondet_pending: Cell::new(false),
+            settle_wakers: RefCell::new(vec![]),
+            tainted: Cell::new(false),
+            poisoned: Cell::new(false),
         });
 
         let mut input_senders = HashMap::new();
@@ -611,6 +898,7 @@ impl<'a> CompiledSimInstance<'a> {
                     external_registered: self.externals_port_registry.registered.clone(),
                     quiescence: quiescence.clone(),
                     log: self.log,
+                    exhaustive: self.exhaustive,
                 }),
                 async move {
                     thunk(self).await;
@@ -694,79 +982,275 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> Clone for SimRece
 
 impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> Copy for SimReceiver<T, O, R> {}
 
+/// How a [`QuiescenceCheckFuture`] resolves the "did the stream end?" check of
+/// `assert_no_more`. Decided once the simulation has settled (run out of deterministic
+/// work).
+#[derive(Clone, Copy)]
+enum QuiescenceBranch {
+    /// Skip the check and continue the test. Only taken in exhaustive mode, where a
+    /// sibling instance performs the check instead.
+    Continue,
+    /// Perform the check, then end this simulation instance (exhaustive mode), letting
+    /// sibling instances continue past this point without forcing quiescence.
+    CheckThenEnd,
+    /// Perform the check and keep running. Taken when the simulation is already quiescent
+    /// (the check is free) and in non-exhaustive modes.
+    CheckAndKeepRunning,
+}
+
+/// Decides how to run the quiescence check when the simulation has pending nondeterministic
+/// work (ticks / observations) that the check would force to run.
+fn decide_quiescence_branch() -> QuiescenceBranch {
+    let (exhaustive, log) = CURRENT_SIM_CONNECTIONS.with(|connections| {
+        let connections = connections.borrow();
+        (connections.exhaustive, connections.log)
+    });
+
+    if !exhaustive {
+        return QuiescenceBranch::CheckAndKeepRunning;
+    }
+
+    // In exhaustive mode, fork the search on a bolero decision. The exhaustive driver
+    // enumerates `false` first, so the instance that performs the quiescence check is
+    // explored *before* any instance that continues past this assertion. This ensures that
+    // if the stream has extra output, the failure is attributed to this assertion (with a
+    // decision trace leading exactly to the check) rather than leaking the extra messages
+    // into a later assertion.
+    let continue_without_check: bool = bolero::any();
+    if continue_without_check {
+        if log {
+            eprintln!(
+                "\n{}",
+                "Continuing past quiescence assertion without checking (checked by an earlier instance)"
+                    .color(colored::Color::Cyan)
+                    .bold()
+            );
+        }
+        QuiescenceBranch::Continue
+    } else {
+        if log {
+            eprintln!(
+                "\n{}",
+                "Checking that no more messages arrive (this instance will end after the check)"
+                    .color(colored::Color::Cyan)
+                    .bold()
+            );
+        }
+        QuiescenceBranch::CheckThenEnd
+    }
+}
+
+/// Ends the current simulation instance after a passing quiescence check, by panicking with
+/// [`bolero::generator::bolero_generator::any::Error`], which bolero's engines treat as an
+/// invalid input rather than a test failure. The instance has verified everything up to and
+/// including the quiescence check; sibling instances continue past the check instead.
+fn end_instance_after_quiescence_check() -> ! {
+    bolero::generator::bolero_generator::any::assume(
+        false,
+        "simulation instance ended after quiescence check",
+    );
+    unreachable!()
+}
+
+pin_project_lite::pin_project! {
+    // The "and then the stream ends" half of `assert_no_more` (and thus of
+    // `assert_yields_only*` / `collect_n_only`). First lets the simulation *settle* (see
+    // `poll_settle`): if it settles to quiescence, the check is free and the test simply
+    // continues. Otherwise, in exhaustive mode the search forks into a checking instance and
+    // continuing instances (see `SimReceiver::assert_no_more` and
+    // `decide_quiescence_branch`); in non-exhaustive modes the check runs, forcing the
+    // pending work (which taints the simulation, via `try_next_bytes`).
+    //
+    // See [`FutureTrackingCaller`] for why `poll` is `#[track_caller]`.
+    struct QuiescenceCheckFuture<F: Future<Output = ()>> {
+        #[pin]
+        check: F,
+        settle: SettlePauseGuard,
+        branch: Option<QuiescenceBranch>,
+    }
+}
+
+impl<F: Future<Output = ()>> QuiescenceCheckFuture<F> {
+    fn new(check: F) -> Self {
+        QuiescenceCheckFuture {
+            check,
+            settle: SettlePauseGuard::new(
+                CURRENT_SIM_CONNECTIONS.with(|connections| connections.borrow().quiescence.clone()),
+            ),
+            branch: None,
+        }
+    }
+}
+
+impl<F: Future<Output = ()>> Future for QuiescenceCheckFuture<F> {
+    type Output = ();
+
+    #[track_caller]
+    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        let this = self.as_mut().project();
+
+        if this.branch.is_none() {
+            *this.branch = Some(if ready!(this.settle.poll_settle(cx)) {
+                // Settled to quiescence deterministically, so the check is free.
+                QuiescenceBranch::CheckAndKeepRunning
+            } else {
+                // The check would force nondeterministic work to run.
+                decide_quiescence_branch()
+            });
+        }
+
+        match this.branch.unwrap() {
+            QuiescenceBranch::Continue => Poll::Ready(()),
+            QuiescenceBranch::CheckAndKeepRunning => this.check.poll(cx),
+            QuiescenceBranch::CheckThenEnd => {
+                ready!(this.check.poll(cx));
+                end_instance_after_quiescence_check()
+            }
+        }
+    }
+}
+
 impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimReceiver<T, O, R> {
-    async fn with_stream<Out>(
-        &self,
-        thunk: impl AsyncFnOnce(&mut Pin<&mut dyn Stream<Item = T>>) -> Out,
-    ) -> Out {
-        let (receiver, quiescence) = CURRENT_SIM_CONNECTIONS.with(|connections| {
+    fn connections(&self) -> (Rc<Mutex<UnsyncReceiver<Bytes>>>, Rc<QuiescenceState>) {
+        CURRENT_SIM_CONNECTIONS.with(|connections| {
             let connections = connections.borrow();
             let port = connections.external_registered.get(&self.0).unwrap();
             (
                 connections.output_receivers.get(port).unwrap().clone(),
                 connections.quiescence.clone(),
             )
-        });
+        })
+    }
 
-        let mut receiver_stream = receiver.lock().await;
-        let mut notified_fut = pin!(quiescence.notified());
-        let mut quiescence_aware = futures::stream::poll_fn(|cx| {
-            use std::task::Poll;
-            match receiver_stream.poll_next_unpin(cx) {
-                Poll::Ready(Some(bytes)) => {
-                    return Poll::Ready(Some(bincode::deserialize(&bytes).unwrap()));
-                }
-                Poll::Ready(None) => return Poll::Ready(None),
-                Poll::Pending => {}
-            }
-            if quiescence.is_quiescent() {
-                return Poll::Ready(None);
-            }
-            let () = ready!(notified_fut.as_mut().poll(cx));
-            notified_fut.set(quiescence.notified());
-            Poll::Ready(None)
-        });
-        thunk(&mut pin!(&mut quiescence_aware)).await
+    /// See [`try_next_bytes`].
+    async fn try_next_impl(&self) -> Option<T> {
+        let (receiver, quiescence) = self.connections();
+        try_next_bytes(&receiver, &quiescence)
+            .await
+            .map(|bytes| bincode::deserialize(&bytes).unwrap())
     }
 
     /// Asserts that the stream has ended and no more messages can possibly arrive.
+    ///
+    /// If the check cannot be answered without running pending nondeterministic work (such
+    /// as ticks with buffered inputs):
+    /// - Under [`CompiledSim::exhaustive`], the search forks: one instance performs the
+    ///   check and ends there, while sibling instances skip the check and continue.
+    /// - In other modes, the pending work runs; afterwards, sending more input and then
+    ///   attempting to receive output will panic.
     pub fn assert_no_more(self) -> impl Future<Output = ()>
     where
         T: Debug,
     {
-        FutureTrackingCaller {
+        QuiescenceCheckFuture::new(FutureTrackingCaller {
             future: async move {
-                self.with_stream(async |stream| {
-                    if let Some(next) = stream.next().await {
-                        return Err(format!(
-                            "Stream yielded unexpected message: {:?}, expected termination",
-                            next
-                        ));
-                    }
-                    Ok(())
-                })
-                .await
+                if let Some(next) = self.try_next_impl().await {
+                    return Err(format!(
+                        "Stream yielded unexpected message: {:?}, expected termination",
+                        next
+                    ));
+                }
+                Ok(())
             },
-        }
+        })
     }
 }
 
 impl<T: Serialize + DeserializeOwned> SimReceiver<T, TotalOrder, ExactlyOnce> {
-    /// Receives the next message from the external bincode stream. This will wait until a message
-    /// is available, or return `None` if no more messages can possibly arrive.
-    pub async fn next(&self) -> Option<T> {
-        self.with_stream(async |stream| stream.next().await).await
+    /// Receives the next message from the external bincode stream, waiting (and letting the
+    /// scheduler run any pending simulation work) until one is available. If the simulation
+    /// becomes quiescent without producing a message, the test fails.
+    ///
+    /// This is safe to use in the middle of a test; to observe the *absence* of a message,
+    /// use [`Self::try_next`] or [`Self::assert_no_more`].
+    pub fn next(&self) -> impl use<'_, T> + Future<Output = T> {
+        // Waiting for a message never "overruns" the simulation, even though the scheduler
+        // may run nondeterministic ticks while we wait: if a message arrives, some pending
+        // work was necessary to produce it (schedules that run *extra* work are also valid
+        // executions, explored separately), and if the simulation quiesces instead, the test
+        // fails right here — so no later observation can be affected by the overrun (the
+        // taint set by `try_next_impl` is unobservable). See the module docs for the full
+        // soundness reasoning.
+        FutureTrackingCaller {
+            future: async move {
+                self.try_next_impl().await.ok_or_else(|| {
+                    "Stream ended (simulation quiescent), but another message was expected"
+                        .to_owned()
+                })
+            },
+        }
     }
 
-    /// Collects all remaining messages from the external bincode stream into a collection. This
-    /// will wait until no more messages can possibly arrive.
+    /// Receives the next message from the external bincode stream, or returns `None` if no
+    /// more messages can possibly arrive.
+    ///
+    /// If answering requires forcing pending nondeterministic work to run, then afterwards,
+    /// sending more input and then attempting to receive output will panic. Prefer
+    /// [`Self::next`] (or [`Self::assert_no_more`]) when possible.
+    pub async fn try_next(&self) -> Option<T> {
+        self.try_next_impl().await
+    }
+
+    /// Receives the next `n` messages from the external bincode stream, waiting (and letting
+    /// the scheduler run any pending simulation work) until they are available. If the
+    /// simulation becomes quiescent before `n` messages arrive, the test fails.
+    ///
+    /// Like [`Self::next`], this is safe to use in the middle of a test. It does not check
+    /// that the stream ends afterwards; use [`Self::collect_n_only`] for that.
+    pub fn collect_n<C: Default + Extend<T>>(
+        &self,
+        n: usize,
+    ) -> impl use<'_, T, C> + Future<Output = C> {
+        FutureTrackingCaller {
+            future: async move {
+                let mut out = C::default();
+                for i in 0..n {
+                    // Like `next`, waiting for each message is safe mid-test; the taint on a
+                    // forced `None` is unobservable because the test fails below.
+                    if let Some(v) = self.try_next_impl().await {
+                        out.extend([v]);
+                    } else {
+                        return Err(format!(
+                            "Stream ended (simulation quiescent) after {} messages, but {} were expected",
+                            i, n
+                        ));
+                    }
+                }
+                Ok(out)
+            },
+        }
+    }
+
+    /// Receives the next `n` messages (like [`Self::collect_n`]) and then asserts that the
+    /// stream ends (like [`Self::assert_no_more`], forking the search in exhaustive mode).
+    pub async fn collect_n_only<C: Default + Extend<T>>(self, n: usize) -> C
+    where
+        T: Debug,
+    {
+        let out = self.collect_n(n).await;
+        self.assert_no_more().await;
+        out
+    }
+
+    /// Collects all remaining messages from the external bincode stream into a collection,
+    /// waiting until no more messages can possibly arrive.
+    ///
+    /// If this has to force pending nondeterministic work to run, it should be the last
+    /// observation of the test: afterwards, sending more input and then attempting to
+    /// receive output will panic. When the number of expected messages is known, prefer
+    /// [`Self::collect_n`] / [`Self::collect_n_only`].
     pub async fn collect<C: Default + Extend<T>>(self) -> C {
-        self.with_stream(async |stream| stream.collect().await)
-            .await
+        let mut out = C::default();
+        while let Some(v) = self.try_next_impl().await {
+            out.extend([v]);
+        }
+        out
     }
 
     /// Asserts that the stream yields exactly the expected sequence of messages, in order.
     /// This does not check that the stream ends, use [`Self::assert_yields_only`] for that.
+    ///
+    /// Like [`Self::next`], this is safe to use in the middle of a test.
     pub fn assert_yields<T2: Debug, I: IntoIterator<Item = T2>>(
         &self,
         expected: I,
@@ -779,7 +1263,9 @@ impl<T: Serialize + DeserializeOwned> SimReceiver<T, TotalOrder, ExactlyOnce> {
                 let mut expected: VecDeque<T2> = expected.into_iter().collect();
 
                 while !expected.is_empty() {
-                    if let Some(next) = self.next().await {
+                    // Like `next`, waiting for each expected message is safe mid-test; the
+                    // taint on a forced `None` is unobservable because the test fails below.
+                    if let Some(next) = self.try_next_impl().await {
                         let next_expected = expected.pop_front().unwrap();
                         if next != next_expected {
                             return Err(format!(
@@ -801,7 +1287,7 @@ impl<T: Serialize + DeserializeOwned> SimReceiver<T, TotalOrder, ExactlyOnce> {
     }
 
     /// Asserts that the stream yields only the expected sequence of messages, in order,
-    /// and then ends.
+    /// and then ends (like [`Self::assert_no_more`], forking the search in exhaustive mode).
     pub fn assert_yields_only<T2: Debug, I: IntoIterator<Item = T2>>(
         &self,
         expected: I,
@@ -827,22 +1313,19 @@ pin_project_lite::pin_project! {
     // create these concrete future types that (1) have `#[track_caller]` on their `poll()`
     // method and (2) have the `panic!` triggered in their `poll()` method (or in a directly
     // nested concrete future).
-    struct FutureTrackingCaller<F: Future<Output = Result<(), String>>> {
+    struct FutureTrackingCaller<F> {
         #[pin]
         future: F,
     }
 }
 
-impl<F: Future<Output = Result<(), String>>> Future for FutureTrackingCaller<F> {
-    type Output = ();
+impl<T, F: Future<Output = Result<T, String>>> Future for FutureTrackingCaller<F> {
+    type Output = T;
 
     #[track_caller]
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
         match ready!(self.as_mut().project().future.poll(cx)) {
-            Ok(()) => std::task::Poll::Ready(()),
+            Ok(v) => Poll::Ready(v),
             Err(e) => panic!("{}", e),
         }
     }
@@ -865,10 +1348,7 @@ impl<F1: Future<Output = ()>, F2: Future<Output = ()>> Future for ChainedFuture<
     type Output = ();
 
     #[track_caller]
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
         if !self.first_done {
             ready!(self.as_mut().project().first.poll(cx));
             *self.as_mut().project().first_done = true;
@@ -879,22 +1359,60 @@ impl<F1: Future<Output = ()>, F2: Future<Output = ()>> Future for ChainedFuture<
 }
 
 impl<T: Serialize + DeserializeOwned> SimReceiver<T, NoOrder, ExactlyOnce> {
+    /// Receives the next `n` messages, sorted, waiting (and letting the scheduler run any
+    /// pending simulation work) until they are available. If the simulation becomes quiescent
+    /// before `n` messages arrive, the test fails.
+    ///
+    /// Like [`SimReceiver::next`], this is safe to use in the middle of a test.
+    pub fn collect_n_sorted<C: Default + Extend<T> + AsMut<[T]>>(
+        &self,
+        n: usize,
+    ) -> impl use<'_, T, C> + Future<Output = C>
+    where
+        T: Ord,
+    {
+        FutureTrackingCaller {
+            future: async move {
+                let mut out = C::default();
+                for i in 0..n {
+                    // Like `next`, waiting for each message is safe mid-test; the taint on a
+                    // forced `None` is unobservable because the test fails below.
+                    if let Some(v) = self.try_next_impl().await {
+                        out.extend([v]);
+                    } else {
+                        return Err(format!(
+                            "Stream ended (simulation quiescent) after {} messages, but {} were expected",
+                            i, n
+                        ));
+                    }
+                }
+                out.as_mut().sort();
+                Ok(out)
+            },
+        }
+    }
+
     /// Collects all remaining messages from the external bincode stream into a collection,
     /// sorting them. This will wait until no more messages can possibly arrive.
+    ///
+    /// If this has to force pending nondeterministic work to run, it should be the last
+    /// observation of the test; see [`collect`](SimReceiver::collect).
     pub async fn collect_sorted<C: Default + Extend<T> + AsMut<[T]>>(self) -> C
     where
         T: Ord,
     {
-        self.with_stream(async |stream| {
-            let mut collected: C = stream.collect().await;
-            collected.as_mut().sort();
-            collected
-        })
-        .await
+        let mut collected = C::default();
+        while let Some(v) = self.try_next_impl().await {
+            collected.extend([v]);
+        }
+        collected.as_mut().sort();
+        collected
     }
 
     /// Asserts that the stream yields exactly the expected sequence of messages, in some order.
     /// This does not check that the stream ends, use [`Self::assert_yields_only_unordered`] for that.
+    ///
+    /// Like [`SimReceiver::next`], this is safe to use in the middle of a test.
     pub fn assert_yields_unordered<T2: Debug, I: IntoIterator<Item = T2>>(
         &self,
         expected: I,
@@ -904,37 +1422,33 @@ impl<T: Serialize + DeserializeOwned> SimReceiver<T, NoOrder, ExactlyOnce> {
     {
         FutureTrackingCaller {
             future: async {
-                self.with_stream(async |stream| {
-                    let mut expected: Vec<T2> = expected.into_iter().collect();
+                let mut expected: Vec<T2> = expected.into_iter().collect();
 
-                    while !expected.is_empty() {
-                        if let Some(next) = stream.next().await {
-                            let idx = expected.iter().enumerate().find(|(_, e)| &next == *e);
-                            if let Some((i, _)) = idx {
-                                expected.swap_remove(i);
-                            } else {
-                                return Err(format!(
-                                    "Stream yielded unexpected message: {:?}",
-                                    next
-                                ));
-                            }
+                while !expected.is_empty() {
+                    // Like `next`, waiting for each expected message is safe mid-test; the
+                    // taint on a forced `None` is unobservable because the test fails below.
+                    if let Some(next) = self.try_next_impl().await {
+                        let idx = expected.iter().enumerate().find(|(_, e)| &next == *e);
+                        if let Some((i, _)) = idx {
+                            expected.swap_remove(i);
                         } else {
-                            return Err(format!(
-                                "Stream ended early, still expected: {:?}",
-                                expected
-                            ));
+                            return Err(format!("Stream yielded unexpected message: {:?}", next));
                         }
+                    } else {
+                        return Err(format!(
+                            "Stream ended early, still expected: {:?}",
+                            expected
+                        ));
                     }
+                }
 
-                    Ok(())
-                })
-                .await
+                Ok(())
             },
         }
     }
 
     /// Asserts that the stream yields only the expected sequence of messages, in some order,
-    /// and then ends.
+    /// and then ends (like [`Self::assert_no_more`], forking the search in exhaustive mode).
     pub fn assert_yields_only_unordered<T2: Debug, I: IntoIterator<Item = T2>>(
         &self,
         expected: I,
@@ -1017,12 +1531,11 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> Copy
 }
 
 impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterReceiver<T, O, R> {
-    async fn with_member_stream<Out>(
+    fn member_connections(
         &self,
         member_id: u32,
-        thunk: impl AsyncFnOnce(&mut Pin<&mut dyn Stream<Item = T>>) -> Out,
-    ) -> Out {
-        let (receiver, quiescence) = CURRENT_SIM_CONNECTIONS.with(|connections| {
+    ) -> (Rc<Mutex<UnsyncReceiver<Bytes>>>, Rc<QuiescenceState>) {
+        CURRENT_SIM_CONNECTIONS.with(|connections| {
             let connections = connections.borrow();
             let port = connections.external_registered.get(&self.0).unwrap();
             let receivers = connections.cluster_output_receivers.get(port).unwrap();
@@ -1030,56 +1543,113 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterReceive
                 receivers[&member_id].clone(),
                 connections.quiescence.clone(),
             )
-        });
+        })
+    }
 
-        let mut lock = receiver.lock().await;
-        let mut notified_fut = pin!(quiescence.notified());
-        let mut quiescence_aware = futures::stream::poll_fn(|cx| {
-            use std::task::Poll;
-            match lock.poll_next_unpin(cx) {
-                Poll::Ready(Some(bytes)) => {
-                    return Poll::Ready(Some(bincode::deserialize(&bytes).unwrap()));
-                }
-                Poll::Ready(None) => return Poll::Ready(None),
-                Poll::Pending => {}
-            }
-            if quiescence.is_quiescent() {
-                return Poll::Ready(None);
-            }
-            let () = ready!(notified_fut.as_mut().poll(cx));
-            notified_fut.set(quiescence.notified());
-            Poll::Ready(None)
-        });
-        thunk(&mut pin!(&mut quiescence_aware)).await
+    /// See [`try_next_bytes`].
+    async fn try_next_impl(&self, member_id: u32) -> Option<T> {
+        let (receiver, quiescence) = self.member_connections(member_id);
+        try_next_bytes(&receiver, &quiescence)
+            .await
+            .map(|bytes| bincode::deserialize(&bytes).unwrap())
     }
 }
 
 impl<T: Serialize + DeserializeOwned> SimClusterReceiver<T, TotalOrder, ExactlyOnce> {
-    /// Receives the next value from a specific cluster member.
-    pub async fn next(&self, member_id: u32) -> Option<T> {
-        self.with_member_stream(member_id, async |stream| stream.next().await)
-            .await
+    /// Receives the next value from a specific cluster member, waiting (and letting the
+    /// scheduler run any pending simulation work) until one is available. If the simulation
+    /// becomes quiescent without producing a value, the test fails.
+    ///
+    /// This is safe to use in the middle of a test; to observe the *absence* of a value,
+    /// use [`Self::try_next`].
+    pub fn next(&self, member_id: u32) -> impl use<'_, T> + Future<Output = T> {
+        // See `SimReceiver::next` for why waiting for a value never "overruns" the
+        // simulation.
+        FutureTrackingCaller {
+            future: async move {
+                self.try_next_impl(member_id).await.ok_or_else(|| {
+                    "Stream ended (simulation quiescent), but another message was expected"
+                        .to_owned()
+                })
+            },
+        }
     }
 
-    /// Collects all remaining values from a specific cluster member into a collection.
+    /// Receives the next value from a specific cluster member, or returns `None` if no more
+    /// values can possibly arrive.
+    ///
+    /// If answering requires forcing pending nondeterministic work to run, then afterwards,
+    /// sending more input and then attempting to receive output will panic. Prefer
+    /// [`Self::next`] when possible.
+    pub async fn try_next(&self, member_id: u32) -> Option<T> {
+        self.try_next_impl(member_id).await
+    }
+
+    /// Collects all remaining values from a specific cluster member into a collection,
+    /// waiting until no more values can possibly arrive.
+    ///
+    /// If this has to force pending nondeterministic work to run, it should be the last
+    /// observation of the test; see [`SimReceiver::collect`].
     pub async fn collect<C: Default + Extend<T>>(self, member_id: u32) -> C {
-        self.with_member_stream(member_id, async |stream| stream.collect().await)
-            .await
+        let mut out = C::default();
+        while let Some(v) = self.try_next_impl(member_id).await {
+            out.extend([v]);
+        }
+        out
     }
 }
 
 impl<T: Serialize + DeserializeOwned> SimClusterReceiver<T, NoOrder, ExactlyOnce> {
-    /// Collects all remaining values from a specific cluster member, sorted.
+    /// Receives the next `n` values from a specific cluster member, sorted, waiting (and
+    /// letting the scheduler run any pending simulation work) until they are available. If
+    /// the simulation becomes quiescent before `n` values arrive, the test fails.
+    ///
+    /// Like [`SimReceiver::next`], this is safe to use in the middle of a test.
+    pub fn collect_n_sorted<C: Default + Extend<T> + AsMut<[T]>>(
+        &self,
+        member_id: u32,
+        n: usize,
+    ) -> impl use<'_, T, C> + Future<Output = C>
+    where
+        T: Ord,
+    {
+        FutureTrackingCaller {
+            future: async move {
+                let mut out = C::default();
+                for i in 0..n {
+                    // Like `SimReceiver::next`, waiting for each message is safe mid-test;
+                    // the taint on a forced `None` is unobservable because the test fails
+                    // below.
+                    if let Some(v) = self.try_next_impl(member_id).await {
+                        out.extend([v]);
+                    } else {
+                        return Err(format!(
+                            "Stream ended (simulation quiescent) after {} messages, but {} were expected",
+                            i, n
+                        ));
+                    }
+                }
+                out.as_mut().sort();
+                Ok(out)
+            },
+        }
+    }
+
+    /// Collects all remaining values from a specific cluster member, sorted, waiting until no
+    /// more values can possibly arrive.
+    ///
+    /// If this has to force pending nondeterministic work to run, it should be the last
+    /// observation of the test; see [`SimReceiver::collect`].
     pub async fn collect_sorted<C: Default + Extend<T> + AsMut<[T]>>(self, member_id: u32) -> C
     where
         T: Ord,
     {
-        self.with_member_stream(member_id, async |stream| {
-            let mut collected: C = stream.collect().await;
-            collected.as_mut().sort();
-            collected
-        })
-        .await
+        let mut collected = C::default();
+        while let Some(v) = self.try_next_impl(member_id).await {
+            collected.extend([v]);
+        }
+        collected.as_mut().sort();
+        collected
     }
 }
 
@@ -1276,6 +1846,15 @@ impl<W: std::io::Write> LaunchedSim<W> {
 
                     // Signal quiescence and wait for new input.
                     self.quiescence.wait_for_resume().await;
+                } else if self.quiescence.pause_nondet.get() > 0 {
+                    // The test is querying whether the simulation can quiesce without
+                    // nondeterministic work (see `QuiescenceCheckFuture`). Report that
+                    // ticks/observations are pending and pause until the test decides how
+                    // to proceed.
+                    self.quiescence.nondet_pending.set(true);
+                    self.quiescence.wake_settled();
+                    self.quiescence.resume_notify.notified().await;
+                    self.quiescence.nondet_pending.set(false);
                 } else {
                     let next_tick_or_obs = (0..(self.possibly_ready_ticks.len()
                         + self.possibly_ready_observation.len()))

--- a/hydro_lang/src/sim/mod.rs
+++ b/hydro_lang/src/sim/mod.rs
@@ -62,6 +62,8 @@ pub mod runtime;
 #[cfg(stageleft_runtime)]
 #[doc(hidden)]
 pub use compiled::continue_if_impl;
+#[cfg(stageleft_runtime)]
+pub use compiled::quiesce;
 
 /// Continues the current simulation instance only if the given condition holds, otherwise
 /// stopping and discarding the instance.

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -28,7 +28,7 @@ fn sim_crash_in_output() {
     flow.sim().fuzz(async || {
         in_send.send(bolero::any::<Vec<u8>>().into());
 
-        let x = out_recv.next().await.unwrap();
+        let x = out_recv.next().await;
         if !x.is_empty() && x[0] == 42 && x.len() > 1 && x[1] == 43 && x.len() > 2 && x[2] == 44 {
             panic!("boom");
         }
@@ -56,7 +56,7 @@ fn sim_crash_in_output_with_filter() {
     flow.sim().fuzz(async || {
         in_send.send(bolero::any::<Vec<u8>>().into());
 
-        if let Some(x) = out_recv.next().await
+        if let Some(x) = out_recv.try_next().await
             && x.len() > 2
             && x[2] == 44
         {
@@ -84,10 +84,10 @@ fn sim_batch_preserves_order_fuzzed() {
         in_send.send(2);
         in_send.send(3);
 
-        assert_eq!(out_recv.next().await.unwrap(), 1);
-        assert_eq!(out_recv.next().await.unwrap(), 2);
-        assert_eq!(out_recv.next().await.unwrap(), 3);
-        assert!(out_recv.next().await.is_none());
+        assert_eq!(out_recv.next().await, 1);
+        assert_eq!(out_recv.next().await, 2);
+        assert_eq!(out_recv.next().await, 3);
+        assert!(out_recv.try_next().await.is_none());
     });
 }
 
@@ -144,7 +144,7 @@ fn sim_crash_with_fuzzed_batching() {
 
         in_send.send(99); // the fuzzer must put this in a later batch
 
-        while let Some(out) = out_recv.next().await {
+        while let Some(out) = out_recv.try_next().await {
             if out == 456 {
                 // make sure exhaustive can't catch the bug by using trivial (size 1) batches
                 return;
@@ -185,7 +185,7 @@ fn trace_for_fuzzed_batching() {
 
                 in_send.send(99); // the fuzzer must put this in a later batch
 
-                while let Some(out) = out_recv.next().await {
+                while let Some(out) = out_recv.try_next().await {
                     if out == 456 {
                         // make sure exhaustive can't catch the bug by using trivial (size 1) batches
                         return;
@@ -237,7 +237,7 @@ fn trace_for_fuzzed_batching_sliced() {
 
                 in_send.send(99); // the fuzzer must put this in a later batch
 
-                while let Some(out) = out_recv.next().await {
+                while let Some(out) = out_recv.try_next().await {
                     if out == 456 {
                         // make sure exhaustive can't catch the bug by using trivial (size 1) batches
                         return;
@@ -323,9 +323,9 @@ fn sim_cluster_e2m_m2e() {
             in_send.send(2, 3); // member 2 gets 3
 
             // Each member multiplies by 10
-            assert_eq!(out_recv.next(0).await, Some(10));
-            assert_eq!(out_recv.next(1).await, Some(20));
-            assert_eq!(out_recv.next(2).await, Some(30));
+            assert_eq!(out_recv.next(0).await, 10);
+            assert_eq!(out_recv.next(1).await, 20);
+            assert_eq!(out_recv.next(2).await, 30);
         });
 }
 #[test]
@@ -398,6 +398,252 @@ fn assert_yields_only_catches_extra_value() {
         send_port.send(2u32);
         // Expects only [1], but stream also produces 2 → should panic
         out_port.assert_yields_only([1u32]).await;
+    });
+}
+
+/// A two-slice program for testing quiescence handling: the first slice passes the input
+/// through, and a second slice counts a clone of the first slice's output, reporting the
+/// current count whenever a read request arrives. After `assert_yields`/`assert_yields_only`
+/// observes the passed-through messages, the second slice's tick still has the cloned
+/// messages buffered, so the simulation cannot settle to quiescence deterministically.
+fn two_slice_counter_program(
+    process: Process<'_>,
+) -> (
+    SimSender<u32, TotalOrder, ExactlyOnce>,
+    SimReceiver<u32, TotalOrder, ExactlyOnce>,
+    SimSender<(), TotalOrder, ExactlyOnce>,
+    SimReceiver<i32, TotalOrder, ExactlyOnce>,
+) {
+    let (send_port, input) = process.sim_input();
+
+    let first_slice_out = sliced! {
+        let in_batch = use::batch(input, nondet!(/** test */));
+        in_batch
+    };
+
+    let first_slice_out_cloned = first_slice_out.clone();
+    let (send_read_counter, read_counter) = process.sim_input();
+    #[expect(unused_mut, reason = "`mut` is consumed by the `sliced!` macro")]
+    let second_slice_count_out = sliced! {
+        let mut count = use::state(|l| l.singleton(q!(0)));
+        let cloned_batch = use::batch(first_slice_out_cloned, nondet!(/** test */));
+        let read_counter_batch = use::batch(read_counter, nondet!(/** test */));
+
+        let count_mut = count.by_mut();
+        cloned_batch.for_each(q!(|_| {
+            *count_mut += 1
+        }));
+
+        read_counter_batch.first().into_stream().map(q!(|_| *count_mut))
+    };
+
+    let out_port = first_slice_out.sim_output();
+    let second_slice_out_port = second_slice_count_out.sim_output();
+
+    (
+        send_port,
+        out_port,
+        send_read_counter,
+        second_slice_out_port,
+    )
+}
+
+#[test]
+fn sim_assert_yields_only_doesnt_trigger_unnecessary_ticks() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process::<()>();
+    let (send_port, out_port, send_read_counter, second_slice_out_port) =
+        two_slice_counter_program(process);
+
+    let mut at_least_one_zero = false;
+    flow.sim().exhaustive(async || {
+        send_port.send_many([1u32, 2u32]);
+        out_port.assert_yields_only([1u32, 2u32]).await;
+
+        send_read_counter.send(());
+        let count_first_read = second_slice_out_port.next().await;
+        if count_first_read == 0 {
+            at_least_one_zero = true;
+        }
+    });
+
+    assert!(at_least_one_zero);
+}
+
+/// When `assert_yields_only` observes extra output, the failure must be attributed to that
+/// assertion (via its quiescence check) rather than leaking the extra message into a later
+/// assertion. In exhaustive mode, the instance that performs the quiescence check must be
+/// explored *first*, so the misattributed failure is never reached.
+#[test]
+fn sim_assert_yields_only_checks_quiescence_first() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process::<()>();
+
+    let (send_port, input) = process.sim_input();
+    let out_port = input.atomic().end_atomic().sim_output();
+
+    let mut instances = 0;
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        flow.sim().exhaustive(async || {
+            instances += 1;
+            send_port.send_many([1u32, 2u32, 3u32]);
+            // The extra `3` must be caught here by the quiescence check...
+            out_port.assert_yields_only([1u32, 2u32]).await;
+
+            // ...and not surface as a mismatch (`expected 4, got 3`) in this later assertion.
+            send_port.send(4u32);
+            out_port.assert_yields_only([4u32]).await;
+        });
+    }));
+
+    let panic_msg = *result.unwrap_err().downcast::<String>().unwrap();
+    assert!(
+        panic_msg.contains("expected termination"),
+        "failure was not attributed to the quiescence check: {}",
+        panic_msg
+    );
+    // The failing quiescence check must be explored on the very first instance
+    // (bolero replays the failing instance once, hence 2).
+    assert_eq!(instances, 2);
+}
+
+/// Concurrent receiver awaits (e.g. via `join!`) each hold their own scheduler pause while
+/// settling: one of them finishing (or being dropped) must not unpause the scheduler while
+/// the other is still settling. This exercises the pause *count* on the quiescence state.
+#[test]
+fn sim_concurrent_settling_awaits() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process::<()>();
+    let (send_port, out_port, send_read_counter, second_slice_out_port) =
+        two_slice_counter_program(process);
+
+    flow.sim().exhaustive(async || {
+        send_port.send_many([1u32, 2u32]);
+        send_read_counter.send(());
+
+        let (msgs, count) = futures::join!(
+            out_port.collect_n::<Vec<_>>(2),
+            second_slice_out_port.next()
+        );
+        assert_eq!(msgs, vec![1, 2]);
+        assert!(count <= 2);
+    });
+}
+
+/// Outside exhaustive mode there is no forking, so when `assert_yields_only`'s quiescence
+/// check has to force pending nondeterministic work (the second slice's buffered ticks), the
+/// instance is tainted: sending more input and then receiving output must panic instead of
+/// potentially misattributing failures caused by the forced overrun.
+#[test]
+#[should_panic(expected = "cannot receive more simulator output")]
+fn sim_fuzz_forced_quiescence_check_poisons_later_receives() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process::<()>();
+    let (send_port, out_port, send_read_counter, second_slice_out_port) =
+        two_slice_counter_program(process);
+
+    // uses RNG fuzzing when run under `cargo test`
+    flow.sim().fuzz(async || {
+        send_port.send_many([1u32, 2u32]);
+        // The second slice still has the cloned messages buffered, so this check must force
+        // its ticks to run, tainting the instance.
+        out_port.assert_yields_only([1u32, 2u32]).await;
+
+        // Sending after the taint poisons the instance...
+        send_read_counter.send(());
+        // ...so this receive must panic.
+        let _ = second_slice_out_port.next().await;
+    });
+}
+
+/// When the simulation settles to quiescence with only deterministic work, the quiescence
+/// check is free: even outside exhaustive mode, it does not taint the instance, so the test
+/// can keep sending input and asserting afterwards.
+#[test]
+fn sim_fuzz_free_quiescence_check_does_not_taint() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process::<()>();
+
+    let (send_port, input) = process.sim_input();
+    // A pass-through flow with no ticks: consuming the expected messages leaves no pending
+    // nondeterministic work, so the quiescence check settles deterministically.
+    let out_port = input.sim_output();
+
+    // uses RNG fuzzing when run under `cargo test`
+    flow.sim().fuzz(async || {
+        send_port.send(1u32);
+        out_port.assert_yields_only([1u32]).await;
+
+        // Not poisoned: the check above was free, so the test can continue.
+        send_port.send(2u32);
+        out_port.assert_yields_only([2u32]).await;
+    });
+}
+
+/// The drain-everything APIs (`collect`, `try_next`) cannot fork the search (their result
+/// feeds the rest of the test), so they taint the instance in *every* mode — including
+/// exhaustive — when they force pending nondeterministic work to run.
+#[test]
+#[should_panic(expected = "cannot receive more simulator output")]
+fn sim_collect_poisons_later_receives_even_in_exhaustive() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process::<()>();
+    let (send_port, out_port, send_read_counter, second_slice_out_port) =
+        two_slice_counter_program(process);
+
+    flow.sim().exhaustive(async || {
+        send_port.send_many([1u32, 2u32]);
+        // Draining forces the second slice's buffered ticks to run, tainting the instance.
+        let all: Vec<u32> = out_port.collect().await;
+        assert_eq!(all, vec![1, 2]);
+
+        // Sending after the taint poisons the instance, so the receive must panic.
+        send_read_counter.send(());
+        let _ = second_slice_out_port.next().await;
+    });
+}
+
+/// `sim::quiesce()` is an explicit phase barrier: it forces the simulation to settle and
+/// lifts the taint, so multi-phase tests can drain outputs between rounds of input without
+/// poisoning later receives.
+#[test]
+fn sim_quiesce_barrier_allows_receives_after_forced_drain() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process::<()>();
+    let (send_port, out_port, send_read_counter, second_slice_out_port) =
+        two_slice_counter_program(process);
+
+    flow.sim().exhaustive(async || {
+        send_port.send_many([1u32, 2u32]);
+        // This drain forces the second slice's buffered ticks to run, tainting the instance
+        // (see sim_collect_poisons_later_receives_even_in_exhaustive)...
+        let all: Vec<u32> = out_port.collect().await;
+        assert_eq!(all, vec![1, 2]);
+
+        // ...but an explicit phase barrier declares that the test intends to observe only
+        // fully-settled states from here on, so later phases are allowed.
+        crate::sim::quiesce().await;
+
+        send_read_counter.send(());
+        // After the barrier, both cloned messages are guaranteed to have been counted.
+        assert_eq!(second_slice_out_port.next().await, 2);
+    });
+}
+
+/// `next()` always returns a message; if the simulation quiesces without producing one, the
+/// test fails (rather than returning an `Option` like `try_next()`).
+#[test]
+#[should_panic(expected = "another message was expected")]
+fn sim_next_fails_when_no_message_can_arrive() {
+    let mut flow = FlowBuilder::new();
+    let process = flow.process::<()>();
+
+    let (send_port, input) = process.sim_input();
+    let out_port = input.filter(q!(|x: &u32| *x > 10)).sim_output();
+
+    flow.sim().exhaustive(async || {
+        send_port.send(1u32); // filtered out, so no message ever arrives
+        let _ = out_port.next().await;
     });
 }
 

--- a/hydro_lang/tests/snapshots-nightly/sim_fuzzer__fuzz_with_cargo_sim_continue_if.snap
+++ b/hydro_lang/tests/snapshots-nightly/sim_fuzzer__fuzz_with_cargo_sim_continue_if.snap
@@ -3,6 +3,6 @@ source: hydro_lang/tests/sim_fuzzer.rs
 expression: "lines[block_start..block_start + 4].join(\"\\n\")"
 ---
 Condition failed (discarding simulation instance):
---> hydro_lang/src/sim/tests/mod.rs:1013:9
+--> hydro_lang/src/sim/tests/mod.rs:1259:9
  |        crate::sim::continue_if!(
  |        ^ first batch was a singleton

--- a/hydro_lang/tests/snapshots/sim_fuzzer__fuzz_with_cargo_sim_continue_if.snap
+++ b/hydro_lang/tests/snapshots/sim_fuzzer__fuzz_with_cargo_sim_continue_if.snap
@@ -3,6 +3,6 @@ source: hydro_lang/tests/sim_fuzzer.rs
 expression: "lines[block_start..block_start + 4].join(\"\\n\")"
 ---
 Condition failed (discarding simulation instance):
---> hydro_lang/src/sim/tests/mod.rs:1013:9
+--> hydro_lang/src/sim/tests/mod.rs:1259:9
  |        crate::sim::continue_if!(
  |        ^ first batch was a singleton

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -953,7 +953,7 @@ mod tests {
 
             let mut next_expected = 0;
             for i in 1..=4 {
-                let (next_slot, v) = out_recv.next().await.unwrap();
+                let (next_slot, v) = out_recv.next().await;
                 assert_eq!(v, i);
 
                 if next_expected < 123 {

--- a/hydro_test/src/cluster/raft.rs
+++ b/hydro_test/src/cluster/raft.rs
@@ -1221,6 +1221,9 @@ mod tests {
                 interrupt_send.send(0, ());
                 interrupt_send.send(1, ());
 
+                // Phase barrier: let all vote traffic settle so the collected histories
+                // are complete before the retry is fired.
+                hydro_lang::sim::quiesce().await;
                 for member in 0..CLUSTER_SIZE as u32 {
                     transitions[member as usize].extend(view_recv.collect::<Vec<_>>(member).await);
                 }
@@ -1229,6 +1232,7 @@ mod tests {
                 // ended in a split vote, member 0 must now win a fresh term outright.
                 interrupt_send.send(0, ());
 
+                hydro_lang::sim::quiesce().await;
                 for member in 0..CLUSTER_SIZE as u32 {
                     transitions[member as usize].extend(view_recv.collect::<Vec<_>>(member).await);
                 }
@@ -1331,10 +1335,11 @@ mod tests {
                 let member_1 = MemberId::<Replica>::from_raw_id(1);
                 let mut histories: Vec<Vec<LeaderView<Replica>>> = vec![Vec::new(); CLUSTER_SIZE];
 
-                // Phase 1: an uncontested election. The quiescing collects double as
-                // barriers: all vote traffic settles before any heartbeat is sent.
+                // Phase 1: an uncontested election. The `quiesce` phase barriers ensure
+                // all vote traffic settles before any heartbeat is sent.
                 interrupt_send.send(0, ());
 
+                hydro_lang::sim::quiesce().await;
                 for member in 0..CLUSTER_SIZE as u32 {
                     histories[member as usize].extend(view_recv.collect::<Vec<_>>(member).await);
                 }
@@ -1361,6 +1366,7 @@ mod tests {
                 // Phase 2: one real heartbeat round from the leader.
                 heartbeat_interrupt_send.send(0, ());
 
+                hydro_lang::sim::quiesce().await;
                 for member in 0..CLUSTER_SIZE as u32 {
                     let new_transitions: Vec<LeaderView<Replica>> =
                         view_recv.collect(member).await;
@@ -1398,6 +1404,7 @@ mod tests {
                 // heartbeat since its last interrupt, so no candidacy may start and
                 // no member's view may change.
                 interrupt_send.send(1, ());
+                hydro_lang::sim::quiesce().await;
                 for member in 0..CLUSTER_SIZE as u32 {
                     let new_transitions: Vec<LeaderView<Replica>> =
                         view_recv.collect(member).await;
@@ -1412,6 +1419,7 @@ mod tests {
                 // a real candidacy; member 1 wins term 2 (all logs are empty, so
                 // every voter grants), deposing member 0.
                 interrupt_send.send(1, ());
+                hydro_lang::sim::quiesce().await;
                 for member in 0..CLUSTER_SIZE as u32 {
                     histories[member as usize].extend(view_recv.collect::<Vec<_>>(member).await);
                 }
@@ -1427,6 +1435,7 @@ mod tests {
                 // One heartbeat round converges everyone — including the deposed
                 // member 0 — onto the new leader.
                 heartbeat_interrupt_send.send(1, ());
+                hydro_lang::sim::quiesce().await;
                 for member in 0..CLUSTER_SIZE as u32 {
                     histories[member as usize].extend(view_recv.collect::<Vec<_>>(member).await);
                 }
@@ -2178,6 +2187,7 @@ mod tests {
                     async |committed: &mut Vec<Vec<LogEntry<String>>>, at_least: usize| {
                         for _ in 0..MAX_ROUNDS {
                             heartbeat_interrupt_send.send(0, ());
+                            hydro_lang::sim::quiesce().await;
                             for member in 0..N as u32 {
                                 committed[member as usize]
                                     .extend(committed_recv.collect::<Vec<_>>(member).await);
@@ -2200,8 +2210,9 @@ mod tests {
 
                 // Phase 1: member 0 wins term 1 through a real election. No heartbeat
                 // has ever been observed, so the interrupt cannot be suppressed; the
-                // quiescing collect settles all vote traffic before anything else.
+                // `quiesce` barrier settles all vote traffic before anything else.
                 election_interrupt_send.send(0, ());
+                hydro_lang::sim::quiesce().await;
                 let during_election: Vec<LogEntry<String>> = committed_recv.collect(0).await;
                 assert!(
                     during_election.is_empty(),
@@ -2235,6 +2246,7 @@ mod tests {
                 // the forward_ref loop into member 1's LeaderView; a misdirected
                 // request must come back with that learned hint.
                 request_send.send(1, "misdirected".to_owned());
+                hydro_lang::sim::quiesce().await;
                 let follower_redirects: Vec<(String, Option<MemberId<Replica>>)> =
                     redirected_recv.collect(1).await;
                 assert_eq!(
@@ -2247,6 +2259,7 @@ mod tests {
                 // previous election interrupt, so its timeout must be suppressed:
                 // no candidacy, no term bump, member 0 stays leader...
                 election_interrupt_send.send(1, ());
+                hydro_lang::sim::quiesce().await;
                 let after_suppression: Vec<LogEntry<String>> = committed_recv.collect(1).await;
                 assert!(
                     after_suppression.is_empty(),
@@ -2364,9 +2377,10 @@ mod tests {
             .fuzz(async || {
                 let mut committed: Vec<Vec<LogEntry<String>>> = vec![Vec::new(); N];
 
-                // Quiesce, fold each member's newly committed entries into its
-                // history, drain redirects, and check the fork invariant.
+                // Quiesce (phase barrier), fold each member's newly committed entries
+                // into its history, drain redirects, and check the fork invariant.
                 let collect_and_check = async |committed: &mut Vec<Vec<LogEntry<String>>>| {
+                    hydro_lang::sim::quiesce().await;
                     for member in 0..N as u32 {
                         committed[member as usize]
                             .extend(committed_recv.collect::<Vec<_>>(member).await);
@@ -2378,7 +2392,8 @@ mod tests {
 
                 // Phase 1: member 0 wins term 1 uncontested and commits a seed entry,
                 // so later (possibly stale) challengers have something to be behind.
-                // The quiescing collect after the interrupt lets the election settle
+                // The `quiesce` barrier (in collect_and_check) after the interrupt lets
+                // the election settle
                 // (vote traffic and view propagation) before the request is sent —
                 // otherwise the request could race ahead of member 0's leadership and
                 // be redirected into the void. This phase is deliberately race-free,

--- a/hydro_test/src/distributed/versioning.rs
+++ b/hydro_test/src/distributed/versioning.rs
@@ -219,7 +219,7 @@ mod tests {
                 // Wait until both members have discovered full membership.
                 for member in [0, 1] {
                     loop {
-                        match membership_output.next(member).await {
+                        match membership_output.try_next(member).await {
                             Some(count) if count >= 2 => break,
                             Some(_) => continue,
                             None => return,
@@ -229,7 +229,7 @@ mod tests {
 
                 inputter.send(0, Request::Write { value: 42 });
 
-                let r1 = output.collect_sorted::<Vec<_>>(0).await;
+                let r1 = output.collect_n_sorted::<Vec<_>>(0, 1).await;
                 match r1.as_slice() {
                     [Response { value: 42 }] => {
                         write_confirmed = true;
@@ -285,7 +285,7 @@ mod tests {
             .with_cluster_size(&servers_v2, 1)
             .exhaustive(async || {
                 loop {
-                    match membership_output.next(0).await {
+                    match membership_output.try_next(0).await {
                         Some(count) if count >= 2 => break,
                         Some(_) => continue,
                         None => return,
@@ -293,7 +293,7 @@ mod tests {
                 }
 
                 loop {
-                    match membership_output_v2.next(1).await {
+                    match membership_output_v2.try_next(1).await {
                         Some(count) if count >= 2 => break,
                         Some(_) => continue,
                         None => return,
@@ -302,7 +302,7 @@ mod tests {
 
                 inputter.send(0, Request::Write { value: 42 });
 
-                let r1 = output.collect_sorted::<Vec<_>>(0).await;
+                let r1 = output.collect_n_sorted::<Vec<_>>(0, 1).await;
                 match r1.as_slice() {
                     [] => return,
                     [Response { value: 42 }] => {
@@ -365,7 +365,7 @@ mod tests {
             .exhaustive(async || {
                 for (handle, member) in [(&membership_output, 0u32), (&membership_output_v2, 1)] {
                     loop {
-                        match handle.next(member).await {
+                        match handle.try_next(member).await {
                             Some(count) if count >= 2 => break,
                             Some(_) => continue,
                             None => return,
@@ -375,7 +375,7 @@ mod tests {
 
                 inputter.send(0, Request::Write { value: 42 });
 
-                let r1 = output.collect_sorted::<Vec<_>>(0).await;
+                let r1 = output.collect_n_sorted::<Vec<_>>(0, 1).await;
                 match r1.as_slice() {
                     [Response { value: 42 }] => {
                         write_confirmed = true;
@@ -452,7 +452,7 @@ mod tests {
             .exhaustive(async || {
                 for (handle, member) in [(&membership_output, 0u32), (&membership_output_v3, 1)] {
                     loop {
-                        match handle.next(member).await {
+                        match handle.try_next(member).await {
                             Some(count) if count >= 2 => break,
                             Some(_) => continue,
                             None => return,
@@ -462,7 +462,7 @@ mod tests {
 
                 inputter.send(0, Request::Write { value: 42 });
 
-                let r1 = output.collect_sorted::<Vec<_>>(0).await;
+                let r1 = output.collect_n_sorted::<Vec<_>>(0, 1).await;
                 match r1.as_slice() {
                     [Response { value: 42 }] => {
                         write_confirmed = true;


### PR DESCRIPTION
Observing the end of a sim output stream (`assert_yields_only`, `collect`, the old
`next() -> Option`) always drove the simulator to full quiescence, forcing pending
nondeterministic work (ticks / observations) to run. This advanced the simulation past
states that later assertions needed to observe — hiding scenarios in exhaustive mode
(#3067) — and let extra messages produced by the forced work surface at *later*
assertions, misattributing failures.

The scheduler now distinguishes deterministic work (async dataflow propagation) from
nondeterministic work (ticks / observations that consume bolero decisions), and
absence-observing APIs proceed in phases:

- **Settle**: the scheduler runs only deterministic work, pausing before
  nondeterministic work (pause requests are counted so concurrent settling awaits each
  hold their own). If the simulation quiesces deterministically, the check is free and
  the test continues — instance counts of existing exhaustive tests are unchanged.
- **Fork (exhaustive)**: if nondeterministic work is pending, `assert_no_more` /
  `assert_yields_only*` / `collect_n_only` fork the search on a bolero decision: one
  instance performs the check and ends there (enumerated *first*, so failures are
  attributed to the right assertion with a precise trace, and its overrun is
  unobservable), while sibling instances skip the check and continue.
- **Taint / poison (other modes, and drain APIs everywhere)**: `try_next` / `collect` /
  `collect_sorted` run the pending work and taint the instance. Reads of the quiescent
  state remain allowed (terminal multi-port drains), but sending input after the taint
  poisons the instance and all further receives panic with an explanation.

BREAKING CHANGE: `SimReceiver::next` / `SimClusterReceiver::next` now return `T`
(failing the test on quiescence) instead of `Option<T>`; use the new `try_next` for the
old behavior. New `collect_n` / `collect_n_only` / `collect_n_sorted` receive a known
number of messages without ever forcing quiescence. `collect` / `collect_sorted` keep
their signatures but panic on receive-after-forced-quiescence-then-send. `fuzz` runs
under `cargo test` now replay failures (with trace logging), so the original panic
propagates instead of a generic "test failed".

Also: module-level rustdoc in `sim/compiled.rs` documenting the soundness reasoning,
correctness comments on the relevant internals, a "Receiving Outputs and Quiescence"
docs section, and new tests covering exhaustive fork ordering/attribution, fuzz-mode
taint+poison, free checks not tainting, exhaustive drain tainting, `next()` failure on
quiescence, and concurrent settling awaits. Call sites migrated across hydro_lang,
hydro_std, and hydro_test.

Fixes #3062, Fixes #3067 