### PR TITLE
test: enable sim tests in doctests via a merged-doctest ctor helper

### DIFF
--- a/docs/docs/hydro/reference/simulation/writing.mdx
+++ b/docs/docs/hydro/reference/simulation/writing.mdx
@@ -48,7 +48,7 @@ The `exhaustive()` method explores *all* possible executions. This is feasible w
 
 Sometimes an assertion only makes sense for a subset of executions—for example, when the property you want to check only holds if certain messages happened to arrive in the same batch. The `hydro_lang::sim::continue_if!` macro lets you express such preconditions: if the condition is false, the current simulation instance is stopped and discarded (it is *not* a test failure), and exploration moves on to the next execution. This is the same concept as `assume` in verification tools and property-based testing libraries (e.g. `kani::assume` or proptest's `prop_assume!`).
 
-```rust,no_run
+```rust
 # use hydro_lang::prelude::*;
 # use hydro_lang::sim::continue_if;
 # let mut flow = FlowBuilder::new();
@@ -60,7 +60,7 @@ Sometimes an assertion only makes sense for a subset of executions—for example
 #     .count()
 #     .all_ticks()
 #     .sim_output();
-flow.sim().fuzz(async || {
+flow.sim().exhaustive(async || {
     in_send.send_many([1, 2]);
     let batch_sizes: Vec<usize> = out_recv.collect().await;
     // only check executions where both messages landed in the first batch

--- a/hydro_test/src/lib.rs
+++ b/hydro_test/src/lib.rs
@@ -14,4 +14,20 @@ pub mod tutorials;
 #[cfg(doctest)]
 mod docs {
     include_mdtests::include_mdtests!("docs/docs/hydro/**/*.md*");
+
+    /// Registers a global constructor in the merged doctest binary so that `IS_TEST` mode is
+    /// enabled for all doctests (required for doctests that compile Hydro programs, e.g. sim
+    /// tests). This works because edition-2024 doctests are combined into a single binary, so
+    /// the `ctor` below runs before every doctest in this crate.
+    ///
+    /// ```rust
+    /// hydro_lang::macro_support::ctor::declarative::ctor!(
+    ///     #[ctor(unsafe)]
+    ///     fn init() {
+    ///         hydro_lang::compile::init_test();
+    ///     }
+    /// );
+    /// fn main() {}
+    /// ```
+    mod doctest_init {}
 }


### PR DESCRIPTION
Root cause investigation: sim snippets were marked `no_run` because the sim
trybuild pipeline requires "test mode" (`hydro_lang::compile::init_test()`),
which is normally enabled by a `#[ctor]` hook inside `#[cfg(test)]` modules
(via `hydro_lang::setup!()`). Doctests do not compile `#[cfg(test)]` code, so
`IS_TEST` stayed false, which meant:
  - the `hydro___test` cargo feature was not passed to the trybuild project,
    so dev-dependency features like `hydro_lang/sim` were missing and the
    generated `sim-dylib` failed to compile (`could not find sim in
    hydro_lang`, missing `colored` re-export, etc.)
  - `__staged.rs` regeneration was skipped.
Deploy doctests never hit this because their generated code only needs the
`deploy_integration` runtime feature, which is enabled unconditionally.

Fix (verified end-to-end): since edition-2024 doctests are merged into a
single binary, a hidden helper doctest in `hydro_test/src/lib.rs` registers a
`ctor` that calls `hydro_lang::compile::init_test()`, enabling test mode for
every doctest in the crate. Removed `no_run` from the `continue_if!` sim
example in `docs/docs/hydro/reference/simulation/writing.mdx` (switched
`fuzz` to `exhaustive`; see remaining gaps below). All 68 hydro_test doctests
pass.

Remaining gaps (not fixed here):
  - `CompiledSim::fuzz` panics in doctests: its backtrace walk for the
    `sim-failures` repro path gets `filename = None` for doctest frames.
    `exhaustive` works fine.
  - trybuild's `features::find()` returns None under doctests (argv[0] does
    not look like `target/debug/deps/name-HASH`), so the source crate's own
    features are not auto-discovered; this did not matter for hydro_test but
    could for crates whose own features gate sim code (fixable in the
    ../trybuild fork).