### PR TITLE
docs(hydro): add Quoting Code reference page and expand quoting gotchas into Quoting Limitations

### DIFF
--- a/docs/docs/hydro/learn/quickstart/index.mdx
+++ b/docs/docs/hydro/learn/quickstart/index.mdx
@@ -95,7 +95,7 @@ To process incoming requests, you use the APIs available on live collections. Th
 
 :::caution
 
-Quoting relies on advanced features of Rust, and can sometimes emit strange type errors. The [Quoting Errors](../../reference/stageleft/errors.mdx) page covers the limitations of `q!`. For example, to invoke a local function `foo` you must use `self::foo`.
+Quoting relies on advanced features of Rust, and can sometimes emit strange type errors. The [Quoting Limitations](../../reference/stageleft/errors.mdx) page covers the limitations of `q!`. For example, to invoke a local function `foo` you must use `self::foo`.
 
 If you forget to wrap an expression in `q!` when that is required, you'll see an error like:
 ```text

--- a/docs/docs/hydro/reference/stageleft/errors.mdx
+++ b/docs/docs/hydro/reference/stageleft/errors.mdx
@@ -1,5 +1,9 @@
-# Quoting Errors
-Quoting relies on advanced features of Rust, and can sometimes emit strange type errors. This page covers the current limitations and workarounds for common quoting errors.
+---
+sidebar_position: 2
+---
+
+# Quoting Limitations
+Quoting relies on advanced features of Rust, and can sometimes emit strange type errors. This page covers the current limitations and workarounds for common quoting gotchas. Each limitation links to a tracking issue on the [Stageleft repository](https://github.com/hydro-project/stageleft), where we aim to eventually fix these edge cases.
 
 :::note
 
@@ -7,9 +11,8 @@ The Hydro team is also working with members of the Rust language team to explore
 
 :::
 
-
 ## References to Local Functions
-Currently, code inside a `q!` macro must use `self::` paths when invoking a local function. For example, in this code invoking `foo` will not compile but `self::foo` works as expected:
+Currently, code inside a `q!` macro must use `self::` paths when invoking a local function. For example, in this code invoking `foo` will not compile but `self::foo` works as expected ([stageleft#93](https://github.com/hydro-project/stageleft/issues/93)):
 
 ```rust,ignore
 # use stageleft::*;
