### PR TITLE
fix(hydro_lang): export sanitizer symbols via `cargo-sim` so fuzzing works outside hydro_lang

### DIFF
--- a/cargo-sim
+++ b/cargo-sim
@@ -5,6 +5,16 @@ mkdir -p fuzz
 
 export CARGO_BUILD_TARGET=$(rustc -vV | grep 'host:' | awk '{print $2}')
 export RUSTFLAGS="$RUSTFLAGS -C prefer-dynamic -Copt-level=3 -Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-inline-8bit-counters -Cllvm-args=-sanitizer-coverage-level=4 -Cllvm-args=-sanitizer-coverage-pc-table -Cllvm-args=-sanitizer-coverage-trace-compares"
+
+# The test binary hosts the libfuzzer runtime (linked in via bolero), and the simulator dlopens a
+# sancov-instrumented dylib whose coverage hooks (e.g. `__sanitizer_cov_pcs_init`) must resolve
+# against that runtime. Export the binary's symbols dynamically so the loader can find them;
+# without this, loading the dylib fails with "undefined symbol: __sanitizer_cov_pcs_init".
+if [[ "$(uname)" == "Darwin" ]]; then
+  export RUSTFLAGS="$RUSTFLAGS -Clink-arg=-export_dynamic"
+else
+  export RUSTFLAGS="$RUSTFLAGS -Clink-arg=-Wl,-export-dynamic"
+fi
 export BOLERO_FUZZER="libfuzzer"
 
 cargo test --lib ${@:2} --nocapture --test-threads=1

--- a/hydro_lang/build.rs
+++ b/hydro_lang/build.rs
@@ -1,20 +1,4 @@
 fn main() {
-    #[cfg(feature = "sim")]
-    {
-        println!("cargo::rerun-if-env-changed=BOLERO_FUZZER");
-        if std::env::var("BOLERO_FUZZER").is_ok() {
-            #[cfg(target_os = "macos")]
-            {
-                println!("cargo::rustc-link-arg=-export_dynamic");
-            }
-
-            #[cfg(target_os = "linux")]
-            {
-                println!("cargo::rustc-link-arg=-Wl,-export-dynamic");
-            }
-        }
-    }
-
     hydro_build_utils::emit_nightly_configuration!();
     stageleft_tool::gen_final!();
 }


### PR DESCRIPTION
The simulator dlopens a sancov-instrumented cdylib whose coverage hooks
(`__sanitizer_cov_pcs_init`, etc.) must resolve against the libfuzzer
runtime in the host test binary, which requires the binary to export its
symbols dynamically. Previously `-export-dynamic` was emitted by
hydro_lang's build.rs via `cargo::rustc-link-arg`, but cargo applies
build-script link args only to that package's own targets — they do not
propagate to dependents. So `cargo sim -p hydro_lang` worked while
`cargo sim -p hydro_test` (or any downstream crate) panicked at dlopen
with "undefined symbol: __sanitizer_cov_pcs_init".

- `cargo-sim`: append the platform-appropriate export-dynamic flag to
  RUSTFLAGS (`-Clink-arg=-Wl,-export-dynamic` on Linux,
  `-Clink-arg=-export_dynamic` on macOS), applying it to every test
  binary regardless of package.
- `hydro_lang/build.rs`: remove the now-redundant BOLERO_FUZZER
  export-dynamic block.

Verified: `nm -D` on the rebuilt hydro_test test binary shows all 18
`__sanitizer_cov_*` symbols exported, and
`cargo sim -p hydro_test -- concurrent_clients::tests::test_concurrent_clients`
runs the libfuzzer engine with coverage feedback instead of panicking.