### PR TITLE
feat(hydro_lang): deprecate unstyled `use(...)` in `sliced!`, add `batch` and `snapshot` styles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5394,9 +5394,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stageleft"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5525642086d3b7d902687aec7a3671ab163412e83200ae82251e4669fabe6e47"
+checksum = "19d1e313737e051a78f7dd3bc9d0cec17fe9bde4aaae37718016cdf002f97493"
 dependencies = [
  "ctor",
  "parking_lot",
@@ -5409,9 +5409,9 @@ dependencies = [
 
 [[package]]
 name = "stageleft_macro"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5b7837bc7433600c0383b3ce2f0c56af945cc347fbc737e7013ed2ed3b4fbc"
+checksum = "81339bbfea24d25eb4aecf32e9eb37308ed801993f0879b99562b5cc0590b29d"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -5422,9 +5422,9 @@ dependencies = [
 
 [[package]]
 name = "stageleft_tool"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08eac826cb2f7db961325c9cec981e9cfd8bceb8be706d1fbb0909aea2305670"
+checksum = "acd847bcaabcdfe9a650cb4aa5d7f136e5905d86881703bc41bcaaf3cd51c588"
 dependencies = [
  "prettyplease",
  "proc-macro-crate 3.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,5 +85,5 @@ uninlined_format_args = "allow"
 unused_async = "warn"
 
 [workspace.dependencies]
-stageleft = "0.15.0"
-stageleft_tool = "0.15.0"
+stageleft = "0.15.1"
+stageleft_tool = "0.15.1"

--- a/docs/docs/hydro/learn/quickstart/concurrent-clients.mdx
+++ b/docs/docs/hydro/learn/quickstart/concurrent-clients.mdx
@@ -81,7 +81,7 @@ And get responses use `cross_singleton` which pairs the count with each client's
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/concurrent_clients.rs">src/concurrent_clients.rs</Link>
 } showLineNumbers={16}>{getLines(concurrentClientsSrc, 16, 21, `
 let get_response = sliced! {
-    let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
+    let request_batch = use::batch(get_requests, nondet!(/** we never observe batch boundaries */));
     let count_snapshot = use::atomic(current_count, nondet!(/** atomicity guarantees consistency wrt increments */));
     request_batch.cross_singleton(count_snapshot).map(q!(|(_, count)| count))
 };

--- a/docs/docs/hydro/learn/quickstart/keyed-counter.mdx
+++ b/docs/docs/hydro/learn/quickstart/keyed-counter.mdx
@@ -109,7 +109,7 @@ This swaps the key and value: `(client_id, key_name)` becomes `(key_name, client
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/keyed_counter.rs">src/keyed_counter.rs</Link>
 } showLineNumbers={28}>{getLines(keyedCounterSrc, 28, 34, `
 let get_lookup = sliced! {
-    let request_batch = use(requests_regrouped, nondet!(/** we never observe batch boundaries */));
+    let request_batch = use::batch(requests_regrouped, nondet!(/** we never observe batch boundaries */));
     let count_snapshot = use::atomic(current_count, nondet!(/** atomicity guarantees consistency wrt increments */));
     request_batch.join_keyed_singleton(count_snapshot)
 };

--- a/docs/docs/hydro/learn/quickstart/single-counter.mdx
+++ b/docs/docs/hydro/learn/quickstart/single-counter.mdx
@@ -74,17 +74,17 @@ let increment_ack = increment_requests;
 
 Now comes the interesting part: how do you respond to get requests with the current count? The challenge is that `current_count` is a singleton that updates asynchronously as increment requests arrive, while `get_requests` is a stream that arrives independently.
 
-Hydro provides the `sliced!` macro for this purpose. It allows you to perform computations that rely on a _version_ of several live collections at some point in time. The way this version is revealed depends on the type of live collection. A `Stream` will be revealed as a **batch** of new elements at that point in time, and a `Singleton` will be revealed as a **snapshot** of the state.
+Hydro provides the `sliced!` macro for this purpose. It allows you to perform computations that rely on a _version_ of several live collections at some point in time. The way this version is revealed depends on the style of `use` statement. With `use::batch`, a `Stream` is revealed as a **batch** of new elements at that point in time, and with `use::snapshot`, a `Singleton` is revealed as a **snapshot** of the state.
 
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/single_client_counter_buggy.rs">src/single_client_counter.rs</Link>
 } showLineNumbers={15}>{getLines(singleClientCounterBuggySrc, 15, 17, `
 let get_response = sliced! {
-    let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
-    let count_snapshot = use(current_count, nondet!(/** intentional, based on when the request came in */));
+    let request_batch = use::batch(get_requests, nondet!(/** we never observe batch boundaries */));
+    let count_snapshot = use::snapshot(current_count, nondet!(/** intentional, based on when the request came in */));
 `)}</CodeBlock>
 
-The `sliced!` macro takes multiple `use` statements, using syntax inspired by React hooks. Each specifies a live collection to slice along with a non-determinism explanation, and returns the current slice. In this case:
+The `sliced!` macro takes multiple `use` statements, using syntax inspired by React hooks. Each specifies a live collection to slice, a style controlling how it is sliced (`use::batch` for streams, `use::snapshot` for singletons), and a non-determinism explanation, and returns the current slice. In this case:
 
 - `request_batch` is a batch of get requests (a `Stream<()>`)
 - `count_snapshot` is the current value of the counter at the time this batch is processed (a `Singleton<usize>`)
@@ -142,16 +142,16 @@ If you run this test with `cargo test -- single_client_counter`, you'll see it f
 
 ```ignore
 Running Tick
-  | let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
-  |                        ^ releasing no items
-  | let count_snapshot = use(current_count, nondet!(/** intentional, based on when the request came in */));
-  |                         ^ releasing snapshot: 0
+  | let request_batch = use::batch(get_requests, nondet!(/** we never observe batch boundaries */));
+  |                         ^ releasing no items
+  | let count_snapshot = use::snapshot(current_count, nondet!(/** intentional, based on when the request came in */));
+  |                          ^ releasing snapshot: 0
 
 Running Tick
-  | let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
-  |                        ^ releasing items: [()]
-  | let count_snapshot = use(current_count, nondet!(/** intentional, based on when the request came in */));
-  |                         ^ releasing unchanged snapshot: 0
+  | let request_batch = use::batch(get_requests, nondet!(/** we never observe batch boundaries */));
+  |                         ^ releasing items: [()]
+  | let count_snapshot = use::snapshot(current_count, nondet!(/** intentional, based on when the request came in */));
+  |                          ^ releasing unchanged snapshot: 0
 
 thread ... panicked at src/single_client_counter.rs:50:
 Stream yielded unexpected message: 0
@@ -159,7 +159,7 @@ Stream yielded unexpected message: 0
 
 What went wrong? The issue is that acknowledging the increment is asynchronous with respect to snapshotting the counter. Even though the test waits for the acknowledgement before sending the get request, the counter snapshot may be an older version (we see this with the "releasing unchanged snapshot" message).
 
-When slicing a `Singleton` with `use`, the only guarantee is that each snapshot is _at least_ the same version as the last snapshot. But this snapshot may lag behind, since changes to a singleton are propagated asynchronously.
+When slicing a `Singleton` with `use::snapshot`, the only guarantee is that each snapshot is _at least_ the same version as the last snapshot. But this snapshot may lag behind, since changes to a singleton are propagated asynchronously.
 
 ## Consistent Snapshots with Atomic
 
@@ -189,7 +189,7 @@ Now, let's focus on the outputs of the counter service. It needs to release ackn
 let increment_ack = increment_request_processing.end_atomic();
 
 let get_response = sliced! {
-    let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
+    let request_batch = use::batch(get_requests, nondet!(/** we never observe batch boundaries */));
     let count_snapshot = use::atomic(current_count, nondet!(/** atomicity guarantees consistency wrt increments */));
     request_batch.cross_singleton(count_snapshot).map(q!(|(_, count)| count))
 };

--- a/docs/docs/hydro/reference/atomic-collections.mdx
+++ b/docs/docs/hydro/reference/atomic-collections.mdx
@@ -20,8 +20,8 @@ let current_count = increment_requests.clone().count();
 let increment_ack = increment_requests.map(q!(|_| "ok"));
 
 let get_response = sliced! {
-    let request_batch = use(get_requests, nondet!(/** ... */));
-    let count_snapshot = use(current_count, nondet!(/** ... */));
+    let request_batch = use::batch(get_requests, nondet!(/** ... */));
+    let count_snapshot = use::snapshot(current_count, nondet!(/** ... */));
     request_batch.cross_singleton(count_snapshot)
 };
 ```
@@ -60,7 +60,7 @@ Now, when you snapshot the count with `use::atomic`, you're guaranteed to observ
 
 ```rust,ignore
 let get_response = sliced! {
-    let request_batch = use(get_requests, nondet!(/** ... */));
+    let request_batch = use::batch(get_requests, nondet!(/** ... */));
     let count_snapshot = use::atomic(current_count, nondet!(/** ... */));
     request_batch.cross_singleton(count_snapshot)
 };
@@ -76,7 +76,7 @@ The `sliced!` macro supports two styles of snapshots:
 
 | Style | Syntax | Guarantee |
 |-------|--------|-----------|
-| Non-atomic | `use(collection, nondet!(...))` | Snapshot is at least as recent as the previous snapshot |
+| Non-atomic | `use::snapshot(collection, nondet!(...))` | Snapshot is at least as recent as the previous snapshot |
 | Atomic | `use::atomic(collection, nondet!(...))` | Same as above **and** reflects all updates released by `end_atomic` |
 
 Use non-atomic snapshots when:

--- a/docs/docs/hydro/reference/correctness/bounded-unbounded.md
+++ b/docs/docs/hydro/reference/correctness/bounded-unbounded.md
@@ -48,7 +48,7 @@ let input: Singleton<_, _, Bounded> = process.singleton(q!(0));
 let unbounded: Singleton<_, _, Unbounded> = input.into();
 ```
 
-Converting from an unbounded collection **to a bounded collection**, however, is more complex. This requires cutting off the unbounded collection at a specific point in time, which is not possible to do deterministically. In Hydro, this conversion is performed by taking a **slice** of the unbounded collection with the [`sliced!`](../state-management/slices.mdx) macro. Inside a `sliced!` block, each `use` hook reveals a bounded version of a live collection: a **batch** of new elements for a `Stream`, or a **snapshot** of the current value for a `Singleton`. Because the boundaries of batches and the timing of snapshots depend on runtime factors, each `use` hook requires a [non-determinism guard](./nondet.md):
+Converting from an unbounded collection **to a bounded collection**, however, is more complex. This requires cutting off the unbounded collection at a specific point in time, which is not possible to do deterministically. In Hydro, this conversion is performed by taking a **slice** of the unbounded collection with the [`sliced!`](../state-management/slices.mdx) macro. Inside a `sliced!` block, each `use` hook reveals a bounded version of a live collection: `use::batch` reveals a **batch** of new elements for a `Stream`, and `use::snapshot` reveals a **snapshot** of the current value for a `Singleton`. Because the boundaries of batches and the timing of snapshots depend on runtime factors, these `use` hooks require a [non-determinism guard](./nondet.md):
 
 ```rust
 # use hydro_lang::prelude::*;
@@ -59,7 +59,7 @@ let unbounded_input: Stream<_, _, Unbounded> =
 
 let doubled = sliced! {
     // inside the slice, `batch` is a **bounded** stream of newly arrived elements
-    let batch = use(unbounded_input, nondet!(
+    let batch = use::batch(unbounded_input, nondet!(
         /// each element is transformed independently, so
         /// batch boundaries do not affect the final result
     ));

--- a/docs/docs/hydro/reference/correctness/nondet.md
+++ b/docs/docs/hydro/reference/correctness/nondet.md
@@ -173,10 +173,10 @@ Compare:
 
 ```rust,ignore
 // ❌ restates that non-determinism exists, but justifies nothing
-let batch = use(requests, nondet!(/** batching is non-deterministic, that's fine */));
+let batch = use::batch(requests, nondet!(/** batching is non-deterministic, that's fine */));
 
 // ✅ states why the result is insensitive to the non-deterministic choice
-let batch = use(requests, nondet!(
+let batch = use::batch(requests, nondet!(
     /// each request is answered using only its own contents and the current
     /// snapshot, so batch boundaries are never observable in the responses
 ));

--- a/docs/docs/hydro/reference/simulation/writing.mdx
+++ b/docs/docs/hydro/reference/simulation/writing.mdx
@@ -75,16 +75,16 @@ When a test fails, the simulator prints a trace showing the decisions it made:
 
 ```text
 Running Tick
-  | let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
-  |                        ^ releasing no items
+  | let request_batch = use::batch(get_requests, nondet!(/** we never observe batch boundaries */));
+  |                         ^ releasing no items
   | let count_snapshot = use::atomic(current_count, nondet!(/** intentional, based on when the request came in */));
-  |                                 ^ releasing snapshot: 0
+  |                          ^ releasing snapshot: 0
 
 Running Tick
-  | let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
-  |                        ^ releasing items: [()]
+  | let request_batch = use::batch(get_requests, nondet!(/** we never observe batch boundaries */));
+  |                         ^ releasing items: [()]
   | let count_snapshot = use::atomic(current_count, nondet!(/** intentional, based on when the request came in */));
-  |                                 ^ releasing unchanged snapshot: 0
+  |                          ^ releasing unchanged snapshot: 0
 
 thread ... panicked at src/single_client_counter.rs:50:
 Stream yielded unexpected message: 0
@@ -107,7 +107,7 @@ When you call `sliced!` with a `use` statement, the simulator makes a decision f
 
 ```rust,ignore
 let get_response = sliced! {
-    let request_batch = use(get_requests, nondet!(/** ... */));
+    let request_batch = use::batch(get_requests, nondet!(/** ... */));
     // ...
 };
 ```
@@ -121,7 +121,7 @@ If three requests arrive and `get_requests` is an ordered stream, the simulator 
 Similarly, when snapshotting a `Singleton`, the simulator decides which version to observe:
 
 ```rust,ignore
-let count_snapshot = use(current_count, nondet!(/** ... */));
+let count_snapshot = use::snapshot(current_count, nondet!(/** ... */));
 ```
 
 If the count has progressed through values 0 → 1 → 2, the simulator might snapshot any of these values. It can also re-release the same snapshot multiple times, simulating the case where state updates haven't propagated yet.

--- a/docs/docs/hydro/reference/state-management/index.md
+++ b/docs/docs/hydro/reference/state-management/index.md
@@ -21,8 +21,8 @@ State derived from asynchronous inputs is `Unbounded`: its value changes over ti
 
 ```rust,ignore
 let get_response = sliced! {
-    let request_batch = use(get_requests, nondet!(/** batch boundaries are not observable */));
-    let count_snapshot = use(current_count, nondet!(/** requests may see any valid version of the count */));
+    let request_batch = use::batch(get_requests, nondet!(/** batch boundaries are not observable */));
+    let count_snapshot = use::snapshot(current_count, nondet!(/** requests may see any valid version of the count */));
 
     let count_ref = count_snapshot.by_ref();
     request_batch.map(q!(|_| *count_ref))
@@ -42,8 +42,8 @@ Some state cannot be expressed as an aggregation of a single stream, such as whe
 
 ```rust,ignore
 let results = sliced! {
-    let deposit_batch = use(deposits, nondet!(/** ... */));
-    let withdrawal_batch = use(withdrawals, nondet!(/** ... */));
+    let deposit_batch = use::batch(deposits, nondet!(/** ... */));
+    let withdrawal_batch = use::batch(withdrawals, nondet!(/** ... */));
     let mut balance = use::state(|l| l.singleton(q!(0)));
 
     let balance_mut = balance.by_mut();

--- a/docs/docs/hydro/reference/state-management/keyed-state.md
+++ b/docs/docs/hydro/reference/state-management/keyed-state.md
@@ -25,7 +25,7 @@ let total_spent: KeyedSingleton<&str, i32, _, _> =
     purchases.fold(q!(|| 0), q!(|acc, amount| *acc += amount));
 // { "alice": 25, "bob": 5 }
 # sliced! {
-#     let snapshot = use(total_spent, nondet!(/** test */));
+#     let snapshot = use::snapshot(total_spent, nondet!(/** test */));
 #     snapshot.entries()
 # }.map(q!(|(k, v)| (k.to_string(), v)))
 # }, |mut stream| async move {
@@ -59,8 +59,8 @@ Because keyed state updates asynchronously, reading it requires taking a **snaps
 let totals = increments.fold(q!(|| 0), q!(|acc, amount| *acc += amount));
 
 let get_response = sliced! {
-    let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
-    let totals_snapshot = use(totals, nondet!(/** each request observes some valid version of the totals */));
+    let request_batch = use::batch(get_requests, nondet!(/** we never observe batch boundaries */));
+    let totals_snapshot = use::snapshot(totals, nondet!(/** each request observes some valid version of the totals */));
 
     request_batch
         .join_keyed_singleton(totals_snapshot)

--- a/docs/docs/hydro/reference/state-management/references-mutations.md
+++ b/docs/docs/hydro/reference/state-management/references-mutations.md
@@ -54,8 +54,8 @@ let highest_bid: Optional<i32, _, _> = process
     .max();
 
 let responses = sliced! {
-    let request_batch = use(get_requests, nondet!(/** each request is handled independently */));
-    let bid_snapshot = use(highest_bid, nondet!(/** each request observes the highest bid at the time it is processed */));
+    let request_batch = use::batch(get_requests, nondet!(/** each request is handled independently */));
+    let bid_snapshot = use::snapshot(highest_bid, nondet!(/** each request observes the highest bid at the time it is processed */));
     let bid_ref = bid_snapshot.by_ref();
     request_batch.map(q!(|req| (req, bid_ref.unwrap_or(0))))
 };
@@ -80,7 +80,7 @@ Mutable references shine inside slice blocks, combined with [state hooks](./slic
 let deposits = process.source_iter(q!(vec![10, 20, 30]));
 
 let running_balance = sliced! {
-    let batch = use(deposits, nondet!(/** running totals are unaffected by batch boundaries */));
+    let batch = use::batch(deposits, nondet!(/** running totals are unaffected by batch boundaries */));
     let mut balance = use::state(|l| l.singleton(q!(0)));
     let balance_mut = balance.by_mut();
 
@@ -111,7 +111,7 @@ When a collection is accessed by several closures — especially when some of th
 let input = process.source_iter(q!(vec![3]));
 
 let out = sliced! {
-    let batch = use(input, nondet!(/** single input element, so batching is not observable */));
+    let batch = use::batch(input, nondet!(/** single input element, so batching is not observable */));
     let mut total = use::state(|l| l.singleton(q!(0)));
     let total_mut = total.by_mut();
 
@@ -150,8 +150,8 @@ The most important use of mutable references is state that must be **read and wr
 # let deposits = process.source_iter(q!(vec![10, 20]));
 # let balance_reads = process.source_iter(q!(vec![()]));
 let (deposit_acks, read_responses) = sliced! {
-    let deposit_batch = use(deposits, nondet!(/** deposits are commutative, so batch boundaries don't affect the balance */));
-    let read_batch = use(balance_reads, nondet!(/** each read observes the balance at the time it is processed */));
+    let deposit_batch = use::batch(deposits, nondet!(/** deposits are commutative, so batch boundaries don't affect the balance */));
+    let read_batch = use::batch(balance_reads, nondet!(/** each read observes the balance at the time it is processed */));
     let mut balance = use::state(|l| l.singleton(q!(0)));
 
     // Writes are declared first: apply all deposits in this batch...

--- a/docs/docs/hydro/reference/state-management/singletons-optionals.md
+++ b/docs/docs/hydro/reference/state-management/singletons-optionals.md
@@ -118,8 +118,8 @@ let get_requests = // ... stream of get requests
 let current_count = increments.count();
 
 let get_response = sliced! {
-    let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
-    let count_snapshot = use(current_count, nondet!(/** each request observes some valid version of the count */));
+    let request_batch = use::batch(get_requests, nondet!(/** we never observe batch boundaries */));
+    let count_snapshot = use::snapshot(current_count, nondet!(/** each request observes some valid version of the count */));
 
     let count_ref = count_snapshot.by_ref();
     request_batch.map(q!(|_| *count_ref))

--- a/docs/docs/hydro/reference/state-management/slice-hooks.md
+++ b/docs/docs/hydro/reference/state-management/slice-hooks.md
@@ -9,7 +9,7 @@ Every [slice block](./slices.mdx) begins with one or more **hooks**: `use` state
 ```rust,ignore
 let output = sliced! {
     // hooks come first...
-    let batch = use(requests, nondet!(/** ... */));
+    let batch = use::batch(requests, nondet!(/** ... */));
     let snapshot = use::atomic(current_count, nondet!(/** ... */));
     let mut buffer = use::state_null::<Stream<_, _, _, TotalOrder>>();
 
@@ -20,18 +20,24 @@ let output = sliced! {
 
 All hooks must appear before the body of the slice, and all collections consumed by hooks must live at the same [location](../locations/index.md).
 
-## The Default Hook: `use`
+## Batches and Snapshots: `use::batch` and `use::snapshot`
 
-The default hook, `use(collection, nondet!(...))`, reveals a **bounded** version of the collection: either a *batch* of new elements or a *snapshot* of the current value, depending on the collection type.
+The two fundamental hooks reveal a **bounded** version of a collection: `use::batch(collection, nondet!(...))` reveals a *batch* of new elements for stream-like collections, and `use::snapshot(collection, nondet!(...))` reveals a *snapshot* of the current value for singleton-like collections.
 
-| Input collection | Revealed as |
-|---|---|
-| `Stream` | **Batch** of elements that arrived since the last slice |
-| `Singleton` | **Snapshot** of the current value |
-| `Optional` | **Snapshot** of the current value (possibly absent) |
-| `KeyedStream` | **Batch** of new elements, grouped per key |
-| `KeyedSingleton` (unbounded values) | **Snapshot** of the current entries |
-| `KeyedSingleton` (`BoundedValue`) | **Batch** of newly arrived entries |
+| Input collection | Hook | Revealed as |
+|---|---|---|
+| `Stream` | `use::batch` | **Batch** of elements that arrived since the last slice |
+| `Singleton` | `use::snapshot` | **Snapshot** of the current value |
+| `Optional` | `use::snapshot` | **Snapshot** of the current value (possibly absent) |
+| `KeyedStream` | `use::batch` | **Batch** of new elements, grouped per key |
+| `KeyedSingleton` (unbounded values) | `use::snapshot` | **Snapshot** of the current entries |
+| `KeyedSingleton` (`BoundedValue`) | `use::batch` | **Batch** of newly arrived entries |
+
+:::note
+
+The style-less `use(collection, nondet!(...))` hook, which picked between batching and snapshotting automatically based on the collection type, is deprecated in favor of the explicit `use::batch` and `use::snapshot` hooks.
+
+:::
 
 In all cases, the revealed collection is [`Bounded`](../correctness/bounded-unbounded.md): its contents are frozen for the duration of the slice, so you can safely observe it in its entirety (including with [reference handles](./references-mutations.md)).
 
@@ -45,8 +51,8 @@ let requests = process.source_iter(q!(vec![1, 2, 3]));
 let scale = process.singleton(q!(10));
 
 let scaled = sliced! {
-    let batch = use(requests, nondet!(/** batch boundaries don't affect per-element results */));
-    let scale_snapshot = use(scale, nondet!(/** the scale is constant, so all snapshots are identical */));
+    let batch = use::batch(requests, nondet!(/** batch boundaries don't affect per-element results */));
+    let scale_snapshot = use::snapshot(scale, nondet!(/** the scale is constant, so all snapshots are identical */));
     batch.cross_singleton(scale_snapshot).map(q!(|(x, s)| x * s))
 };
 // 10, 20, 30
@@ -59,7 +65,7 @@ let scaled = sliced! {
 # }));
 ```
 
-A [`KeyedSingleton`](../streaming-data/keyed-singletons.mdx) with the `BoundedValue` bound gets special treatment. Because each key's value is immutable once it appears, there is no need to re-observe existing entries: the hook reveals a batch containing only the *newly arrived* entries, and each entry is revealed in exactly one slice. This makes `BoundedValue` keyed singletons behave like a stream of request/response entries:
+A [`KeyedSingleton`](../streaming-data/keyed-singletons.mdx) with the `BoundedValue` bound gets special treatment. Because each key's value is immutable once it appears, there is no need to re-observe existing entries: `use::batch` reveals a batch containing only the *newly arrived* entries, and each entry is revealed in exactly one slice. This makes `BoundedValue` keyed singletons behave like a stream of request/response entries:
 
 ```rust
 # use hydro_lang::prelude::*;
@@ -71,7 +77,7 @@ let events: Stream<(&str, i32), _, Unbounded> = process
 let first_events = events.into_keyed().first(); // KeyedSingleton<&str, i32, _, BoundedValue>
 
 let processed = sliced! {
-    let new_entries = use(first_events, nondet!(/** each entry is handled independently, so batching is not observable */));
+    let new_entries = use::batch(first_events, nondet!(/** each entry is handled independently, so batching is not observable */));
     new_entries.entries()
 };
 // ("alice", 1), ("bob", 2) in some order
@@ -96,7 +102,7 @@ Because batch boundaries and snapshot timing remain non-deterministic, every `us
 
 ## Atomic Hooks: `use::atomic`
 
-By default, a snapshot may lag arbitrarily behind outputs your program has already released, which can violate guarantees like read-after-write consistency. The `use::atomic(collection, nondet!(...))` hook strengthens the default hook for collections in an atomic context (created with `.atomic()`): the revealed batch or snapshot is guaranteed to be **consistent with respect to** the outputs released via `end_atomic()` on that same atomic context.
+By default, a snapshot may lag arbitrarily behind outputs your program has already released, which can violate guarantees like read-after-write consistency. The `use::atomic(collection, nondet!(...))` hook strengthens the batching and snapshotting hooks for collections in an atomic context (created with `.atomic()`): the revealed batch or snapshot is guaranteed to be **consistent with respect to** the outputs released via `end_atomic()` on that same atomic context.
 
 ```rust,ignore
 let increment_request_processing = increment_requests.atomic();
@@ -104,7 +110,7 @@ let current_count = increment_request_processing.clone().count();
 let increment_ack = increment_request_processing.end_atomic();
 
 let get_response = sliced! {
-    let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
+    let request_batch = use::batch(get_requests, nondet!(/** we never observe batch boundaries */));
     let count_snapshot = use::atomic(current_count, nondet!(/** atomicity guarantees consistency wrt increments */));
     let count_ref = count_snapshot.by_ref();
     request_batch.map(q!(|_| *count_ref))
@@ -125,7 +131,7 @@ Use `use::state(|l| initial)` when the state has a known initial value. The clos
 # tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
 # let input_stream = process.source_iter(q!(vec![1, 2, 3]));
 let running_count = sliced! {
-    let batch = use(input_stream, nondet!(/** batch boundaries don't affect the final count */));
+    let batch = use::batch(input_stream, nondet!(/** batch boundaries don't affect the final count */));
     let mut counter = use::state(|l| l.singleton(q!(0)));
 
     // Increment the counter by the number of items in this batch
@@ -147,8 +153,8 @@ Use `use::state_null::<Type>()` when the state should start out null: an empty `
 let payloads_with_leader = sliced! {
     let mut unsent_payloads = use::state_null::<Stream<_, _, _, TotalOrder>>();
 
-    let payload_batch = use(payloads, nondet!(/** ... */));
-    let latest_leader = use(leader_id, nondet!(/** ... */));
+    let payload_batch = use::batch(payloads, nondet!(/** ... */));
+    let latest_leader = use::snapshot(leader_id, nondet!(/** ... */));
 
     // Combine buffered and new payloads
     let all_payloads = unsent_payloads.chain(payload_batch);
@@ -165,12 +171,12 @@ Instead of reassigning the state binding, you can also mutate state in place wit
 
 ### State Hooks vs. Sliced Singletons
 
-State hooks differ from singletons consumed with `use` in an important way:
+State hooks differ from singletons consumed with `use::snapshot` in an important way:
 
 - **Sliced singletons** observe *external* state that is derived deterministically (e.g. by `fold`) and updates independently of the slice.
 - **State hooks** are *internal* to the slice and hold values you compute between iterations.
 
-Prefer deriving state with deterministic APIs and observing it via `use` when possible; the type system provides stronger guarantees for such state. Reach for state hooks when the update logic fundamentally depends on the slice structure (buffering, batched accumulation, multi-input mutation).
+Prefer deriving state with deterministic APIs and observing it via `use::snapshot` when possible; the type system provides stronger guarantees for such state. Reach for state hooks when the update logic fundamentally depends on the slice structure (buffering, batched accumulation, multi-input mutation).
 
 ## Unslicing: Returning Values from a Slice
 

--- a/docs/docs/hydro/reference/state-management/slices.mdx
+++ b/docs/docs/hydro/reference/state-management/slices.mdx
@@ -19,19 +19,19 @@ Hydro provides the `sliced!` macro to solve this problem. It allows you to take 
 use hydro_lang::prelude::*;
 
 let get_response = sliced! {
-    let request_batch = use(get_requests, nondet!(/** batch boundaries are never observed */));
-    let count_snapshot = use(current_count, nondet!(/** each request reads the count at the time it is processed */));
+    let request_batch = use::batch(get_requests, nondet!(/** batch boundaries are never observed */));
+    let count_snapshot = use::snapshot(current_count, nondet!(/** each request reads the count at the time it is processed */));
 
     let count_ref = count_snapshot.by_ref();
     request_batch.map(q!(|_req| *count_ref))
 };
 ```
 
-A `sliced!` block starts with one or more `use` statements — **hooks**, with syntax inspired by React hooks — each specifying a live collection to slice. Each hook returns the sliced version of the collection, which is [bounded](../correctness/bounded-unbounded.md) for the duration of the slice:
+A `sliced!` block starts with one or more `use` statements — **hooks**, with syntax inspired by React hooks — each specifying a live collection to slice and a style controlling how it is sliced. Each hook returns the sliced version of the collection, which is [bounded](../correctness/bounded-unbounded.md) for the duration of the slice:
 
-- For a `Stream` / `KeyedStream`, you get a **batch** of elements that arrived since the last slice
-- For a `Singleton` / `Optional`, you get a **snapshot** of the current value
-- For a `KeyedSingleton`, you get a **snapshot** of the current entries, or a **batch** of new entries if values are immutable (`BoundedValue`)
+- For a `Stream` / `KeyedStream`, `use::batch` gives a **batch** of elements that arrived since the last slice
+- For a `Singleton` / `Optional`, `use::snapshot` gives a **snapshot** of the current value
+- For a `KeyedSingleton`, `use::snapshot` gives a **snapshot** of the current entries, or `use::batch` gives a **batch** of new entries if values are immutable (`BoundedValue`)
 
 The full set of hooks — including atomic and stateful variants — and their per-collection semantics are documented in [Slice Hooks](./slice-hooks.md).
 
@@ -50,7 +50,7 @@ In the animation below, elements arrive continuously on the input stream. When a
 let numbers = process.source_iter(q!(vec![1, 2, 3, 4, 5]));
 
 let stringified = sliced! {
-    let batch = use(numbers, nondet!(/** batch boundaries don't affect final result */));
+    let batch = use::batch(numbers, nondet!(/** batch boundaries don't affect final result */));
     batch.map(q!(|x| x.to_string()))
 };
 // Eventually emits: "1", "2", "3", "4", "5" (in batches)
@@ -78,8 +78,8 @@ let requests: Stream<()> = ...; // (), (), ()
 let state: Singleton<i32> = ...; // 5 ~> 7
 
 let scaled = sliced! {
-    let batch = use(requests, nondet!(/** batch boundaries are non-deterministic */));
-    let current_state = use(state, nondet!(/** snapshot timing is non-deterministic */));
+    let batch = use::batch(requests, nondet!(/** batch boundaries are non-deterministic */));
+    let current_state = use::snapshot(state, nondet!(/** snapshot timing is non-deterministic */));
     batch.cross_singleton(current_state)
 };
 ```
@@ -102,8 +102,8 @@ let get_requests = process.source_iter(q!(vec!["alice", "bob"]));
 let current_count = increments.count();
 
 let get_response = sliced! {
-    let request_batch = use(get_requests, nondet!(/** batch boundaries are never observed */));
-    let count_snapshot = use(current_count, nondet!(/** each request reads the count at the time it is processed */));
+    let request_batch = use::batch(get_requests, nondet!(/** batch boundaries are never observed */));
+    let count_snapshot = use::snapshot(current_count, nondet!(/** each request reads the count at the time it is processed */));
 
     let count_ref = count_snapshot.by_ref();
     request_batch.map(q!(|requester| (requester, *count_ref)))
@@ -120,7 +120,7 @@ Because the snapshot revealed by the hook is bounded, `by_ref()` gives you a han
 
 :::caution
 
-Snapshots taken with a plain `use` hook are only guaranteed to be *monotone* — they may lag behind outputs your program has already released. If clients require read-after-write consistency (e.g., a get request issued after an acknowledged increment must observe that increment), use [atomic collections](../atomic-collections.mdx) and the `use::atomic` hook.
+Snapshots taken with the `use::snapshot` hook are only guaranteed to be *monotone* — they may lag behind outputs your program has already released. If clients require read-after-write consistency (e.g., a get request issued after an acknowledged increment must observe that increment), use [atomic collections](../atomic-collections.mdx) and the `use::atomic` hook.
 
 :::
 
@@ -138,7 +138,7 @@ Sometimes you need to maintain state across slice iterations—for example, accu
 
 ```rust,ignore
 let running_count = sliced! {
-    let batch = use(input_stream, nondet!(/** batch boundaries don't affect final count */));
+    let batch = use::batch(input_stream, nondet!(/** batch boundaries don't affect final count */));
     let mut counter = use::state(|l| l.singleton(q!(0)));
 
     // Increment counter by the number of items in this batch
@@ -170,8 +170,8 @@ sampled_state.clone().for_each(q!(|sample| {
 }));
 
 let periodic_output = sliced! {
-    let sample_batch = use(sampled_state, nondet!(/** batch boundaries are non-deterministic */));
-    let other_state_snapshot = use(other_state, nondet!(/** snapshot timing is non-deterministic */));
+    let sample_batch = use::batch(sampled_state, nondet!(/** batch boundaries are non-deterministic */));
+    let other_state_snapshot = use::snapshot(other_state, nondet!(/** snapshot timing is non-deterministic */));
 
     sample_batch.cross_singleton(other_state_snapshot)
         .map(q!(|(s1, s2)| process(s1, s2)))
@@ -187,8 +187,8 @@ let ticks = process.source_interval(
 );
 
 let periodic_output = sliced! {
-    let tick_batch = use(ticks, nondet!(/** batch boundaries are non-deterministic */));
-    let state = use(current_state, nondet!(/** snapshot timing is non-deterministic */));
+    let tick_batch = use::batch(ticks, nondet!(/** batch boundaries are non-deterministic */));
+    let state = use::snapshot(current_state, nondet!(/** snapshot timing is non-deterministic */));
 
     // Only emit when there is at least one tick in this batch
     state.filter_if(tick_batch.first().is_some()).into_stream()

--- a/docs/docs/hydro/reference/streaming-data/keyed-singletons.mdx
+++ b/docs/docs/hydro/reference/streaming-data/keyed-singletons.mdx
@@ -155,9 +155,9 @@ let unit_price: Singleton<u32, _, _> = // computed elsewhere, may change over ti
 
 let quotes = sliced! {
     // the entries that arrived since the previous slice; each order appears exactly once
-    let new_orders = use(orders, nondet!(/** each order is quoted independently, exactly once */));
+    let new_orders = use::batch(orders, nondet!(/** each order is quoted independently, exactly once */));
     // a snapshot of the current price
-    let price = use(unit_price, nondet!(/** each order is quoted at the price when it is processed */));
+    let price = use::snapshot(unit_price, nondet!(/** each order is quoted at the price when it is processed */));
 
     new_orders
         .into_keyed_stream()

--- a/docs/docs/hydro/reference/streaming-data/keyed-streams.mdx
+++ b/docs/docs/hydro/reference/streaming-data/keyed-streams.mdx
@@ -130,7 +130,7 @@ let purchases = process.source_iter(q!(vec![
 purchases.fold(q!(|| 0), q!(|acc, amount| *acc += amount))
 # ;
 # sliced! {
-#     let snap = use(out, nondet!(/** test */));
+#     let snap = use::snapshot(out, nondet!(/** test */));
 #     snap.entries()
 # }.map(q!(|(k, v)| (k.to_string(), v)))
 # }, |mut stream| async move {
@@ -176,7 +176,7 @@ health_checks.fold(
 )
 # ;
 # sliced! {
-#     let snap = use(out, nondet!(/** test */));
+#     let snap = use::snapshot(out, nondet!(/** test */));
 #     snap.entries()
 # }.map(q!(|(k, v)| (k.to_string(), v)))
 # }, |mut stream| async move {

--- a/hydro_lang/src/handoff_ref.rs
+++ b/hydro_lang/src/handoff_ref.rs
@@ -563,7 +563,7 @@ mod tests {
         let items = node.source_iter(q!(1..=3i32));
 
         sliced! {
-            let items = use(items, nondet!(/** test */));
+            let items = use::batch(items, nondet!(/** test */));
             let my_count = items
                 .location()
                 .source_iter(q!(0..5i32))
@@ -596,7 +596,7 @@ mod tests {
         let items = node.source_iter(q!(1..=3i32));
 
         sliced! {
-            let items = use(items, nondet!(/** test */));
+            let items = use::batch(items, nondet!(/** test */));
             let my_count = items
                 .location()
                 .source_iter(q!(0..5i32))

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -1056,9 +1056,9 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
                 );
 
                 let result = sliced! {
-                    let snapshot = use(me, nondet!(/** thresholds are deterministic */));
+                    let snapshot = use::snapshot(me, nondet!(/** thresholds are deterministic */));
                     let thresh_snapshot =
-                        use(thresholds, nondet!(/** thresholds are deterministic */));
+                        use::batch(thresholds, nondet!(/** thresholds are deterministic */));
                     let mut already_crossed =
                         use::state_null::<Stream<K, Tick<_>, Bounded, NoOrder>>();
 
@@ -1086,9 +1086,9 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
                 );
 
                 let result = sliced! {
-                    let snapshot = use(me, nondet!(/** thresholds are deterministic */));
+                    let snapshot = use::batch(me, nondet!(/** thresholds are deterministic */));
                     let thresh_snapshot =
-                        use(thresholds, nondet!(/** thresholds are deterministic */));
+                        use::batch(thresholds, nondet!(/** thresholds are deterministic */));
                     let mut already_crossed =
                         use::state_null::<Stream<K, Tick<_>, Bounded, NoOrder>>();
 
@@ -1187,7 +1187,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
                 );
 
                 let result = sliced! {
-                    let snapshot = use(me, nondet!(/** thresholds are deterministic */));
+                    let snapshot = use::snapshot(me, nondet!(/** thresholds are deterministic */));
                     let mut already_crossed =
                         use::state_null::<Stream<K, Tick<_>, Bounded, NoOrder>>();
 
@@ -1224,7 +1224,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
                 );
 
                 let result = sliced! {
-                    let snapshot = use(me, nondet!(/** thresholds are deterministic */));
+                    let snapshot = use::batch(me, nondet!(/** thresholds are deterministic */));
                     let mut already_crossed =
                         use::state_null::<Stream<K, Tick<_>, Bounded, NoOrder>>();
 

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -1043,7 +1043,7 @@ where
             }
             Err(me) => {
                 let uncasted = sliced! {
-                    let me = use(me, nondet!(/** thresholds are deterministic */));
+                    let me = use::snapshot(me, nondet!(/** thresholds are deterministic */));
                     let mut remaining_threshold = use::state(|l| {
                         let as_option: Optional<_, _, _> = threshold.clone_into_tick(l).into();
                         as_option
@@ -1248,7 +1248,7 @@ where
         nondet: NonDet,
     ) -> Stream<T, L::DropConsistency, Unbounded, TotalOrder, AtLeastOnce> {
         sliced! {
-            let snapshot = use(self, nondet);
+            let snapshot = use::snapshot(self, nondet);
             snapshot.into_stream()
         }
         .weaken_retries()
@@ -1274,8 +1274,8 @@ where
     {
         let samples = self.location.source_interval(interval);
         sliced! {
-            let snapshot = use(self, nondet);
-            let sample_batch = use(samples, nondet);
+            let snapshot = use::snapshot(self, nondet);
+            let sample_batch = use::batch(samples, nondet);
 
             snapshot.filter_if(sample_batch.first().is_some()).into_stream()
         }
@@ -1868,7 +1868,7 @@ mod tests {
         let folded = source_iter.fold(q!(|| 0), q!(|a, b| *a += b));
 
         let out_recv = sliced! {
-            let v = use(folded, nondet!(/** test */));
+            let v = use::snapshot(folded, nondet!(/** test */));
             v.clone().zip(v).into_stream()
         }
         .sim_output();
@@ -1950,7 +1950,7 @@ mod tests {
         let source = node.source_iter(q!(vec![1i32, 2, 3]));
 
         let (first, second) = sliced! {
-            let batch = use(source, nondet!(/** test */));
+            let batch = use::batch(source, nondet!(/** test */));
             let mut total = use::state(|l| l.singleton(q!(0i32)));
             let total_mut = total.by_mut();
 
@@ -1991,7 +1991,7 @@ mod tests {
         let source = node.source_iter(q!(vec![3i32]));
 
         let out_recv = sliced! {
-            let batch = use(source, nondet!(/** test */));
+            let batch = use::batch(source, nondet!(/** test */));
             let mut total = use::state(|l| l.singleton(q!(0i32)));
             let total_mut = total.by_mut();
 

--- a/hydro_lang/src/live_collections/sliced/mod.rs
+++ b/hydro_lang/src/live_collections/sliced/mod.rs
@@ -23,6 +23,9 @@ macro_rules! __sliced_parse_uses__ {
     };
 
     // Parse immutable use statements without style: let name = use(args...);
+    // This form is deprecated; the `default` style function it expands to is marked
+    // `#[deprecated]`, which surfaces a deprecation warning on the user's `use(...)` tokens
+    // (via `copy_span!`).
     (
         @uses [$($uses:tt)*]
         @states [$($states:tt)*]
@@ -136,19 +139,27 @@ macro_rules! __sliced_parse_uses__ {
 /// # Syntax
 /// The `sliced!` macro takes in a closure-like syntax specifying the live collections to be sliced
 /// and the body of the transformation. Each `use` statement indicates a live collection to be sliced,
-/// along with a non-determinism explanation. Optionally, a style can be specified to control how the
-/// live collection is sliced (e.g., atomically). All `use` statements must appear before the body.
+/// along with a non-determinism explanation. The style specifies how the live collection is sliced:
+/// `use::batch` for stream-like collections (such as [`Stream`](crate::live_collections::Stream)),
+/// `use::snapshot` for singleton-like collections (such as
+/// [`Singleton`](crate::live_collections::Singleton)), and `use::atomic` for atomically-processed
+/// collections. All `use` statements must appear before the body.
 ///
 /// ```rust,ignore
 /// let stream = sliced! {
-///     let name1 = use(collection1, nondet!(/** explanation */));
-///     let name2 = use::atomic(collection2, nondet!(/** explanation */));
+///     let name1 = use::batch(stream1, nondet!(/** explanation */));
+///     let name2 = use::snapshot(singleton2, nondet!(/** explanation */));
+///     let name3 = use::atomic(collection3, nondet!(/** explanation */));
 ///
 ///     // arbitrary statements can follow
 ///     let intermediate = name1.map(...);
 ///     intermediate.cross_singleton(name2)
 /// };
 /// ```
+///
+/// The style-less form `use(collection, nondet!(...))`, which picks between batching and
+/// snapshotting automatically based on the collection type, is deprecated; use the explicit
+/// `use::batch` or `use::snapshot` styles instead.
 ///
 /// # Stateful Computations
 /// The `sliced!` macro also supports stateful computations across iterations using `let mut` bindings
@@ -163,7 +174,7 @@ macro_rules! __sliced_parse_uses__ {
 ///
 /// ```rust,ignore
 /// let counter_stream = sliced! {
-///     let batch = use(input_stream, nondet!(/** explanation */));
+///     let batch = use::batch(input_stream, nondet!(/** explanation */));
 ///     let mut counter = use::state(|l| l.singleton(q!(0)));
 ///
 ///     // Increment counter by the number of items in this batch
@@ -522,7 +533,7 @@ mod tests {
         let (input_send, input) = node.sim_input::<i32, _, _>();
 
         let out_recv = sliced! {
-            let batch = use(input, nondet!(/** test */));
+            let batch = use::batch(input, nondet!(/** test */));
             let mut counter = use::state(|l| l.singleton(q!(0)));
 
             let new_count = counter.clone().zip(batch.count())
@@ -558,7 +569,7 @@ mod tests {
         let (input_send, input) = node.sim_input::<i32, _, _>();
 
         let out_recv = sliced! {
-            let batch = use(input, nondet!(/** test */));
+            let batch = use::batch(input, nondet!(/** test */));
             let mut prev = use::state_null::<Optional<i32, Tick<_>, Bounded>>();
 
             // Output the previous value (or -1 if none)
@@ -595,7 +606,7 @@ mod tests {
         let (input_send, input) = node.sim_input::<i32, _, _>();
 
         let out_recv = sliced! {
-            let batch = use(input, nondet!(/** test */));
+            let batch = use::batch(input, nondet!(/** test */));
             let mut items = use::state(|l| l.source_iter(q!([10, 20])));
 
             // Output the current state, then replace it with the batch

--- a/hydro_lang/src/live_collections/sliced/style.rs
+++ b/hydro_lang/src/live_collections/sliced/style.rs
@@ -20,7 +20,8 @@ use crate::nondet::NonDet;
 
 /// Default style wrapper that stores a collection and its non-determinism guard.
 ///
-/// This is used by the `sliced!` macro when no explicit style is specified.
+/// This is used by the `sliced!` macro when no explicit style is specified. This style is
+/// deprecated; use the explicit [`batch`] or [`snapshot`] styles instead.
 pub struct Default<T> {
     pub(crate) collection: T,
     pub(crate) nondet: NonDet,
@@ -35,8 +36,58 @@ impl<T> Default<T> {
 
 /// Helper function for unstyled `use` in `sliced!` macro - wraps the collection in Default style.
 #[doc(hidden)]
+#[deprecated(
+    note = "use `use::batch(...)` for stream-like collections or `use::snapshot(...)` for singleton-like collections instead"
+)]
 pub fn default<T>(t: T, nondet: NonDet) -> Default<T> {
     Default::new(t, nondet)
+}
+
+/// Batch style wrapper that stores a stream-like collection and its non-determinism guard.
+///
+/// This is used by the `sliced!` macro when `use::batch(...)` is specified.
+pub struct Batch<T> {
+    pub(crate) collection: T,
+    pub(crate) nondet: NonDet,
+}
+
+impl<T> Batch<T> {
+    /// Creates a new batch-styled wrapper.
+    pub fn new(collection: T, nondet: NonDet) -> Self {
+        Self { collection, nondet }
+    }
+}
+
+/// Wraps a stream-like live collection (such as a [`Stream`](crate::live_collections::Stream),
+/// [`KeyedStream`](crate::live_collections::KeyedStream), or a
+/// [`KeyedSingleton`](crate::live_collections::KeyedSingleton) with bounded values) to be
+/// sliced into non-deterministic batches of asynchronously arriving elements.
+pub fn batch<T>(t: T, nondet: NonDet) -> Batch<T> {
+    Batch::new(t, nondet)
+}
+
+/// Snapshot style wrapper that stores a singleton-like collection and its non-determinism guard.
+///
+/// This is used by the `sliced!` macro when `use::snapshot(...)` is specified.
+pub struct Snapshot<T> {
+    pub(crate) collection: T,
+    pub(crate) nondet: NonDet,
+}
+
+impl<T> Snapshot<T> {
+    /// Creates a new snapshot-styled wrapper.
+    pub fn new(collection: T, nondet: NonDet) -> Self {
+        Self { collection, nondet }
+    }
+}
+
+/// Wraps a singleton-like live collection (such as a
+/// [`Singleton`](crate::live_collections::Singleton),
+/// [`Optional`](crate::live_collections::Optional), or a
+/// [`KeyedSingleton`](crate::live_collections::KeyedSingleton) with asynchronously updated
+/// values) to be sliced into non-deterministic snapshots of its continuously changing value.
+pub fn snapshot<T>(t: T, nondet: NonDet) -> Snapshot<T> {
+    Snapshot::new(t, nondet)
 }
 
 /// Atomic style wrapper that stores a collection and its non-determinism guard.
@@ -246,6 +297,119 @@ impl<'a, K, V, L: Location<'a>> Slicable<'a, L::DropConsistency>
     }
     fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
         let out = self.collection.batch(tick, self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+// ============================================================================
+// Batch style Slicable implementations (stream-like collections)
+//
+// All of these drop consistency because they are performing non-deterministic
+// batching.
+// ============================================================================
+
+impl<'a, T, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
+    Slicable<'a, L::DropConsistency> for Batch<crate::live_collections::Stream<T, L, B, O, R>>
+{
+    type Slice = crate::live_collections::Stream<T, Tick<L::DropConsistency>, Bounded, O, R>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().drop_consistency()
+    }
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
+        let out = self.collection.batch(tick, self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
+    Slicable<'a, L::DropConsistency>
+    for Batch<crate::live_collections::KeyedStream<K, V, L, B, O, R>>
+{
+    type Slice =
+        crate::live_collections::KeyedStream<K, V, Tick<L::DropConsistency>, Bounded, O, R>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().drop_consistency()
+    }
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
+        let out = self.collection.batch(tick, self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+impl<'a, K, V, L: Location<'a>> Slicable<'a, L::DropConsistency>
+    for Batch<crate::live_collections::KeyedSingleton<K, V, L, BoundedValue>>
+{
+    type Slice = crate::live_collections::KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().drop_consistency()
+    }
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
+        let out = self.collection.batch(tick, self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+// ============================================================================
+// Snapshot style Slicable implementations (singleton-like collections)
+//
+// All of these drop consistency because they are performing non-deterministic
+// snapshotting.
+// ============================================================================
+
+impl<'a, T, L: Location<'a>, B: SingletonBound> Slicable<'a, L::DropConsistency>
+    for Snapshot<crate::live_collections::Singleton<T, L, B>>
+{
+    type Slice = crate::live_collections::Singleton<T, Tick<L::DropConsistency>, Bounded>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().drop_consistency()
+    }
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
+        let out = self.collection.snapshot(tick, self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+impl<'a, T, L: Location<'a>, B: Boundedness> Slicable<'a, L::DropConsistency>
+    for Snapshot<crate::live_collections::Optional<T, L, B>>
+{
+    type Slice = crate::live_collections::Optional<T, Tick<L::DropConsistency>, Bounded>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().drop_consistency()
+    }
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
+        let out = self.collection.snapshot(tick, self.nondet);
+        out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
+        out
+    }
+}
+
+impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Unbounded>>
+    Slicable<'a, L::DropConsistency>
+    for Snapshot<crate::live_collections::KeyedSingleton<K, V, L, B>>
+{
+    type Slice = crate::live_collections::KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded>;
+    type Backtrace = crate::compile::ir::backtrace::Backtrace;
+
+    fn get_location(&self) -> L::DropConsistency {
+        self.collection.location().drop_consistency()
+    }
+    fn slice(self, tick: &Tick<L::DropConsistency>, backtrace: Self::Backtrace) -> Self::Slice {
+        let out = self.collection.snapshot(tick, self.nondet);
         out.ir_node.borrow_mut().op_metadata_mut().backtrace = backtrace;
         out
     }

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -3509,8 +3509,8 @@ mod tests {
             node.source_external_bincode::<_, _, TotalOrder, ExactlyOnce>(&external);
 
         let out = sliced! {
-            let input = use(input, nondet!(/** test */));
-            let v = use(node.source_iter(q!(vec![1, 2, 3])).reduce(q!(|acc, v| *acc += v)), nondet!(/** test */));
+            let input = use::batch(input, nondet!(/** test */));
+            let v = use::snapshot(node.source_iter(q!(vec![1, 2, 3])).reduce(q!(|acc, v| *acc += v)), nondet!(/** test */));
             input.cross_singleton(v.into_stream().count())
         }
         .send_bincode_external(&external);
@@ -3547,8 +3547,8 @@ mod tests {
             node.source_external_bincode::<_, _, TotalOrder, ExactlyOnce>(&external);
 
         let out = sliced! {
-            let input = use(input, nondet!(/** test */));
-            let v = use(node.source_iter(q!(vec![1, 2, 3])).reduce(q!(|acc, v| *acc += v)).into_singleton(), nondet!(/** test */));
+            let input = use::batch(input, nondet!(/** test */));
+            let v = use::snapshot(node.source_iter(q!(vec![1, 2, 3])).reduce(q!(|acc, v| *acc += v)).into_singleton(), nondet!(/** test */));
             input.cross_singleton(v.into_stream().count())
         }
         .send_bincode_external(&external);
@@ -4916,7 +4916,7 @@ mod tests {
         let (trigger_send, trigger) = node.sim_input::<i32, TotalOrder, ExactlyOnce>();
 
         let out_recv = sliced! {
-            let batch = use(trigger, nondet!(/** test */));
+            let batch = use::batch(trigger, nondet!(/** test */));
             let counter = batch.location().source_iter(q!(vec![0i32]))
                 .fold(q!(|| 0i32), q!(|acc, v| *acc += v));
             let counter_mut = counter.by_mut();
@@ -4958,7 +4958,7 @@ mod tests {
         let (trigger_send, trigger) = node.sim_input::<i32, TotalOrder, ExactlyOnce>();
 
         let out_recv = sliced! {
-            let batch = use(trigger, nondet!(/** test */));
+            let batch = use::batch(trigger, nondet!(/** test */));
             let offset = batch
                 .location()
                 .source_iter(q!(vec![10i32]))

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -326,8 +326,8 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
             nondet!(/** dropped prefixes don't affect broadcast */),
         ));
         sliced! {
-            let members_snapshot = use(ids, nondet_membership);
-            let elements = use(self, nondet_membership);
+            let members_snapshot = use::snapshot(ids, nondet_membership);
+            let elements = use::batch(self, nondet_membership);
 
             let current_members = members_snapshot.filter(q!(|b| *b));
             elements.repeat_with_keys(current_members)
@@ -740,8 +740,8 @@ impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyO
             nondet!(/** dropped prefixes don't affect broadcast */),
         ));
         sliced! {
-            let members_snapshot = use(ids, nondet_membership);
-            let elements = use(self.enumerate(), nondet_membership);
+            let members_snapshot = use::snapshot(ids, nondet_membership);
+            let elements = use::batch(self.enumerate(), nondet_membership);
 
             let current_members = members_snapshot
                 .filter(q!(|b| *b))
@@ -888,8 +888,8 @@ impl<'a, T, L, B: Boundedness, C: Consistency>
             nondet!(/** dropped prefixes don't affect broadcast */),
         ));
         sliced! {
-            let members_snapshot = use(ids, nondet_membership);
-            let elements = use(self.enumerate(), nondet_membership);
+            let members_snapshot = use::snapshot(ids, nondet_membership);
+            let elements = use::batch(self.enumerate(), nondet_membership);
 
             let current_members = members_snapshot
                 .filter(q!(|b| *b))
@@ -1233,8 +1233,8 @@ impl<'a, T, L, B: Boundedness, C: Consistency, O: Ordering, R: Retries>
             nondet!(/** dropped prefixes don't affect broadcast */),
         ));
         sliced! {
-            let members_snapshot = use(ids, nondet_membership);
-            let elements = use(self, nondet_membership);
+            let members_snapshot = use::snapshot(ids, nondet_membership);
+            let elements = use::batch(self, nondet_membership);
 
             let current_members = members_snapshot.filter(q!(|b| *b));
             elements.repeat_with_keys(current_members)
@@ -1745,7 +1745,7 @@ mod tests {
             );
 
         let out_recv = sliced! {
-            let snapshot = use(received, nondet!(/** test */));
+            let snapshot = use::snapshot(received, nondet!(/** test */));
             snapshot.into_stream()
         }
         .sim_output();
@@ -1800,7 +1800,7 @@ mod tests {
             );
 
         let out_recv = sliced! {
-            let snapshot = use(received, nondet!(/** test */));
+            let snapshot = use::snapshot(received, nondet!(/** test */));
             snapshot.into_stream()
         }
         .sim_output();

--- a/hydro_lang/src/location/tick.rs
+++ b/hydro_lang/src/location/tick.rs
@@ -383,7 +383,7 @@ mod tests {
 
         let write_ack_recv = atomic_write.end_atomic().sim_output();
         let read_response_recv = sliced! {
-            let batch_of_req = use(read_req, nondet!(/** test */));
+            let batch_of_req = use::batch(read_req, nondet!(/** test */));
             let latest_singleton = use::atomic(current_state, nondet!(/** test */));
             batch_of_req.cross_singleton(latest_singleton)
         }
@@ -430,8 +430,8 @@ mod tests {
         let write_ack_recv = write_req.sim_output();
 
         let read_response_recv = sliced! {
-            let batch_of_req = use(read_req, nondet!(/** test */));
-            let latest_singleton = use(current_state, nondet!(/** test */));
+            let batch_of_req = use::batch(read_req, nondet!(/** test */));
+            let latest_singleton = use::snapshot(current_state, nondet!(/** test */));
             batch_of_req.cross_singleton(latest_singleton)
         }
         .sim_output();

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -118,7 +118,7 @@ fn fuzzed_batching_program_sliced<'a>(
     let (in_send, input) = node.sim_input();
 
     let out_recv = sliced! {
-        let batch = use(input, nondet!(/** test */));
+        let batch = use::batch(input, nondet!(/** test */));
         batch.fold(q!(|| 0), q!(|acc, v| *acc += v)).into_stream()
     }
     .sim_output();
@@ -342,7 +342,7 @@ fn sim_cluster_unordered_input() {
     // Batch the unordered input through a tick via `sliced!` so the simulator
     // explores the different interleavings of the unordered arrivals.
     let out_recv = sliced! {
-        let batch = use(input, nondet!(/** test */));
+        let batch = use::batch(input, nondet!(/** test */));
         batch.map(q!(|x| x * 10))
     }
     .sim_cluster_output();
@@ -469,7 +469,7 @@ fn sim_fold_sample_eager_state_count() {
         ),
     );
     let out_recv = sliced! {
-        let snapshot = use(folded, nondet!(/** test */));
+        let snapshot = use::snapshot(folded, nondet!(/** test */));
         snapshot.into_stream()
     }
     .sim_output();
@@ -507,7 +507,7 @@ fn sim_fold_commutative_explores_all_subset_sums() {
         ),
     );
     let out_recv = sliced! {
-        let snapshot = use(folded, nondet!(/** test */));
+        let snapshot = use::snapshot(folded, nondet!(/** test */));
         snapshot.into_stream()
     }
     .sim_output();
@@ -543,7 +543,7 @@ fn sim_fold_total_order_no_permutation() {
     let source = node.source_stream(q!(tokio_stream::iter(vec!["a", "b", "c"])));
     let folded = source.fold(q!(|| String::new()), q!(|acc, v| acc.push_str(v)));
     let out_recv = sliced! {
-        let snapshot = use(folded, nondet!(/** test */));
+        let snapshot = use::snapshot(folded, nondet!(/** test */));
         snapshot.into_stream()
     }
     .sim_output();
@@ -585,7 +585,7 @@ fn sim_fold_keyed_no_order() {
         ),
     );
     let out_recv = sliced! {
-        let snapshot = use(folded, nondet!(/** test */));
+        let snapshot = use::snapshot(folded, nondet!(/** test */));
         snapshot.entries()
     }
     .sim_output();
@@ -617,13 +617,13 @@ fn sim_fold_tee_downstream_sees_different_subsets() {
     let folded = source.fold(q!(|| 0), q!(|acc, v| *acc += v));
 
     let out_a = sliced! {
-        let snapshot = use(folded.clone(), nondet!(/** test */));
+        let snapshot = use::snapshot(folded.clone(), nondet!(/** test */));
         snapshot.into_stream()
     }
     .sim_output();
 
     let out_b = sliced! {
-        let snapshot = use(folded, nondet!(/** test */));
+        let snapshot = use::snapshot(folded, nondet!(/** test */));
         snapshot.into_stream()
     }
     .sim_output();
@@ -677,7 +677,7 @@ fn sim_fold_catches_false_commutativity() {
         ),
     );
     let out_recv = sliced! {
-        let snapshot = use(folded, nondet!(/** test */));
+        let snapshot = use::snapshot(folded, nondet!(/** test */));
         snapshot.into_stream()
     }
     .sim_output();
@@ -768,7 +768,7 @@ fn sim_singleton_not_ready_until_producer_runs() {
 
     // First sliced block: produces an Unbounded Singleton
     let produced_singleton = sliced! {
-        let batch = use(in_no_order.clone(), nondet!(/** batch */));
+        let batch = use::batch(in_no_order.clone(), nondet!(/** batch */));
         batch.assume_ordering::<TotalOrder>(nondet!(/** order */))
             .fold(q!(|| 0u32), q!(|acc, v| *acc += v))
     };
@@ -777,8 +777,8 @@ fn sim_singleton_not_ready_until_producer_runs() {
     // If the simulator schedules this tick before the first one has run,
     // the SingletonHook has no value → panic.
     let out = sliced! {
-        let trigger = use(in_no_order, nondet!(/** batch */));
-        let snapshot = use(produced_singleton, nondet!(/** snapshot */));
+        let trigger = use::batch(in_no_order, nondet!(/** batch */));
+        let snapshot = use::snapshot(produced_singleton, nondet!(/** snapshot */));
         trigger.cross_singleton(snapshot)
     }
     .assume_ordering::<TotalOrder>(nondet!(/** test */));
@@ -860,7 +860,7 @@ fn sim_unbounded_optional_rejected_snapshot() {
         .latest();
 
     let output = sliced! {
-        let snapshot = use(optional, nondet!(/** test */));
+        let snapshot = use::snapshot(optional, nondet!(/** test */));
         snapshot.into_stream()
     }
     .sim_output();

--- a/hydro_lang/src/sim/tests/snapshots/trace_for_fuzzed_batching_sliced.snap
+++ b/hydro_lang/src/sim/tests/snapshots/trace_for_fuzzed_batching_sliced.snap
@@ -2,12 +2,13 @@
 source: hydro_lang/src/sim/tests/mod.rs
 expression: log_str
 ---
-Running Tick
-* --> src/sim/tests/mod.rs:121:24
-*  |        let batch = use(input, nondet!(/** test */));
-*  |                       ^ releasing items: [456, 456, 456, 456, 456, 456, 456, 456, ..] (1000 total)
 
 Running Tick
-* --> src/sim/tests/mod.rs:121:24
-*  |        let batch = use(input, nondet!(/** test */));
-*  |                       ^ releasing items: [100, 23]
+* --> src/sim/tests/mod.rs:121:25
+*  |        let batch = use::batch(input, nondet!(/** test */));
+*  |                        ^ releasing items: [456, 456, 456, 456, 456, 456, 456, 456, ..] (1000 total)
+
+Running Tick
+* --> src/sim/tests/mod.rs:121:25
+*  |        let batch = use::batch(input, nondet!(/** test */));
+*  |                        ^ releasing items: [100, 23]

--- a/hydro_lang/tests/compile-fail/sliced_state_bad_initializer.rs
+++ b/hydro_lang/tests/compile-fail/sliced_state_bad_initializer.rs
@@ -25,7 +25,7 @@ fn test<'a>(input: Stream<u32, Process<'a, P1>>) {
     };
 
     sliced! {
-        let s = use(input, nondet!(/** test */));
+        let s = use::batch(input, nondet!(/** test */));
 
         let mut bad = use::state(&clock.initializer);
 

--- a/hydro_lang/tests/compile-fail/sliced_state_error_in_initializer.rs
+++ b/hydro_lang/tests/compile-fail/sliced_state_error_in_initializer.rs
@@ -6,7 +6,7 @@ struct P1 {}
 
 fn test<'a>(input: Stream<u32, Process<'a, P1>>) {
     sliced! {
-        let s = use(input, nondet!(/** test */));
+        let s = use::batch(input, nondet!(/** test */));
 
         // The error inside the initializer body should be attributed to the exact
         // expression that caused it, not the entire `sliced!` block.

--- a/hydro_lang/tests/compile-fail/stable/sliced_missing_arg.stderr
+++ b/hydro_lang/tests/compile-fail/stable/sliced_missing_arg.stderr
@@ -10,6 +10,31 @@ error[E0425]: cannot find value `fake` in this scope
 14 |         let f = use::atomic(fake, nondet!(/** test */));
    |                             ^^^^ not found in this scope
 
+warning: use of deprecated function `hydro_lang::live_collections::sliced::style::default`: use `use::batch(...)` for stream-like collections or `use::snapshot(...)` for singleton-like collections instead
+ --> tests/compile-fail/stable/sliced_missing_arg.rs:9:21
+  |
+9 |         let a = use(input);
+  |                     ^^^^^
+  |
+  = note: `#[warn(deprecated)]` on by default
+  = note: this warning originates in the macro `$crate::__sliced_parse_uses__` which comes from the expansion of the macro `sliced` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: use of deprecated function `hydro_lang::live_collections::sliced::style::default`: use `use::batch(...)` for stream-like collections or `use::snapshot(...)` for singleton-like collections instead
+  --> tests/compile-fail/stable/sliced_missing_arg.rs:11:21
+   |
+11 |         let c = use(input, 123);
+   |                     ^^^^^
+   |
+   = note: this warning originates in the macro `$crate::__sliced_parse_uses__` which comes from the expansion of the macro `sliced` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: use of deprecated function `hydro_lang::live_collections::sliced::style::default`: use `use::batch(...)` for stream-like collections or `use::snapshot(...)` for singleton-like collections instead
+  --> tests/compile-fail/stable/sliced_missing_arg.rs:13:21
+   |
+13 |         let e = use(fake, nondet!(/** test */));
+   |                     ^^^^
+   |
+   = note: this warning originates in the macro `$crate::__sliced_parse_uses__` which comes from the expansion of the macro `sliced` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> tests/compile-fail/stable/sliced_missing_arg.rs:9:21
    |

--- a/hydro_std/src/bench_client/mod.rs
+++ b/hydro_std/src/bench_client/mod.rs
@@ -65,7 +65,7 @@ where
     Output: 'a + Clone,
 {
     let new_payload_ids = sliced! {
-        let num_clients_per_node = use(num_clients_per_node, nondet!(/** This is a constant */));
+        let num_clients_per_node = use::snapshot(num_clients_per_node, nondet!(/** This is a constant */));
         let mut next_virtual_client = use::state(|l| Optional::from(l.singleton(q!((0u32, None)))));
 
         // Set up virtual clients - spawn new ones each tick until we reach the limit
@@ -108,8 +108,8 @@ where
     );
 
     sliced! {
-        let start_times = use(start_times, nondet!(/** Only one in-flight message per virtual client at any time, and outputs happen-after inputs, so if an output is received the start_times must contain its input time. */));
-        let current_outputs = use(protocol_outputs, nondet!(/** Batching is required to compare output to input time, but does not actually affect the result. */));
+        let start_times = use::snapshot(start_times, nondet!(/** Only one in-flight message per virtual client at any time, and outputs happen-after inputs, so if an output is received the start_times must contain its input time. */));
+        let current_outputs = use::batch(protocol_outputs, nondet!(/** Batching is required to compare output to input time, but does not actually affect the result. */));
 
         let end_times_and_output = current_outputs
             .reduce(q!(|curr, new| {
@@ -143,8 +143,8 @@ pub fn compute_throughput_latency<'a, Client: 'a>(
     let punctuation = clients.source_interval(q!(Duration::from_millis(interval_millis)));
 
     let (interval_throughput, interval_latency) = sliced! {
-        let punctuation = use(punctuation, nondet_measurement_window);
-        let latencies = use(latencies, nondet_measurement_window);
+        let punctuation = use::batch(punctuation, nondet_measurement_window);
+        let latencies = use::batch(latencies, nondet_measurement_window);
         let mut latency_histogram = use::state(|l| l.singleton(q!(Rc::new(RefCell::new(Histogram::<u64>::new(3).unwrap())))));
         let mut throughput = use::state(|l| l.singleton(q!(0usize)));
 
@@ -225,9 +225,9 @@ pub fn aggregate_bench_results<'a, Client: 'a, Aggregator>(
         .map(q!(|wrapper| wrapper.histogram));
 
     let (combined_throughputs, combined_latencies) = sliced! {
-        let punctuation = use(punctuation, nondet_sampling);
-        let a_throughputs = use(a_throughputs, nondet_sampling);
-        let a_latencies = use(a_latencies, nondet_sampling);
+        let punctuation = use::batch(punctuation, nondet_sampling);
+        let a_throughputs = use::batch(a_throughputs, nondet_sampling);
+        let a_latencies = use::batch(a_latencies, nondet_sampling);
         let mut latency_histogram = use::state(|l| l.singleton(q!(Rc::new(RefCell::new(Histogram::<u64>::new(3).unwrap())))));
         let mut throughput = use::state(|l| l.singleton(q!(0usize)));
 

--- a/hydro_std/src/quorum.rs
+++ b/hydro_std/src/quorum.rs
@@ -20,7 +20,7 @@ pub fn collect_quorum_with_response<
     Stream<(K, E), L, Unbounded, Order>,
 ) {
     let quorums = sliced! {
-        let new_inputs = use(responses.clone(), nondet!(
+        let new_inputs = use::batch(responses.clone(), nondet!(
             /// We always persist values that have not reached quorum, so even
             /// with arbitrary batching we always produce deterministic quorum results.
         ));
@@ -95,7 +95,7 @@ pub fn collect_quorum<'a, L: Location<'a>, Order: Ordering, K: Clone + Eq + Hash
     Stream<(K, E), L, Unbounded, Order>,
 ) {
     let just_reached_quorum = sliced! {
-        let new_inputs = use(responses.clone(), nondet!(
+        let new_inputs = use::batch(responses.clone(), nondet!(
             /// We always persist values that have not reached quorum, so even
             /// with arbitrary batching we always produce deterministic quorum results.
         ));

--- a/hydro_std/src/request_response.rs
+++ b/hydro_std/src/request_response.rs
@@ -19,7 +19,7 @@ pub fn join_responses<'a, K: Clone + Eq + Hash, M: Clone, V: Clone, L: Location<
     sliced! {
         let mut remaining_to_join = use::state_null::<Stream<(K, M), _, _, NoOrder>>();
 
-        let response_batch = use(responses, nondet!(
+        let response_batch = use::batch(responses, nondet!(
             /// Because we persist the metadata, delays resulting from
             /// batching boundaries do not affect the output contents.
         ));

--- a/hydro_test/src/cluster/paxos_bench.rs
+++ b/hydro_test/src/cluster/paxos_bench.rs
@@ -79,7 +79,7 @@ pub fn paxos_bench<'a>(
                     ));
 
                 sliced! {
-                    let snapshot = use(a_checkpoint_largest_seqs, nondet!(
+                    let snapshot = use::snapshot(a_checkpoint_largest_seqs, nondet!(
                         /// even though we batch the checkpoint messages, because we reduce over the entire history,
                         /// the final min checkpoint is deterministic
                     ));

--- a/hydro_test/src/cluster/paxos_log_bench.rs
+++ b/hydro_test/src/cluster/paxos_log_bench.rs
@@ -63,7 +63,7 @@ pub fn paxos_log_bench<'a>(
             // Compute checkpoints on the leader
             let nondet_log_holes = nondet!(/** Current max log sequence number dpeends on when the commit is confirmed */);
             let p_checkpoint = sliced! {
-                let new_slots = use(sequenced_payloads.into_keyed().keys(), nondet_log_holes);
+                let new_slots = use::batch(sequenced_payloads.into_keyed().keys(), nondet_log_holes);
                 let mut log_holes = use::state_null::<Stream<usize, Tick<_>, Bounded, NoOrder>>();
                 let mut prev_checkpoint_slot = use::state::<Singleton<usize, Tick<_>, Bounded>>(|l| l.singleton(q!(0)));
 

--- a/hydro_test/src/cluster/paxos_with_client.rs
+++ b/hydro_test/src/cluster/paxos_with_client.rs
@@ -69,8 +69,8 @@ pub trait PaxosLike<'a>: Sized {
                 let payloads_at_proposer = sliced! {
                     let mut unsent_payloads = use::state_null::<Stream<_, _, _, TotalOrder>>();
 
-                    let payload_batch = use(payloads, nondet!(/** see below */));
-                    let latest_leader = use(cur_leader_id,
+                    let payload_batch = use::batch(payloads, nondet!(/** see below */));
+                    let latest_leader = use::snapshot(cur_leader_id,
                         nondet!(
                             /// the risk here is that we send a batch of requests
                             /// with a stale leader ID, but because the leader ID comes from the

--- a/hydro_test/src/distributed/versioning.rs
+++ b/hydro_test/src/distributed/versioning.rs
@@ -62,8 +62,8 @@ where
             .source_cluster_membership_stream(to, nondet_membership),
     );
     let (filtered, members_out) = sliced! {
-        let members_snapshot = use(ids, nondet_membership);
-        let elements = use(requests, nondet_membership);
+        let members_snapshot = use::snapshot(ids, nondet_membership);
+        let elements = use::batch(requests, nondet_membership);
 
         let current_members = members_snapshot
             .filter(q!(|b| *b))

--- a/hydro_test/src/external_client/chat.rs
+++ b/hydro_test/src/external_client/chat.rs
@@ -35,8 +35,8 @@ pub fn chat_server<'a, P>(
     nondet_user_arrival_broadcast: NonDet,
 ) -> KeyedStream<u64, String, Process<'a, P>, Unbounded, NoOrder> {
     sliced! {
-        let msg_batch = use(in_stream, nondet_user_arrival_broadcast);
-        let members = use(track_membership(membership), nondet_user_arrival_broadcast);
+        let msg_batch = use::batch(in_stream, nondet_user_arrival_broadcast);
+        let members = use::snapshot(track_membership(membership), nondet_user_arrival_broadcast);
 
         let current_members = members.filter(q!(|b| *b)).keys();
         current_members.cross_product(msg_batch.entries()).into_keyed()

--- a/hydro_test/src/external_client/echo.rs
+++ b/hydro_test/src/external_client/echo.rs
@@ -10,7 +10,7 @@ pub fn echo_server<'a, P>(
     membership: KeyedStream<u64, MembershipEvent, Process<'a, P>, Unbounded, TotalOrder>,
 ) -> KeyedStream<u64, String, Process<'a, P>, Unbounded, TotalOrder> {
     sliced! {
-        let conns = use(track_membership(membership), nondet!(/** logging */));
+        let conns = use::snapshot(track_membership(membership), nondet!(/** logging */));
         conns.filter(q!(|b| *b)).key_count()
     }
     .sample_every(q!(Duration::from_secs(1)), nondet!(/** logging */))

--- a/hydro_test/src/external_client/http_counter.rs
+++ b/hydro_test/src/external_client/http_counter.rs
@@ -86,7 +86,7 @@ pub fn http_counter_server<'a, P>(
         .value_counts();
 
     let lookup_result = sliced! {
-        let batch_get_requests = use(get_stream, nondet!(/** batch get requests */));
+        let batch_get_requests = use::batch(get_stream, nondet!(/** batch get requests */));
         let cur_counters = use::atomic(counters, nondet!(/** intentional non-determinism for get timing */));
 
         batch_get_requests.lookup_keyed_singleton(cur_counters).into_keyed_stream()

--- a/hydro_test/src/local/chat_app.rs
+++ b/hydro_test/src/local/chat_app.rs
@@ -16,8 +16,8 @@ pub fn chat_app<'a>(
         let current_users = users_stream.collect_vec();
 
         sliced! {
-            let users = use(current_users, nondet_user_arrival_broadcast);
-            let messages = use(messages, nondet_user_arrival_broadcast);
+            let users = use::snapshot(current_users, nondet_user_arrival_broadcast);
+            let messages = use::batch(messages, nondet_user_arrival_broadcast);
 
             users.flatten_ordered().cross_product(messages).weaken_ordering::<NoOrder>()
         }

--- a/hydro_test/src/local/count_elems.rs
+++ b/hydro_test/src/local/count_elems.rs
@@ -4,7 +4,7 @@ pub fn count_elems<'a, T: 'a>(
     input_stream: Stream<T, Process<'a>, Unbounded>,
 ) -> Stream<u32, Process<'a>, Unbounded> {
     sliced! {
-        let batch = use(input_stream.map(q!(|_| 1)), nondet!(/** test */));
+        let batch = use::batch(input_stream.map(q!(|_| 1)), nondet!(/** test */));
         batch.fold(q!(|| 0), q!(|a, b| *a += b)).into_stream()
     }
 }

--- a/hydro_test/src/local/graph_reachability.rs
+++ b/hydro_test/src/local/graph_reachability.rs
@@ -9,9 +9,9 @@ pub fn graph_reachability<'a>(
 
     sliced! {
         let mut reached = use::state_null::<Stream<_, _, _, NoOrder>>();
-        let new_roots = use(roots, nondet!(/** roots can be inserted on any tick because we are fixpointing */));
-        let current_edges = use(edges.collect_vec(), nondet!(/** edges can be inserted on any tick because we are fixpointing */));
-        let spin = use(spinner, nondet!(/** force infinite loop for fixpoint */));
+        let new_roots = use::batch(roots, nondet!(/** roots can be inserted on any tick because we are fixpointing */));
+        let current_edges = use::snapshot(edges.collect_vec(), nondet!(/** edges can be inserted on any tick because we are fixpointing */));
+        let spin = use::batch(spinner, nondet!(/** force infinite loop for fixpoint */));
 
         reached = reached.chain(new_roots);
         let reachable = reached

--- a/hydro_test/src/maelstrom/broadcast.rs
+++ b/hydro_test/src/maelstrom/broadcast.rs
@@ -44,8 +44,8 @@ fn broadcast_core<'a, C: 'a>(
         cluster.forward_ref::<Stream<_, _, Unbounded, NoOrder, AtLeastOnce>>();
 
     let cur_state = sliced! {
-        let new_writes = use(writes, nondet!(/** TODO */));
-        let recv_broadcast = use(broadcasted, nondet!(/** TODO */));
+        let new_writes = use::batch(writes, nondet!(/** TODO */));
+        let recv_broadcast = use::batch(broadcasted, nondet!(/** TODO */));
         let mut local_state = use::state_null::<Stream<_, _, _, NoOrder>>();
 
         local_state = local_state.chain(new_writes).weaken_retries::<AtLeastOnce>()
@@ -102,8 +102,8 @@ pub fn broadcast_server<'a, C: 'a>(
     }));
 
     let read_response = sliced! {
-        let req = use(read_requests, nondet!(/** batching of requests does not matter */));
-        let data = use(
+        let req = use::batch(read_requests, nondet!(/** batching of requests does not matter */));
+        let data = use::snapshot(
             current_state,
             nondet!(/** we only guarantee eventual consistency */)
         );

--- a/hydro_test/src/tutorials/concurrent_clients.rs
+++ b/hydro_test/src/tutorials/concurrent_clients.rs
@@ -14,7 +14,7 @@ pub fn concurrent_counter_service<'a>(
     let increment_ack = increment_request_processing.end_atomic();
 
     let get_response = sliced! {
-        let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
+        let request_batch = use::batch(get_requests, nondet!(/** we never observe batch boundaries */));
         let count_snapshot = use::atomic(current_count, nondet!(/** atomicity guarantees consistency wrt increments */));
 
         request_batch.cross_singleton(count_snapshot).map(q!(|(_, count)| count))

--- a/hydro_test/src/tutorials/keyed_counter.rs
+++ b/hydro_test/src/tutorials/keyed_counter.rs
@@ -26,7 +26,7 @@ pub fn keyed_counter_service<'a, L: Location<'a>>(
         .into_keyed();
 
     let get_lookup = sliced! {
-        let request_batch = use(requests_regrouped, nondet!(/** we never observe batch boundaries */));
+        let request_batch = use::batch(requests_regrouped, nondet!(/** we never observe batch boundaries */));
         let count_snapshot = use::atomic(current_count, nondet!(/** atomicity guarantees consistency wrt increments */));
 
         request_batch.join_keyed_singleton(count_snapshot)

--- a/hydro_test/src/tutorials/keyed_counter_non_atomic.rs
+++ b/hydro_test/src/tutorials/keyed_counter_non_atomic.rs
@@ -25,8 +25,8 @@ pub fn keyed_counter_service_buggy<'a, L: Location<'a>, O: Ordering>(
         .into_keyed();
 
     let get_lookup = sliced! {
-        let request_batch = use(requests_regrouped, nondet!(/** we never observe batch boundaries */));
-        let count_snapshot = use(current_count, nondet!(/** atomicity guarantees consistency wrt increments */));
+        let request_batch = use::batch(requests_regrouped, nondet!(/** we never observe batch boundaries */));
+        let count_snapshot = use::snapshot(current_count, nondet!(/** atomicity guarantees consistency wrt increments */));
 
         request_batch.join_keyed_singleton(count_snapshot)
     };

--- a/hydro_test/src/tutorials/single_client_counter.rs
+++ b/hydro_test/src/tutorials/single_client_counter.rs
@@ -14,7 +14,7 @@ pub fn single_client_counter_service<'a>(
     let increment_ack = increment_request_processing.end_atomic();
 
     let get_response = sliced! {
-        let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
+        let request_batch = use::batch(get_requests, nondet!(/** we never observe batch boundaries */));
         let count_snapshot = use::atomic(current_count, nondet!(/** atomicity guarantees consistency wrt increments */));
 
         request_batch.cross_singleton(count_snapshot).map(q!(|(_, count)| count))

--- a/hydro_test/src/tutorials/single_client_counter_buggy.rs
+++ b/hydro_test/src/tutorials/single_client_counter_buggy.rs
@@ -13,8 +13,8 @@ pub fn single_client_counter_service_buggy<'a>(
     let increment_ack = increment_requests;
 
     let get_response = sliced! {
-        let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
-        let count_snapshot = use(current_count, nondet!(/** intentional, based on when the request came in */));
+        let request_batch = use::batch(get_requests, nondet!(/** we never observe batch boundaries */));
+        let count_snapshot = use::snapshot(current_count, nondet!(/** intentional, based on when the request came in */));
 
         request_batch.cross_singleton(count_snapshot).map(q!(|(_, count)| count))
     };

--- a/hydro_test/src/tutorials/single_counter.rs
+++ b/hydro_test/src/tutorials/single_counter.rs
@@ -14,7 +14,7 @@ pub fn single_counter_service<'a>(
     let increment_ack = increment_request_processing.end_atomic();
 
     let get_response = sliced! {
-        let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
+        let request_batch = use::batch(get_requests, nondet!(/** we never observe batch boundaries */));
         let count_snapshot = use::atomic(current_count, nondet!(/** atomicity guarantees consistency wrt increments */));
 
         request_batch.cross_singleton(count_snapshot).map(q!(|(_, count)| count))

--- a/hydro_test/src/tutorials/single_counter_buggy.rs
+++ b/hydro_test/src/tutorials/single_counter_buggy.rs
@@ -14,8 +14,8 @@ pub fn single_counter_service_buggy<'a>(
     let increment_ack = increment_requests;
 
     let get_response = sliced! {
-        let request_batch = use(get_requests, nondet!(/** we never observe batch boundaries */));
-        let count_snapshot = use(current_count, nondet!(/** intentional, based on when the request came in */));
+        let request_batch = use::batch(get_requests, nondet!(/** we never observe batch boundaries */));
+        let count_snapshot = use::snapshot(current_count, nondet!(/** intentional, based on when the request came in */));
 
         request_batch.cross_singleton(count_snapshot).map(q!(|(_, count)| count))
     };

--- a/template/hydro/.prompts/challenge-keyed-counter.md
+++ b/template/hydro/.prompts/challenge-keyed-counter.md
@@ -61,7 +61,7 @@ pub fn keyed_counter_service<'a, L: Location<'a>>(
         .into_keyed();
 
     let get_lookup = sliced! {
-        let request_batch = use(requests_regrouped, nondet!(/** we never observe batch boundaries */));
+        let request_batch = use::batch(requests_regrouped, nondet!(/** we never observe batch boundaries */));
         let count_snapshot = use::atomic(current_count, nondet!(/** atomicity guarantees consistency wrt increments */));
 
         request_batch.join_keyed_singleton(count_snapshot)


### PR DESCRIPTION
The style-less `use(collection, nondet)` form in `sliced!` automatically picked between
batching (stream-like collections) and snapshotting (singleton-like collections), which
hid an important semantic distinction from developers. This change:

- Adds explicit `use::batch(...)` for stream-like collections (`Stream`, `KeyedStream`,
  and `KeyedSingleton` with bounded values), backed by a new `Batch` style wrapper.
- Adds explicit `use::snapshot(...)` for singleton-like collections (`Singleton`,
  `Optional`, and `KeyedSingleton` with asynchronously-updated values), backed by a new
  `Snapshot` style wrapper.
- Marks the hidden `style::default` helper as `#[deprecated]`; because the `sliced!`
  macro re-spans the expansion onto the user's tokens via `copy_span!`, the deprecation
  warning surfaces directly on the user's `use(...)` statement.
- Migrates all internal call sites in `hydro_lang`, `hydro_std`, and `hydro_test` to the
  explicit styles.
- Updates `sliced!` macro documentation to describe the explicit styles and note the
  deprecation.
- Updates the Docusaurus docs (quickstart tutorials, state-management, correctness,
  simulation, atomic-collections, streaming-data pages): all embedded `getLines`
  snippet assertions match the migrated sources, standalone examples use the explicit
  styles, and slice-hooks.md documents the `use::batch`/`use::snapshot` hooks along
  with a deprecation note for the style-less form.
- Bumps `stageleft`/`stageleft_tool` to 0.15.1, which fixes the deprecation warning on
  the generated `lib_pub.rs` re-export of the deprecated `default` style helper.
- Regenerates the derived template prompt (`template/generate_prompts.py`) and stable
  insta/trybuild snapshots affected by the migration (nightly snapshots are left
  untouched; CI auto-updates them).