@@ -22,7 +25,7 @@ fn uses_foo_quoted() {
 ```
 
 ## Local Imports Inside Functions
-Imports (`use` statements) inside a function body are not visible to `q!`. Any symbols referenced inside `q!` must be imported at the module level.
+Imports (`use` statements) inside a function body are not visible to `q!`. Any symbols referenced inside `q!` must be imported at the module level ([stageleft#94](https://github.com/hydro-project/stageleft/issues/94)).
 
 ```rust,ignore
 # use stageleft::*;
@@ -37,8 +40,82 @@ fn uses_module_import() {
 }
 ```
 
+## Public Types Must Be Used Through Their Public API
+Quoted code is eventually compiled as part of a *generated* crate, not the crate where you wrote it. For `pub` types, this means quoted code can only use their **public** fields and methods — even when the `q!` block is written inside the crate that defines the type, where private fields would normally be visible.
+
+Code that touches a private field of a `pub` type will typecheck where you write it, but fail later when the deployed binaries are compiled (including in Hydro's simulator), with an error like ``field `max_size` of struct ... is private`` pointing into generated code ([stageleft#96](https://github.com/hydro-project/stageleft/issues/96)):
+
+```rust,ignore
+pub struct Config {
+    max_size: usize, // private field of a pub struct
+}
+
+// in the same crate that defines Config:
+q!(|c: Config| c.max_size) // typechecks, but fails during staged compilation
+q!(|c: Config| c.get_max_size()) // works if get_max_size is pub
+```
+
+To fix this, make the fields `pub` or expose public accessors and constructors for anything quoted code needs to touch.
+
+Relatedly, `pub` types declared inside private modules ([stageleft#18](https://github.com/hydro-project/stageleft/issues/18)) or inside `#[cfg(test)]` modules ([stageleft#43](https://github.com/hydro-project/stageleft/issues/43)) may fail to resolve during staged compilation.
+
+## Methods on Private Types
+The situation for fully private (non-`pub`) types is reversed: quoted code **can** construct them and access their fields (even private ones), but methods from handwritten `impl` blocks are not available, failing during staged compilation with a `no method found` error ([stageleft#97](https://github.com/hydro-project/stageleft/issues/97)):
+
+```rust,ignore
+struct SessionState {
+    count: u32,
+}
+
+impl SessionState {
+    fn bump(&mut self) { self.count += 1; }
+}
+
+q!(|s: &mut SessionState| s.count += 1) // works, field access is fine
+q!(|s: &mut SessionState| s.bump()) // fails during staged compilation
+```
+
+Traits implemented via `#[derive(...)]` (such as `Clone` or `Debug`) **do** work on private types. To use handwritten methods, make the type `pub` (and follow the public-API rule above), or refactor the logic into free functions.
+
+## Capturing Unsupported Types
+As described in [Quoting Code](./quoting.mdx#supported-types), only certain types can be captured by quoted code: integers, strings, and Hydro's special handles. Capturing anything else — including `bool` ([stageleft#99](https://github.com/hydro-project/stageleft/issues/99)), floats, `Duration` ([stageleft#55](https://github.com/hydro-project/stageleft/issues/55)), collections, or your own types ([stageleft#45](https://github.com/hydro-project/stageleft/issues/45)) — fails with an unsatisfied `FreeVariable...` trait bound at the `q!` site:
+
+```rust,ignore
+let debug_mode = true;
+// error[E0277]: the trait bound `bool: FreeVariableWithContextWithProps<_, ()>` is not satisfied
+q!(move |x| if debug_mode { dbg!(x) } else { x })
+```
+
+Workarounds: construct the value inside the quote, or capture the primitive components it is built from (e.g. capture a `u64` of milliseconds instead of a `Duration`).
+
+## Captures Require `move` Closures
+When a quoted closure captures a free variable — even a `Copy` type like an integer or `CLUSTER_SELF_ID` — the closure must be marked `move`, or you will get a borrow-checking error mentioning a variable with a `__free` suffix ([stageleft#98](https://github.com/hydro-project/stageleft/issues/98)):
+
+```rust,ignore
+let multiplier = 10;
+q!(|x| x * multiplier) // error[E0373]: closure may outlive the current function...
+q!(move |x| x * multiplier) // works!
+```
+
+## Generic Type Parameters
+Quoted code cannot *name* a generic type parameter of the enclosing function. The quote typechecks where you write it, but the generated code has no way to refer to `T`, so staged compilation fails with ``failed to resolve: use of undeclared type `T` `` ([stageleft#47](https://github.com/hydro-project/stageleft/issues/47)):
+
+```rust,ignore
+fn sum_stream<'a, T: Default + Add<Output = T>>(
+    stream: Stream<T, Process<'a, ()>>,
+) -> Singleton<T, Process<'a, ()>, Bounded> {
+    stream.fold(q!(|| T::default()), q!(|acc, x| *acc = *acc + x)) // fails during staged compilation
+}
+```
+
+Type *inference* involving generics works fine — only explicit mentions of the parameter are a problem. You can usually let the compiler infer the type instead:
+
+```rust,ignore
+stream.fold(q!(|| Default::default()), q!(|acc, x| *acc = *acc + x)) // works!
+```
+
 ## References to Free Variables in Macros
-Quoted code can refer to special types of external variables called "free variables". These include primitives such as integers and strings, as well as special types such as `CLUSTER_SELF_ID`. Stageleft does not currently handle references to these variables directly inside macros with custom syntax. To work around this, you should first load the free variable into a local variable and then use it from the macro.
+Quoted code can refer to special types of external variables called "free variables". These include primitives such as integers and strings, as well as special types such as `CLUSTER_SELF_ID`. Stageleft does not currently handle references to these variables directly inside macros with custom syntax ([stageleft#95](https://github.com/hydro-project/stageleft/issues/95)). To work around this, you should first load the free variable into a local variable and then use it from the macro.
 
 ```rust,ignore
 # use stageleft::*;
@@ -50,3 +127,65 @@ fn uses_free_variable() {
   }) // works!
 }
 ```
+
+## Private Declarative Macros
+A `macro_rules!` macro that is shared across modules with `pub(crate) use my_macro;` (instead of `#[macro_export]`) will break during staged compilation ([stageleft#48](https://github.com/hydro-project/stageleft/issues/48)). The workaround is to export the macro but hide it from documentation:
+
+```rust,ignore
+#[macro_export]
+#[doc(hidden)]
+macro_rules! my_macro { /* ... */ }
+```
+
+## Helper Functions Returning `impl Trait`
+Calling a function from your crate that returns `-> impl Trait` inside quoted code can fail during staged compilation with a "mismatched types ... found opaque type" error, because the return type is partially expanded in the generated code ([stageleft#63](https://github.com/hydro-project/stageleft/issues/63)). As a workaround, return a concrete type (e.g. a boxed trait object) from helpers called inside `q!`.
+
+## Types Defined in Private Modules
+The generated code sometimes needs to spell out the full name of a type that flows across a `q!` boundary (for example, the element type of a stream). Rust reports a type's name based on the module where it is *defined* — but many libraries (including the standard library) define types in private modules and only expose them through public re-exports. Naively naming such a type would produce an uncompilable path.
+
+To handle this, Stageleft maintains a table of **rewrite rules** that map private definition paths to their public re-export paths. Common cases in `std`, `tokio`, and `bytes` are covered out of the box (e.g. `std::collections::hash::map::HashMap` is rewritten to `std::collections::hash_map::HashMap`, and iterator types like the one returned by `std::iter::repeat` are rewritten to their `std::iter` re-exports), and `hydro_lang` registers additional rules for its dependencies. But the table is not exhaustive: if quoted code produces a type without a rewrite rule, staged compilation fails with a ``module ... is private`` error pointing into generated code ([stageleft#72](https://github.com/hydro-project/stageleft/issues/72) is an example of such a missing rule, since fixed).
+
+The simplest workaround is to avoid exposing the problematic type across the `q!` boundary, e.g. by collecting into a `Vec` inside the quote. If you are writing a **library** built on Hydro, you can also register your own rewrite rule using a `ctor` (a function that runs at program startup), exactly like `hydro_lang` does for its dependencies:
+
+```rust,ignore
+ctor::declarative::ctor!(
+    #[ctor(unsafe)]
+    fn init_rewrites() {
+        // `LinesCodec` is defined in the private module `tokio_util::codec::lines_codec`
+        // but publicly re-exported from `tokio_util::codec`
+        stageleft::add_private_reexport(
+            vec!["tokio_util", "codec", "lines_codec"],
+            vec!["tokio_util", "codec"],
+        );
+    }
+);
+```
+
+## Combining `#[cfg(stageleft_runtime)]` with Other Conditions
+The `#[cfg(stageleft_runtime)]` marker (used, for example, around `hydro_lang::setup!()` and for items that should not be visible to quoted code) is only recognized when written as a standalone attribute. Combining it with other conditions inside `all(...)` is not detected ([stageleft#6](https://github.com/hydro-project/stageleft/issues/6)). Stack separate attributes instead:
+
+```rust,ignore
+#[cfg(all(stageleft_runtime, feature = "deploy"))] // don't do this, not detected
+mod deploy_utils;
+
+#[cfg(stageleft_runtime)] // works!
+#[cfg(feature = "deploy")]
+mod deploy_utils;
+```
+
+## Self-Dependencies in `[dev-dependencies]`
+A crate that lists *itself* in `[dev-dependencies]` (a common trick to enable extra features in tests) may not be handled correctly by staged compilation ([stageleft#39](https://github.com/hydro-project/stageleft/issues/39)).
+
+## Multiple Statements Without a Block
+The `q!` macro accepts a single Rust *expression*. Passing multiple top-level statements can crash staged compilation instead of producing a clean error ([stageleft#20](https://github.com/hydro-project/stageleft/issues/20)). Wrap multi-statement snippets in a block:
+
+```rust,ignore
+q!(let x = 123; move |a: usize| a + x) // don't do this, may crash
+q!({
+  let x = 123;
+  move |a: usize| a + x
+}) // works!
+```
+
+## Spurious Warnings in Generated Code
+When compiling deployment binaries, you may see `unused_braces` warnings ("unnecessary braces around block return value") pointing into generated files ([stageleft#91](https://github.com/hydro-project/stageleft/issues/91)). These are harmless artifacts of code generation and can be ignored.

--- a/docs/docs/hydro/reference/stageleft/index.mdx
+++ b/docs/docs/hydro/reference/stageleft/index.mdx
@@ -5,10 +5,12 @@ sidebar_position: 0
 
 Hydro uses a library called Stageleft to power the `q!` macro and code generation logic. 
 
+The [Quoting Code](./quoting.mdx) page explains how to use the `q!` macro and how quoted code can capture variables (free variables) such as configuration values and Hydro state references. The [Quoting Limitations](./errors.mdx) page covers known edge cases and workarounds.
+
 For detailed documentation on Stageleft's architecture and the `q!` macro, see the [Stageleft README](https://github.com/hydro-project/stageleft/blob/main/README.md).
 
 :::note
 
-Hydro programmers need not understand how Stageleft works under the hood; this information is provided here for readers interested in how its `q!` macro works.
+Hydro programmers need not understand how Stageleft works under the hood; the [Quoting Code](./quoting.mdx) page covers everything you need to write Hydro programs, and further information is provided for readers interested in how the `q!` macro works.
 
 :::

--- a/docs/docs/hydro/reference/stageleft/quoting.mdx
+++ b/docs/docs/hydro/reference/stageleft/quoting.mdx
@@ -1,0 +1,170 @@
+---
+sidebar_position: 1
+---
+
+# Quoting Code
+Hydro programs are executed in **two stages**. First, your Rust code runs like a normal program to *build* the dataflow graph: every call to an operator like `map` or `fold` adds a node to the graph, but does not process any data. Then, Hydro compiles that graph into binaries which are deployed to your machines; only then does data start flowing.
+
+The `q!` macro (for **q**uote) is the bridge between these stages. Code wrapped in `q!(...)` is not executed while the graph is being built. Instead, it is captured and compiled into the deployed binaries, where it runs every time an element flows through the operator:
+
+```rust
+# use hydro_lang::prelude::*;
+# use futures::StreamExt;
+# tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
+process
+    .source_iter(q!(vec![1, 2, 3]))
+    .map(q!(|x| x * 2))
+# }, |mut stream| async move {
+# assert_eq!(stream.next().await.unwrap(), 2);
+# assert_eq!(stream.next().await.unwrap(), 4);
+# assert_eq!(stream.next().await.unwrap(), 6);
+# }));
+```
+
+In this example, `vec![1, 2, 3]` and `|x| x * 2` run **at runtime** on the deployed machine, while the calls to `source_iter` and `map` run **ahead of time** to construct the graph.
+
+Even though quoted code does not run immediately, it is **fully typechecked** where you write it. You get normal compiler errors, type inference, and IDE support (autocomplete, go-to-definition) inside `q!` blocks, just like regular Rust.
+
+## What Runs When
+A helpful rule of thumb: everything *outside* `q!` runs **once**, on your development machine (or CI), when the graph is constructed. Everything *inside* `q!` runs **on the deployed machines**, potentially many times.
+
+This distinction matters for code with side effects. For example, reading a timestamp outside `q!` captures the time when the graph was built, not when a message is processed:
+
+```rust,ignore
+// runs once, when the graph is built (probably not what you want)
+let start = std::time::SystemTime::now();
+
+// runs on the deployed machine, once per element
+requests.map(q!(|req| (std::time::SystemTime::now(), req)))
+```
+
+## Capturing Variables
+Quoted code can refer to variables defined outside the `q!` block. These are called **free variables**. Because the quoted code will run later, on a different machine, capturing a variable works differently than in a regular Rust closure: the *value* of the variable is embedded into the compiled program as a constant.
+
+This is useful for configuration values that are known when the graph is built, such as batch sizes or replication factors:
+
+```rust
+# use hydro_lang::prelude::*;
+# use futures::StreamExt;
+# tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
+let multiplier = 10; // computed while building the graph
+process
+    .source_iter(q!(vec![1, 2, 3]))
+    .map(q!(move |x| x * multiplier)) // multiplier is baked into the binary
+# }, |mut stream| async move {
+# assert_eq!(stream.next().await.unwrap(), 10);
+# assert_eq!(stream.next().await.unwrap(), 20);
+# assert_eq!(stream.next().await.unwrap(), 30);
+# }));
+```
+
+Note the `move` keyword on the closure; capturing variables inside a closure generally requires `move` (see the [limitations page](./errors.mdx) for details).
+
+Because the captured value is a snapshot taken at graph-construction time, changing the original variable afterwards has no effect on the deployed program. And when quoted code runs on a [cluster](../locations/clusters.md), every member sees the same captured value.
+
+### Supported Types
+Only certain types of values can be captured, because Hydro must be able to embed them into the generated program:
+
+| Type | Notes |
+|---|---|
+| Integers (`i8`–`i128`, `u8`–`u128`, `isize`, `usize`) | Embedded as literal values |
+| `&str` and `String` | Both appear as `&'static str` inside the quote |
+| Hydro handles | See [special free variables](#hydros-special-free-variables) below |
+
+Capturing any other type (including `bool`, floats, `Vec`, or your own structs) is a compile-time error mentioning an unsatisfied `FreeVariable...` trait bound:
+
+```rust,ignore
+let thresholds = vec![10, 20, 30];
+// error[E0277]: the trait bound `Vec<i32>: FreeVariableWithContextWithProps<_, ()>`
+// is not satisfied
+requests.map(q!(move |x| thresholds.contains(&x)))
+```
+
+The usual workarounds are to construct the value *inside* the quote, or to capture the primitive components it is built from:
+
+```rust
+# use hydro_lang::prelude::*;
+# use futures::StreamExt;
+# tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
+let limit = 20; // capture the primitive instead
+process
+    .source_iter(q!(vec![10, 20, 30]))
+    .filter(q!(move |x| {
+        let thresholds = vec![10, 20, 30]; // constructed at runtime
+        thresholds.contains(x) && *x <= limit
+    }))
+# }, |mut stream| async move {
+# assert_eq!(stream.next().await.unwrap(), 10);
+# assert_eq!(stream.next().await.unwrap(), 20);
+# }));
+```
+
+## Hydro's Special Free Variables
+Some Hydro APIs provide special values that can be captured inside `q!`. Unlike literal captures, these are **not** baked in as constants; instead, they are placeholders that resolve to a live value on the machine where the code runs.
+
+### Cluster Member Identity
+[`CLUSTER_SELF_ID`](../locations/clusters.md#self-identification) can be captured by quoted code that runs on a `Cluster`, and resolves to the ID of the specific cluster member executing the code — so each member sees a *different* value:
+
+```rust
+# use hydro_lang::prelude::*;
+# use futures::StreamExt;
+# tokio_test::block_on(hydro_lang::test_util::multi_location_test(|flow, process| {
+use hydro_lang::location::cluster::CLUSTER_SELF_ID;
+
+let workers: Cluster<()> = flow.cluster::<()>();
+workers
+    .source_iter(q!(vec![123]))
+    .map(q!(move |x| format!("{} on {}", x, CLUSTER_SELF_ID)))
+    .send(&process, TCP.fail_stop().bincode())
+    .values()
+# }, |mut stream| async move {
+# let mut results = Vec::new();
+# for _ in 0..4 { results.push(stream.next().await.unwrap()); }
+# results.sort();
+# assert_eq!(results, vec!["123 on MemberId::<()>(0)", "123 on MemberId::<()>(1)", "123 on MemberId::<()>(2)", "123 on MemberId::<()>(3)"]);
+# }));
+```
+
+Because `CLUSTER_SELF_ID` only makes sense on a cluster, capturing it in code that runs on a `Process` is a compile-time error. This is a general property of Hydro's special free variables: they are typechecked against the **location** where the quoted code will run.
+
+### State References
+Reference handles created with [`.by_ref()` and `.by_mut()`](../state-management/references-mutations.md) are also free variables. When captured by a `q!` closure, they resolve at runtime to a reference to the live contents of another collection at the same location:
+
+```rust
+# use hydro_lang::prelude::*;
+# use futures::StreamExt;
+# tokio_test::block_on(hydro_lang::test_util::stream_transform_test(|process| {
+let total: Singleton<i32, _, Bounded> = process
+    .source_iter(q!(0..5i32))
+    .fold(q!(|| 0), q!(|acc, x| *acc += x)); // 10
+let total_ref = total.by_ref(); // a handle that can be captured in q!
+
+process
+    .source_iter(q!(vec![1, 2, 3]))
+    .map(q!(|x| x + *total_ref)) // resolves to &i32 at runtime
+# }, |mut stream| async move {
+# let mut results = vec![];
+# for _ in 0..3 { results.push(stream.next().await.unwrap()); }
+# results.sort();
+# assert_eq!(results, vec![11, 12, 13]);
+# }));
+```
+
+See [References and Mutations](../state-management/references-mutations.md) for the full documentation of reference handles.
+
+## Referencing Functions and Types
+Quoted code can freely use functions, types, and constants defined at the module level of your crate, as well as items from your dependencies. This lets you factor runtime logic into ordinary Rust functions:
+
+```rust,ignore
+pub fn sanitize(input: &str) -> String {
+    input.trim().to_lowercase()
+}
+
+pub fn sanitized_requests<'a>(
+    requests: Stream<String, Process<'a, MyServer>>,
+) -> Stream<String, Process<'a, MyServer>> {
+    requests.map(q!(|s| self::sanitize(&s)))
+}
+```
+
+Keep in mind that the quoted code will ultimately be compiled as part of a *generated* crate, not the crate where you wrote it. Hydro takes care of resolving paths for you, but this is the source of a few limitations — for example, local functions must be referenced with a `self::` prefix (as shown above), imports must be at the module level, `pub` types must be used through their public API, and types that cross the quote boundary must be nameable through public paths. These edge cases are covered on the [Quoting Limitations](./errors.mdx) page.


### PR DESCRIPTION
Adds a new user-facing "Quoting Code" page under the Stageleft reference section
(docs/docs/hydro/reference/stageleft/quoting.mdx) explaining:
- the two-stage execution model and what the q! macro does (graph construction
  vs. runtime, with a "what runs when" rule of thumb)
- capturing variables (free variables): snapshot semantics, the supported set of
  capturable types (integers, &str/String as &'static str), and workarounds for
  unsupported types
- Hydro's special free variables that resolve to live values at runtime:
  CLUSTER_SELF_ID and by_ref/by_mut state reference handles
- referencing module-level functions/types from quoted code

Rewrites the errors page as "Quoting Limitations", keeping the original three
gotchas and adding newly verified ones, each linked to a tracking issue on
hydro-project/stageleft:
- pub types must be used through their public API (private fields of pub structs
  fail at staged-compile time) — hydro-project/stageleft#96, related hydro-project/stageleft#18/hydro-project/stageleft#43
- handwritten impl blocks on private types unavailable (derives work) — hydro-project/stageleft#97
- capturing unsupported types (bool hydro-project/stageleft#99, Duration hydro-project/stageleft#55, general hydro-project/stageleft#45)
- captures require `move` closures even for Copy types — hydro-project/stageleft#98
- generic type parameters cannot be named inside q! — hydro-project/stageleft#47
- private declarative macros — hydro-project/stageleft#48
- helpers returning `-> impl Trait` — hydro-project/stageleft#63
- multiple top-level statements crash — hydro-project/stageleft#20
- spurious unused_braces warnings in generated code — hydro-project/stageleft#91
- local functions need self:: (hydro-project/stageleft#93), module-level imports (hydro-project/stageleft#94), free variables
  in custom-syntax macros (hydro-project/stageleft#95)

Issues 93–99 were filed as part of this change; the behaviors were verified
empirically against a scratch copy of the stageleft test crates (private-field
access, private-type methods, derive behavior, capture errors, move requirement,
and generic-parameter splicing).

Also updates the Stageleft index page to link both pages and fixes the
quickstart link text. All compiled doc examples pass `cargo test -p hydro_test
--doc` (mdtests), and the MDX was validated with @mdx-js/mdx.