### PR TITLE
refactor(hydro_test): eliminate uses of MemberId::from_raw_id from Paxos / Compartmentalized Paxos

### DIFF
--- a/hydro_test/examples/paxos.rs
+++ b/hydro_test/examples/paxos.rs
@@ -146,7 +146,9 @@ async fn main() {
         ""
     };
     let create_trybuild_host = |host: Arc<dyn Host + 'static>, name: &str, i: usize| {
-        let mut tbh = TrybuildHost::new(host).rustflags(rustflags);
+        let mut tbh = TrybuildHost::new(host)
+            .rustflags(rustflags)
+            .feature("tokio");
         // Pin to core 0 on remote machines
         if args.gcp.is_some() || args.aws {
             tbh = tbh.pin_to_core(0);

--- a/hydro_test/src/cluster/compartmentalized_paxos.rs
+++ b/hydro_test/src/cluster/compartmentalized_paxos.rs
@@ -237,7 +237,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
         NoOrder,
     >,
     config: CompartmentalizedPaxosConfig,
-    a_max_ballot: Singleton<Ballot, Tick<Cluster<'a, Acceptor>>, Bounded>,
+    a_max_ballot: Singleton<Option<Ballot>, Tick<Cluster<'a, Acceptor>>, Bounded>,
     nondet_commit_leader_change: NonDet,
 ) -> (
     Stream<(usize, Option<P>), Cluster<'a, ProxyLeader>, Unbounded, NoOrder>,
@@ -338,7 +338,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
     );
 
     let pl_failed_p2b_to_proposer = fails
-        .map(q!(|(_, ballot)| (ballot.proposer_id.clone(), ballot)))
+        .flat_map_ordered(q!(|(_, ballot)| ballot.map(|b| (b.proposer_id.clone(), b))))
         .inspect(q!(|(_, ballot)| println!("Failed P2b: {:?}", ballot)))
         .demux(proposers, TCP.fail_stop().bincode())
         .values();

--- a/hydro_test/src/cluster/paxos.rs
+++ b/hydro_test/src/cluster/paxos.rs
@@ -261,7 +261,7 @@ pub fn leader_election<'a, L: Clone + Debug + Serialize + DeserializeOwned>(
     Singleton<Ballot, Tick<Cluster<'a, Proposer>>, Bounded>,
     Singleton<bool, Tick<Cluster<'a, Proposer>>, Bounded>,
     Stream<(Option<usize>, L), Tick<Cluster<'a, Proposer>>, Bounded, NoOrder>,
-    Singleton<Ballot, Tick<Cluster<'a, Acceptor>>, Bounded>,
+    Singleton<Option<Ballot>, Tick<Cluster<'a, Acceptor>>, Bounded>,
 ) {
     let (p1b_fail_complete, p1b_fail) =
         proposers.forward_ref::<Stream<Ballot, _, Unbounded, NoOrder>>();
@@ -277,14 +277,7 @@ pub fn leader_election<'a, L: Clone + Debug + Serialize + DeserializeOwned>(
         .merge_unordered(p_received_p2b_ballots)
         .merge_unordered(p_to_proposers_i_am_leader_forward_ref)
         .max()
-        .unwrap_or(
-            proposers
-                .singleton(q!(Ballot {
-                    num: 0,
-                    proposer_id: MemberId::from_raw_id(0)
-                }))
-                .into(),
-        );
+        .into_singleton();
 
     let (p_ballot, p_has_largest_ballot) = p_ballot_calc(p_received_max_ballot.snapshot(
         proposer_tick,
@@ -319,7 +312,6 @@ pub fn leader_election<'a, L: Clone + Debug + Serialize + DeserializeOwned>(
         .values();
 
     let (a_max_ballot, a_to_proposers_p1b) = acceptor_p1(
-        acceptor_tick,
         p_to_acceptors_p1a.batch(
             acceptor_tick,
             nondet!(
@@ -349,7 +341,7 @@ pub fn leader_election<'a, L: Clone + Debug + Serialize + DeserializeOwned>(
 
 // Proposer logic to calculate the next ballot number. Expects p_received_max_ballot, the largest ballot received so far. Outputs streams: ballot_num, and has_largest_ballot, which only contains a value if we have the largest ballot.
 fn p_ballot_calc<'a>(
-    p_received_max_ballot: Singleton<Ballot, Tick<Cluster<'a, Proposer>>, Bounded>,
+    p_received_max_ballot: Singleton<Option<Ballot>, Tick<Cluster<'a, Proposer>>, Bounded>,
 ) -> (
     Singleton<Ballot, Tick<Cluster<'a, Proposer>>, Bounded>,
     Singleton<bool, Tick<Cluster<'a, Proposer>>, Bounded>,
@@ -363,11 +355,11 @@ fn p_ballot_calc<'a>(
             .clone()
             .zip(p_ballot_num)
             .map(q!(move |(received_max_ballot, ballot_num)| {
-                if received_max_ballot
-                    > (Ballot {
+                if let Some(received_max_ballot) = received_max_ballot
+                    && (Ballot {
                         num: ballot_num,
                         proposer_id: CLUSTER_SELF_ID.clone(),
-                    })
+                    }) < received_max_ballot
                 {
                     received_max_ballot.num + 1
                 } else {
@@ -383,7 +375,7 @@ fn p_ballot_calc<'a>(
         let p_has_largest_ballot = p_received_max_ballot
             .zip(p_ballot.clone())
             .map(q!(
-                |(received_max_ballot, cur_ballot)| received_max_ballot <= cur_ballot
+                |(received_max_ballot, cur_ballot)| received_max_ballot <= Some(cur_ballot)
             ));
 
         (yield_atomic(p_ballot), yield_atomic(p_has_largest_ballot))
@@ -473,22 +465,23 @@ fn p_leader_heartbeat<'a>(
 
 #[expect(clippy::type_complexity, reason = "internal paxos code // TODO")]
 fn acceptor_p1<'a, L: Serialize + DeserializeOwned + Clone>(
-    acceptor_tick: &Tick<Cluster<'a, Acceptor>>,
     p_to_acceptors_p1a: Stream<Ballot, Tick<Cluster<'a, Acceptor>>, Bounded, NoOrder>,
     a_log: Singleton<(Option<usize>, L), Tick<Cluster<'a, Acceptor>>, Bounded>,
     proposers: &Cluster<'a, Proposer>,
 ) -> (
-    Singleton<Ballot, Tick<Cluster<'a, Acceptor>>, Bounded>,
-    Stream<(Ballot, Result<(Option<usize>, L), Ballot>), Cluster<'a, Proposer>, Unbounded, NoOrder>,
+    Singleton<Option<Ballot>, Tick<Cluster<'a, Acceptor>>, Bounded>,
+    Stream<
+        (Ballot, Result<(Option<usize>, L), Option<Ballot>>),
+        Cluster<'a, Proposer>,
+        Unbounded,
+        NoOrder,
+    >,
 ) {
     let a_max_ballot = p_to_acceptors_p1a
         .clone()
         .inspect(q!(|p1a| println!("Acceptor received P1a: {:?}", p1a)))
         .across_ticks(|s| s.max())
-        .unwrap_or(acceptor_tick.singleton(q!(Ballot {
-            num: 0,
-            proposer_id: MemberId::from_raw_id(0)
-        })));
+        .into_singleton();
 
     (
         a_max_ballot.clone(),
@@ -499,7 +492,7 @@ fn acceptor_p1<'a, L: Serialize + DeserializeOwned + Clone>(
                 ballot.proposer_id.clone(),
                 (
                     ballot.clone(),
-                    if ballot == max_ballot {
+                    if Some(ballot) == max_ballot {
                         Ok(log)
                     } else {
                         Err(max_ballot)
@@ -517,7 +510,7 @@ fn acceptor_p1<'a, L: Serialize + DeserializeOwned + Clone>(
 fn p_p1b<'a, P: Clone + Serialize + DeserializeOwned>(
     proposer_tick: &Tick<Cluster<'a, Proposer>>,
     a_to_proposers_p1b: Stream<
-        (Ballot, Result<(Option<usize>, P), Ballot>),
+        (Ballot, Result<(Option<usize>, P), Option<Ballot>>),
         Cluster<'a, Proposer>,
         Unbounded,
         NoOrder,
@@ -577,7 +570,7 @@ fn p_p1b<'a, P: Clone + Serialize + DeserializeOwned>(
         p_is_leader,
         // we used an unordered accumulator, so flattened has no order
         p_received_quorum_of_p1bs.flatten_unordered(),
-        fails.map(q!(|(_, ballot)| ballot)),
+        fails.flat_map_ordered(q!(|(_, ballot)| ballot)),
     )
 }
 
@@ -684,7 +677,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
     >,
     f: usize,
 
-    a_max_ballot: Singleton<Ballot, Tick<Cluster<'a, Acceptor>>, Bounded>,
+    a_max_ballot: Singleton<Option<Ballot>, Tick<Cluster<'a, Acceptor>>, Bounded>,
 
     nondet_commit: NonDet,
 ) -> (
@@ -762,7 +755,7 @@ fn sequence_payload<'a, P: PaxosPayload>(
     (
         p_to_replicas.map(q!(|((slot, _ballot), (value, _))| (slot, value))),
         a_log,
-        fails.map(q!(|(_, ballot)| ballot)),
+        fails.flat_map_ordered(q!(|(_, ballot)| ballot)),
     )
 }
 
@@ -801,7 +794,7 @@ pub fn index_payloads<'a, L: Location<'a>, P: PaxosPayload>(
 #[expect(clippy::type_complexity, reason = "internal paxos code // TODO")]
 pub fn acceptor_p2<'a, P: PaxosPayload, S: Clone>(
     acceptor_tick: &Tick<Cluster<'a, Acceptor>>,
-    a_max_ballot: Singleton<Ballot, Tick<Cluster<'a, Acceptor>>, Bounded>,
+    a_max_ballot: Singleton<Option<Ballot>, Tick<Cluster<'a, Acceptor>>, Bounded>,
     p_to_acceptors_p2a: Stream<P2a<P, S>, Cluster<'a, Acceptor>, Unbounded, NoOrder>,
     a_checkpoint: Optional<usize, Cluster<'a, Acceptor>, Unbounded>,
     proposers: &Cluster<'a, S>,
@@ -811,7 +804,7 @@ pub fn acceptor_p2<'a, P: PaxosPayload, S: Clone>(
         Atomic<Cluster<'a, Acceptor>>,
         Unbounded,
     >,
-    Stream<((usize, Ballot), Result<(), Ballot>), Cluster<'a, S>, Unbounded, NoOrder>,
+    Stream<((usize, Ballot), Result<(), Option<Ballot>>), Cluster<'a, S>, Unbounded, NoOrder>,
 ) {
     let p_to_acceptors_p2a_batch = p_to_acceptors_p2a.batch(
         acceptor_tick,
@@ -836,7 +829,7 @@ pub fn acceptor_p2<'a, P: PaxosPayload, S: Clone>(
         .clone()
         .cross_singleton(a_max_ballot.clone()) // Don't consider p2as if the current ballot is higher
         .filter_map(q!(|(p2a, max_ballot)|
-            if p2a.ballot >= max_ballot {
+            if Some(&p2a.ballot) >= max_ballot.as_ref() {
                 Some((p2a.slot, LogValue {
                     ballot: p2a.ballot,
                     value: p2a.value,
@@ -875,7 +868,7 @@ pub fn acceptor_p2<'a, P: PaxosPayload, S: Clone>(
             p2a.sender,
             (
                 (p2a.slot, p2a.ballot.clone()),
-                if p2a.ballot == max_ballot {
+                if Some(p2a.ballot) == max_ballot {
                     Ok(())
                 } else {
                     Err(max_ballot)

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -266,7 +266,7 @@ expression: built.ir()
         ),
         input: Tee {
             inner: <shared 1>: Map {
-                f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , u32) , u32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ,] [move | (received_max_ballot , ballot_num) | { if received_max_ballot > (Ballot { num : ballot_num , proposer_id : CLUSTER_SELF_ID__free . clone () , }) { received_max_ballot . num + 1 } else { ballot_num } }]) }),
+                f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > , u32) , u32 > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) ,] [move | (received_max_ballot , ballot_num) | { if let Some (received_max_ballot) = received_max_ballot && (Ballot { num : ballot_num , proposer_id : CLUSTER_SELF_ID__free . clone () , }) < received_max_ballot { received_max_ballot . num + 1 } else { ballot_num } }]) }),
                 input: Cast {
                     inner: CrossSingleton {
                         left: Tee {
@@ -277,16 +277,42 @@ expression: built.ir()
                                             inner: YieldConcat {
                                                 inner: ChainFirst {
                                                     first: Batch {
-                                                        inner: Reduce {
-                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
-                                                            input: ObserveNonDet {
-                                                                inner: ObserveNonDet {
-                                                                    inner: Chain {
-                                                                        first: Chain {
-                                                                            first: CycleSource {
-                                                                                cycle_id: CycleId(
-                                                                                    5,
-                                                                                ),
+                                                        inner: Map {
+                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_LINE_COL ! ([] [| v | Some (v)]) }),
+                                                            input: Reduce {
+                                                                f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
+                                                                input: ObserveNonDet {
+                                                                    inner: ObserveNonDet {
+                                                                        inner: Chain {
+                                                                            first: Chain {
+                                                                                first: CycleSource {
+                                                                                    cycle_id: CycleId(
+                                                                                        5,
+                                                                                    ),
+                                                                                    metadata: HydroIrMetadata {
+                                                                                        location_id: Cluster(loc1v1),
+                                                                                        collection_kind: Stream {
+                                                                                            bound: Unbounded,
+                                                                                            order: NoOrder,
+                                                                                            retry: ExactlyOnce,
+                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                                second: CycleSource {
+                                                                                    cycle_id: CycleId(
+                                                                                        3,
+                                                                                    ),
+                                                                                    metadata: HydroIrMetadata {
+                                                                                        location_id: Cluster(loc1v1),
+                                                                                        collection_kind: Stream {
+                                                                                            bound: Unbounded,
+                                                                                            order: NoOrder,
+                                                                                            retry: ExactlyOnce,
+                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                        },
+                                                                                    },
+                                                                                },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Cluster(loc1v1),
                                                                                     collection_kind: Stream {
@@ -299,32 +325,18 @@ expression: built.ir()
                                                                             },
                                                                             second: CycleSource {
                                                                                 cycle_id: CycleId(
-                                                                                    3,
+                                                                                    6,
                                                                                 ),
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Cluster(loc1v1),
                                                                                     collection_kind: Stream {
                                                                                         bound: Unbounded,
                                                                                         order: NoOrder,
-                                                                                        retry: ExactlyOnce,
+                                                                                        retry: AtLeastOnce,
                                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                     },
                                                                                 },
                                                                             },
-                                                                            metadata: HydroIrMetadata {
-                                                                                location_id: Cluster(loc1v1),
-                                                                                collection_kind: Stream {
-                                                                                    bound: Unbounded,
-                                                                                    order: NoOrder,
-                                                                                    retry: ExactlyOnce,
-                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                },
-                                                                            },
-                                                                        },
-                                                                        second: CycleSource {
-                                                                            cycle_id: CycleId(
-                                                                                6,
-                                                                            ),
                                                                             metadata: HydroIrMetadata {
                                                                                 location_id: Cluster(loc1v1),
                                                                                 collection_kind: Stream {
@@ -335,34 +347,32 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                         },
+                                                                        trusted: true,
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Cluster(loc1v1),
                                                                             collection_kind: Stream {
                                                                                 bound: Unbounded,
                                                                                 order: NoOrder,
-                                                                                retry: AtLeastOnce,
+                                                                                retry: ExactlyOnce,
                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                             },
                                                                         },
                                                                     },
-                                                                    trusted: true,
+                                                                    trusted: false,
                                                                     metadata: HydroIrMetadata {
                                                                         location_id: Cluster(loc1v1),
                                                                         collection_kind: Stream {
                                                                             bound: Unbounded,
-                                                                            order: NoOrder,
+                                                                            order: TotalOrder,
                                                                             retry: ExactlyOnce,
                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                         },
                                                                     },
                                                                 },
-                                                                trusted: false,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Cluster(loc1v1),
-                                                                    collection_kind: Stream {
+                                                                    collection_kind: Optional {
                                                                         bound: Unbounded,
-                                                                        order: TotalOrder,
-                                                                        retry: ExactlyOnce,
                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                     },
                                                                 },
@@ -371,7 +381,7 @@ expression: built.ir()
                                                                 location_id: Cluster(loc1v1),
                                                                 collection_kind: Optional {
                                                                     bound: Unbounded,
-                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                    element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                                 },
                                                             },
                                                         },
@@ -379,29 +389,20 @@ expression: built.ir()
                                                             location_id: Tick(3, Cluster(loc1v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
-                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                             },
                                                         },
                                                     },
                                                     second: Batch {
                                                         inner: Cast {
-                                                            inner: UnboundSingleton {
-                                                                inner: SingletonSource {
-                                                                    value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [Ballot { num : 0 , proposer_id : MemberId :: from_raw_id (0) }]) },
-                                                                    first_tick_only: false,
-                                                                    metadata: HydroIrMetadata {
-                                                                        location_id: Cluster(loc1v1),
-                                                                        collection_kind: Singleton {
-                                                                            bound: Bounded,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                        },
-                                                                    },
-                                                                },
+                                                            inner: SingletonSource {
+                                                                value: :: std :: option :: Option :: None,
+                                                                first_tick_only: false,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Cluster(loc1v1),
                                                                     collection_kind: Singleton {
                                                                         bound: Unbounded,
-                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                        element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                                     },
                                                                 },
                                                             },
@@ -409,7 +410,7 @@ expression: built.ir()
                                                                 location_id: Cluster(loc1v1),
                                                                 collection_kind: Optional {
                                                                     bound: Unbounded,
-                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                    element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                                 },
                                                             },
                                                         },
@@ -417,7 +418,7 @@ expression: built.ir()
                                                             location_id: Tick(3, Cluster(loc1v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
-                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                             },
                                                         },
                                                     },
@@ -425,7 +426,7 @@ expression: built.ir()
                                                         location_id: Tick(3, Cluster(loc1v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
-                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                            element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                         },
                                                     },
                                                 },
@@ -433,7 +434,7 @@ expression: built.ir()
                                                     location_id: Cluster(loc1v1),
                                                     collection_kind: Optional {
                                                         bound: Unbounded,
-                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                        element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                     },
                                                 },
                                             },
@@ -441,7 +442,7 @@ expression: built.ir()
                                                 location_id: Cluster(loc1v1),
                                                 collection_kind: Singleton {
                                                     bound: Unbounded,
-                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                    element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                 },
                                             },
                                         },
@@ -449,7 +450,7 @@ expression: built.ir()
                                             location_id: Tick(15, Cluster(loc1v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
-                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                             },
                                         },
                                     },
@@ -457,7 +458,7 @@ expression: built.ir()
                                         location_id: Atomic(Tick(15, Cluster(loc1v1))),
                                         collection_kind: Singleton {
                                             bound: Unbounded,
-                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                            element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                         },
                                     },
                                 },
@@ -465,7 +466,7 @@ expression: built.ir()
                                     location_id: Tick(15, Cluster(loc1v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
-                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                        element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                     },
                                 },
                             },
@@ -473,7 +474,7 @@ expression: built.ir()
                                 location_id: Tick(15, Cluster(loc1v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
-                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                    element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                 },
                             },
                         },
@@ -540,7 +541,7 @@ expression: built.ir()
                             location_id: Tick(15, Cluster(loc1v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
-                                element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , u32),
+                                element_type: (core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > , u32),
                             },
                         },
                     },
@@ -548,7 +549,7 @@ expression: built.ir()
                         location_id: Tick(15, Cluster(loc1v1)),
                         collection_kind: Singleton {
                             bound: Bounded,
-                            element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , u32),
+                            element_type: (core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > , u32),
                         },
                     },
                 },
@@ -1134,7 +1135,7 @@ expression: built.ir()
                                     bound: Bounded,
                                     order: NoOrder,
                                     retry: ExactlyOnce,
-                                    element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                    element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                 },
                             },
                         },
@@ -1144,16 +1145,16 @@ expression: built.ir()
                                 bound: Bounded,
                                 order: NoOrder,
                                 retry: ExactlyOnce,
-                                element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                             },
                         },
                     },
                     second: Batch {
                         inner: Tee {
                             inner: <shared 8>: Inspect {
-                                f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| p1b | println ! ("Proposer received P1b: {:?}" , p1b)]) }),
+                                f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >) , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| p1b | println ! ("Proposer received P1b: {:?}" , p1b)]) }),
                                 input: Map {
-                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([] [| (_ , v) | v]) }),
+                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >)) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([] [| (_ , v) | v]) }),
                                     input: Cast {
                                         inner: Network {
                                             name: None,
@@ -1162,19 +1163,19 @@ expression: built.ir()
                                             },
                                             serialize: Custom {
                                                 serialize_fn: Some(
-                                                    hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                    hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >)) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                                 ),
                                             },
                                             deserialize: Custom {
                                                 deserialize_fn: Some(
-                                                    | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Acceptor > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > (& b) . unwrap ()) },
+                                                    | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Acceptor > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >) > (& b) . unwrap ()) },
                                                 ),
                                             },
                                             instantiate_fn: <network instantiate>,
                                             input: Cast {
                                                 inner: YieldConcat {
                                                     inner: Map {
-                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| ((ballot , max_ballot) , log) | (ballot . proposer_id . clone () , (ballot . clone () , if ballot == max_ballot { Ok (log) } else { Err (max_ballot) }))]) }),
+                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >) , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| ((ballot , max_ballot) , log) | (ballot . proposer_id . clone () , (ballot . clone () , if Some (ballot) == max_ballot { Ok (log) } else { Err (max_ballot) }))]) }),
                                                         input: CrossSingleton {
                                                             left: CrossSingleton {
                                                                 left: Tee {
@@ -1836,15 +1837,27 @@ expression: built.ir()
                                                                     inner: Tee {
                                                                         inner: <shared 10>: Cast {
                                                                             inner: ChainFirst {
-                                                                                first: Batch {
-                                                                                    inner: Reduce {
-                                                                                        f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
-                                                                                        input: ObserveNonDet {
-                                                                                            inner: YieldConcat {
-                                                                                                inner: Inspect {
-                                                                                                    f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| p1a | println ! ("Acceptor received P1a: {:?}" , p1a)]) }),
-                                                                                                    input: Tee {
-                                                                                                        inner: <shared 9>,
+                                                                                first: Map {
+                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_LINE_COL ! ([] [| v | Some (v)]) }),
+                                                                                    input: Batch {
+                                                                                        inner: Reduce {
+                                                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
+                                                                                            input: ObserveNonDet {
+                                                                                                inner: YieldConcat {
+                                                                                                    inner: Inspect {
+                                                                                                        f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| p1a | println ! ("Acceptor received P1a: {:?}" , p1a)]) }),
+                                                                                                        input: Tee {
+                                                                                                            inner: <shared 9>,
+                                                                                                            metadata: HydroIrMetadata {
+                                                                                                                location_id: Tick(2, Cluster(loc2v1)),
+                                                                                                                collection_kind: Stream {
+                                                                                                                    bound: Bounded,
+                                                                                                                    order: NoOrder,
+                                                                                                                    retry: ExactlyOnce,
+                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                },
+                                                                                                            },
+                                                                                                        },
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_id: Tick(2, Cluster(loc2v1)),
                                                                                                             collection_kind: Stream {
@@ -1856,59 +1869,37 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(2, Cluster(loc2v1)),
+                                                                                                        location_id: Atomic(Tick(2, Cluster(loc2v1))),
                                                                                                         collection_kind: Stream {
-                                                                                                            bound: Bounded,
+                                                                                                            bound: Unbounded,
                                                                                                             order: NoOrder,
                                                                                                             retry: ExactlyOnce,
                                                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                                         },
                                                                                                     },
                                                                                                 },
+                                                                                                trusted: false,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Atomic(Tick(2, Cluster(loc2v1))),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Unbounded,
-                                                                                                        order: NoOrder,
+                                                                                                        order: TotalOrder,
                                                                                                         retry: ExactlyOnce,
                                                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                                     },
                                                                                                 },
                                                                                             },
-                                                                                            trusted: false,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Atomic(Tick(2, Cluster(loc2v1))),
-                                                                                                collection_kind: Stream {
+                                                                                                collection_kind: Optional {
                                                                                                     bound: Unbounded,
-                                                                                                    order: TotalOrder,
-                                                                                                    retry: ExactlyOnce,
                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                                 },
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Atomic(Tick(2, Cluster(loc2v1))),
-                                                                                            collection_kind: Optional {
-                                                                                                bound: Unbounded,
-                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                            },
-                                                                                        },
-                                                                                    },
-                                                                                    metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(2, Cluster(loc2v1)),
-                                                                                        collection_kind: Optional {
-                                                                                            bound: Bounded,
-                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                        },
-                                                                                    },
-                                                                                },
-                                                                                second: Cast {
-                                                                                    inner: SingletonSource {
-                                                                                        value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [Ballot { num : 0 , proposer_id : MemberId :: from_raw_id (0) }]) },
-                                                                                        first_tick_only: false,
-                                                                                        metadata: HydroIrMetadata {
                                                                                             location_id: Tick(2, Cluster(loc2v1)),
-                                                                                            collection_kind: Singleton {
+                                                                                            collection_kind: Optional {
                                                                                                 bound: Bounded,
                                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                             },
@@ -1918,7 +1909,27 @@ expression: built.ir()
                                                                                         location_id: Tick(2, Cluster(loc2v1)),
                                                                                         collection_kind: Optional {
                                                                                             bound: Bounded,
-                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                            element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
+                                                                                        },
+                                                                                    },
+                                                                                },
+                                                                                second: Cast {
+                                                                                    inner: SingletonSource {
+                                                                                        value: :: std :: option :: Option :: None,
+                                                                                        first_tick_only: false,
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_id: Tick(2, Cluster(loc2v1)),
+                                                                                            collection_kind: Singleton {
+                                                                                                bound: Bounded,
+                                                                                                element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                    metadata: HydroIrMetadata {
+                                                                                        location_id: Tick(2, Cluster(loc2v1)),
+                                                                                        collection_kind: Optional {
+                                                                                            bound: Bounded,
+                                                                                            element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                                                         },
                                                                                     },
                                                                                 },
@@ -1926,7 +1937,7 @@ expression: built.ir()
                                                                                     location_id: Tick(2, Cluster(loc2v1)),
                                                                                     collection_kind: Optional {
                                                                                         bound: Bounded,
-                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                        element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                                                     },
                                                                                 },
                                                                             },
@@ -1934,7 +1945,7 @@ expression: built.ir()
                                                                                 location_id: Tick(2, Cluster(loc2v1)),
                                                                                 collection_kind: Singleton {
                                                                                     bound: Bounded,
-                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                    element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                                                 },
                                                                             },
                                                                         },
@@ -1942,7 +1953,7 @@ expression: built.ir()
                                                                             location_id: Tick(2, Cluster(loc2v1)),
                                                                             collection_kind: Singleton {
                                                                                 bound: Bounded,
-                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                                             },
                                                                         },
                                                                     },
@@ -1950,7 +1961,7 @@ expression: built.ir()
                                                                         location_id: Tick(2, Cluster(loc2v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                            element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                                         },
                                                                     },
                                                                 },
@@ -1960,7 +1971,7 @@ expression: built.ir()
                                                                         bound: Bounded,
                                                                         order: NoOrder,
                                                                         retry: ExactlyOnce,
-                                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >),
                                                                     },
                                                                 },
                                                             },
@@ -1991,7 +2002,7 @@ expression: built.ir()
                                                                     bound: Bounded,
                                                                     order: NoOrder,
                                                                     retry: ExactlyOnce,
-                                                                    element_type: ((hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)),
+                                                                    element_type: ((hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >) , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)),
                                                                 },
                                                             },
                                                         },
@@ -2001,7 +2012,7 @@ expression: built.ir()
                                                                 bound: Bounded,
                                                                 order: NoOrder,
                                                                 retry: ExactlyOnce,
-                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
+                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >)),
                                                             },
                                                         },
                                                     },
@@ -2011,7 +2022,7 @@ expression: built.ir()
                                                             bound: Unbounded,
                                                             order: NoOrder,
                                                             retry: ExactlyOnce,
-                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
+                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >)),
                                                         },
                                                     },
                                                 },
@@ -2022,7 +2033,7 @@ expression: built.ir()
                                                         value_order: NoOrder,
                                                         value_retry: ExactlyOnce,
                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                        value_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                                        value_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                                     },
                                                 },
                                             },
@@ -2033,7 +2044,7 @@ expression: built.ir()
                                                     value_order: NoOrder,
                                                     value_retry: ExactlyOnce,
                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                    value_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                                    value_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                                 },
                                             },
                                         },
@@ -2043,7 +2054,7 @@ expression: built.ir()
                                                 bound: Unbounded,
                                                 order: NoOrder,
                                                 retry: ExactlyOnce,
-                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
+                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >)),
                                             },
                                         },
                                     },
@@ -2053,7 +2064,7 @@ expression: built.ir()
                                             bound: Unbounded,
                                             order: NoOrder,
                                             retry: ExactlyOnce,
-                                            element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                            element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                         },
                                     },
                                 },
@@ -2063,7 +2074,7 @@ expression: built.ir()
                                         bound: Unbounded,
                                         order: NoOrder,
                                         retry: ExactlyOnce,
-                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                     },
                                 },
                             },
@@ -2073,7 +2084,7 @@ expression: built.ir()
                                     bound: Unbounded,
                                     order: NoOrder,
                                     retry: ExactlyOnce,
-                                    element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                    element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                 },
                             },
                         },
@@ -2083,7 +2094,7 @@ expression: built.ir()
                                 bound: Bounded,
                                 order: NoOrder,
                                 retry: ExactlyOnce,
-                                element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                             },
                         },
                     },
@@ -2093,7 +2104,7 @@ expression: built.ir()
                             bound: Bounded,
                             order: NoOrder,
                             retry: ExactlyOnce,
-                            element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                            element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                         },
                     },
                 },
@@ -2103,7 +2114,7 @@ expression: built.ir()
                         bound: Bounded,
                         order: NoOrder,
                         retry: ExactlyOnce,
-                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                     },
                 },
             },
@@ -2117,7 +2128,7 @@ expression: built.ir()
                                 input: Tee {
                                     inner: <shared 12>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([] [move | | (0 , 0)]) }),
-                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([] [move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } }]) }),
+                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([] [move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } }]) }),
                                         input: Cast {
                                             inner: Tee {
                                                 inner: <shared 7>,
@@ -2127,7 +2138,7 @@ expression: built.ir()
                                                         bound: Bounded,
                                                         order: NoOrder,
                                                         retry: ExactlyOnce,
-                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                                     },
                                                 },
                                             },
@@ -2138,7 +2149,7 @@ expression: built.ir()
                                                     value_order: NoOrder,
                                                     value_retry: ExactlyOnce,
                                                     key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                    value_type: core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >,
+                                                    value_type: core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >,
                                                 },
                                             },
                                         },
@@ -2216,7 +2227,7 @@ expression: built.ir()
                     bound: Bounded,
                     order: NoOrder,
                     retry: ExactlyOnce,
-                    element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                    element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                 },
             },
         },
@@ -2345,7 +2356,7 @@ expression: built.ir()
                                                                                             inner: Cast {
                                                                                                 inner: YieldConcat {
                                                                                                     inner: FilterMap {
-                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([] [move | (key , res) | match res { Ok (v) => Some ((key , v)) , Err (_) => None , }]) }),
+                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([] [move | (key , res) | match res { Ok (v) => Some ((key , v)) , Err (_) => None , }]) }),
                                                                                                         input: AntiJoin {
                                                                                                             pos: AntiJoin {
                                                                                                                 pos: Tee {
@@ -2356,7 +2367,7 @@ expression: built.ir()
                                                                                                                             bound: Bounded,
                                                                                                                             order: NoOrder,
                                                                                                                             retry: ExactlyOnce,
-                                                                                                                            element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                                                                                                            element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                                                                                                         },
                                                                                                                     },
                                                                                                                 },
@@ -2423,7 +2434,7 @@ expression: built.ir()
                                                                                                                         bound: Bounded,
                                                                                                                         order: NoOrder,
                                                                                                                         retry: ExactlyOnce,
-                                                                                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                                                                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                                                                                                     },
                                                                                                                 },
                                                                                                             },
@@ -2458,7 +2469,7 @@ expression: built.ir()
                                                                                                                     bound: Bounded,
                                                                                                                     order: NoOrder,
                                                                                                                     retry: ExactlyOnce,
-                                                                                                                    element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                                                                                                    element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                                                                                                 },
                                                                                                             },
                                                                                                         },
@@ -2689,7 +2700,7 @@ expression: built.ir()
                         right: Batch {
                             inner: YieldConcat {
                                 inner: Map {
-                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| (received_max_ballot , cur_ballot) | received_max_ballot <= cur_ballot]) }),
+                                    f: stageleft :: runtime_support :: fn1_type_hint :: < (core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| (received_max_ballot , cur_ballot) | received_max_ballot <= Some (cur_ballot)]) }),
                                     input: Cast {
                                         inner: CrossSingleton {
                                             left: Tee {
@@ -2698,7 +2709,7 @@ expression: built.ir()
                                                     location_id: Tick(15, Cluster(loc1v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
-                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                        element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                     },
                                                 },
                                             },
@@ -2716,7 +2727,7 @@ expression: built.ir()
                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
-                                                    element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                    element_type: (core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
                                                 },
                                             },
                                         },
@@ -2724,7 +2735,7 @@ expression: built.ir()
                                             location_id: Tick(15, Cluster(loc1v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
-                                                element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                element_type: (core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
                                             },
                                         },
                                     },
@@ -2790,10 +2801,10 @@ expression: built.ir()
         cycle_id: CycleId(
             5,
         ),
-        input: Map {
-            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| (_ , ballot) | ballot]) }),
+        input: FlatMap {
+            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| (_ , ballot) | ballot]) }),
             input: FilterMap {
-                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([] [move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , }]) }),
+                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([] [move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , }]) }),
                 input: Tee {
                     inner: <shared 8>,
                     metadata: HydroIrMetadata {
@@ -2802,7 +2813,7 @@ expression: built.ir()
                             bound: Unbounded,
                             order: NoOrder,
                             retry: ExactlyOnce,
-                            element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                            element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                         },
                     },
                 },
@@ -2812,7 +2823,7 @@ expression: built.ir()
                         bound: Unbounded,
                         order: NoOrder,
                         retry: ExactlyOnce,
-                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >),
                     },
                 },
             },
@@ -4265,7 +4276,7 @@ expression: built.ir()
                                     bound: Bounded,
                                     order: NoOrder,
                                     retry: ExactlyOnce,
-                                    element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                    element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                 },
                             },
                         },
@@ -4275,14 +4286,14 @@ expression: built.ir()
                                 bound: Bounded,
                                 order: NoOrder,
                                 retry: ExactlyOnce,
-                                element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                             },
                         },
                     },
                     second: Batch {
                         inner: Tee {
                             inner: <shared 25>: Map {
-                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([] [| (_ , v) | v]) }),
+                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >)) , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([] [| (_ , v) | v]) }),
                                 input: Cast {
                                     inner: Network {
                                         name: None,
@@ -4291,19 +4302,19 @@ expression: built.ir()
                                         },
                                         serialize: Custom {
                                             serialize_fn: Some(
-                                                hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >)) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
                                             ),
                                         },
                                         deserialize: Custom {
                                             deserialize_fn: Some(
-                                                | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Acceptor > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) > (& b) . unwrap ()) },
+                                                | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Acceptor > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >) > (& b) . unwrap ()) },
                                             ),
                                         },
                                         instantiate_fn: <network instantiate>,
                                         input: Cast {
                                             inner: YieldConcat {
                                                 inner: Map {
-                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| (p2a , max_ballot) | (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if p2a . ballot == max_ballot { Ok (()) } else { Err (max_ballot) }))]) }),
+                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >)) > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| (p2a , max_ballot) | (p2a . sender , ((p2a . slot , p2a . ballot . clone ()) , if Some (p2a . ballot) == max_ballot { Ok (()) } else { Err (max_ballot) }))]) }),
                                                     input: CrossSingleton {
                                                         left: Tee {
                                                             inner: <shared 26>: Batch {
@@ -5094,7 +5105,7 @@ expression: built.ir()
                                                                     location_id: Tick(2, Cluster(loc2v1)),
                                                                     collection_kind: Singleton {
                                                                         bound: Bounded,
-                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                        element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                                     },
                                                                 },
                                                             },
@@ -5102,7 +5113,7 @@ expression: built.ir()
                                                                 location_id: Tick(2, Cluster(loc2v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
-                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                    element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                                 },
                                                             },
                                                         },
@@ -5112,7 +5123,7 @@ expression: built.ir()
                                                                 bound: Bounded,
                                                                 order: NoOrder,
                                                                 retry: ExactlyOnce,
-                                                                element_type: (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                element_type: (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >),
                                                             },
                                                         },
                                                     },
@@ -5122,7 +5133,7 @@ expression: built.ir()
                                                             bound: Bounded,
                                                             order: NoOrder,
                                                             retry: ExactlyOnce,
-                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
+                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >)),
                                                         },
                                                     },
                                                 },
@@ -5132,7 +5143,7 @@ expression: built.ir()
                                                         bound: Unbounded,
                                                         order: NoOrder,
                                                         retry: ExactlyOnce,
-                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
+                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >)),
                                                     },
                                                 },
                                             },
@@ -5143,7 +5154,7 @@ expression: built.ir()
                                                     value_order: NoOrder,
                                                     value_retry: ExactlyOnce,
                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                    value_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                                    value_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                                 },
                                             },
                                         },
@@ -5154,7 +5165,7 @@ expression: built.ir()
                                                 value_order: NoOrder,
                                                 value_retry: ExactlyOnce,
                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
-                                                value_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                                value_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                             },
                                         },
                                     },
@@ -5164,7 +5175,7 @@ expression: built.ir()
                                             bound: Unbounded,
                                             order: NoOrder,
                                             retry: ExactlyOnce,
-                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >)),
+                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor > , ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >)),
                                         },
                                     },
                                 },
@@ -5174,7 +5185,7 @@ expression: built.ir()
                                         bound: Unbounded,
                                         order: NoOrder,
                                         retry: ExactlyOnce,
-                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                     },
                                 },
                             },
@@ -5184,7 +5195,7 @@ expression: built.ir()
                                     bound: Unbounded,
                                     order: NoOrder,
                                     retry: ExactlyOnce,
-                                    element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                    element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                 },
                             },
                         },
@@ -5194,7 +5205,7 @@ expression: built.ir()
                                 bound: Bounded,
                                 order: NoOrder,
                                 retry: ExactlyOnce,
-                                element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                             },
                         },
                     },
@@ -5204,7 +5215,7 @@ expression: built.ir()
                             bound: Bounded,
                             order: NoOrder,
                             retry: ExactlyOnce,
-                            element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                            element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                         },
                     },
                 },
@@ -5214,7 +5225,7 @@ expression: built.ir()
                         bound: Bounded,
                         order: NoOrder,
                         retry: ExactlyOnce,
-                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                     },
                 },
             },
@@ -5228,7 +5239,7 @@ expression: built.ir()
                                 input: Tee {
                                     inner: <shared 30>: FoldKeyed {
                                         init: stageleft :: runtime_support :: fn0_type_hint :: < (usize , usize) > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([] [move | | (0 , 0)]) }),
-                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([] [move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } }]) }),
+                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (usize , usize) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > > , () > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([] [move | accum , value | { if value . is_ok () { accum . 0 += 1 ; } else { accum . 1 += 1 ; } }]) }),
                                         input: Cast {
                                             inner: Tee {
                                                 inner: <shared 24>,
@@ -5238,7 +5249,7 @@ expression: built.ir()
                                                         bound: Bounded,
                                                         order: NoOrder,
                                                         retry: ExactlyOnce,
-                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                                                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                                                     },
                                                 },
                                             },
@@ -5249,7 +5260,7 @@ expression: built.ir()
                                                     value_order: NoOrder,
                                                     value_retry: ExactlyOnce,
                                                     key_type: (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
-                                                    value_type: core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >,
+                                                    value_type: core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >,
                                                 },
                                             },
                                         },
@@ -5327,7 +5338,7 @@ expression: built.ir()
                     bound: Bounded,
                     order: NoOrder,
                     retry: ExactlyOnce,
-                    element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                    element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                 },
             },
         },
@@ -5731,7 +5742,7 @@ expression: built.ir()
                                                 inner: Cast {
                                                     inner: YieldConcat {
                                                         inner: FilterMap {
-                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| (p2a , max_ballot) | if p2a . ballot >= max_ballot { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , })) } else { None }]) }),
+                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < (usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| (p2a , max_ballot) | if Some (& p2a . ballot) >= max_ballot . as_ref () { Some ((p2a . slot , LogValue { ballot : p2a . ballot , value : p2a . value , })) } else { None }]) }),
                                                             input: CrossSingleton {
                                                                 left: Tee {
                                                                     inner: <shared 26>,
@@ -5752,7 +5763,7 @@ expression: built.ir()
                                                                             location_id: Tick(2, Cluster(loc2v1)),
                                                                             collection_kind: Singleton {
                                                                                 bound: Bounded,
-                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                                             },
                                                                         },
                                                                     },
@@ -5760,7 +5771,7 @@ expression: built.ir()
                                                                         location_id: Tick(2, Cluster(loc2v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
-                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                            element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                                         },
                                                                     },
                                                                 },
@@ -5770,7 +5781,7 @@ expression: built.ir()
                                                                         bound: Bounded,
                                                                         order: NoOrder,
                                                                         retry: ExactlyOnce,
-                                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: P2a < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) , hydro_test :: __staged :: cluster :: paxos :: Proposer > , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >),
                                                                     },
                                                                 },
                                                             },
@@ -5912,10 +5923,10 @@ expression: built.ir()
         cycle_id: CycleId(
             3,
         ),
-        input: Map {
-            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| (_ , ballot) | ballot]) }),
+        input: FlatMap {
+            f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| (_ , ballot) | ballot]) }),
             input: FilterMap {
-                f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([] [move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , }]) }),
+                f: stageleft :: runtime_support :: fnmut1_type_hint :: < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >) , core :: option :: Option < ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([] [move | (key , res) | match res { Ok (_) => None , Err (e) => Some ((key , e)) , }]) }),
                 input: Tee {
                     inner: <shared 25>,
                     metadata: HydroIrMetadata {
@@ -5924,7 +5935,7 @@ expression: built.ir()
                             bound: Unbounded,
                             order: NoOrder,
                             retry: ExactlyOnce,
-                            element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , hydro_test :: __staged :: cluster :: paxos :: Ballot >),
+                            element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: result :: Result < () , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
                         },
                     },
                 },
@@ -5934,7 +5945,7 @@ expression: built.ir()
                         bound: Unbounded,
                         order: NoOrder,
                         retry: ExactlyOnce,
-                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                        element_type: ((usize , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >),
                     },
                 },
             },

--- a/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
@@ -16,123 +16,125 @@ linkStyle default stroke:#aaa
 6v1["<div style=text-align:center>(6v1)</div> <code><br>tee()</code>"]:::otherClass
 7v1["<div style=text-align:center>(7v1)</div> <code><br>inspect({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| p1a | println!(&quot;Acceptor received P1a: {:?}&quot;, p1a)]<br>    )<br>})</code>"]:::otherClass
 8v1["<div style=text-align:center>(8v1)</div> <code><br>reduce::&lt;<br>    'static,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
-9v1["<div style=text-align:center>(9v1)</div> <code><br>source_iter([<br>    {<br>        crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>            [] [Ballot { num : 0, proposer_id : MemberId::from_raw_id(0) }]<br>        )<br>    },<br>])</code>"]:::otherClass
-10v1["<div style=text-align:center>(10v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-11v1["<div style=text-align:center>(11v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-12v1["<div style=text-align:center>(12v1)</div> <code><br>tee()</code>"]:::otherClass
-13v1["<div style=text-align:center>(13v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+9v1["<div style=text-align:center>(9v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+10v1["<div style=text-align:center>(10v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+11v1["<div style=text-align:center>(11v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+12v1["<div style=text-align:center>(12v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+13v1["<div style=text-align:center>(13v1)</div> <code><br>tee()</code>"]:::otherClass
 14v1["<div style=text-align:center>(14v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-15v1["<div style=text-align:center>(15v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| ((ballot, max_ballot), log) | (ballot.proposer_id.clone(), (ballot<br>        .clone(), if ballot == max_ballot { Ok(log) } else { Err(max_ballot) }))]<br>    )<br>})</code>"]:::otherClass
-16v1["<div style=text-align:center>(16v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-17v1["<div style=text-align:center>(17v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-18v1["<div style=text-align:center>(18v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-19v1["<div style=text-align:center>(19v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::P2a&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>                hydro_test::__staged::cluster::paxos::Proposer,<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-20v1["<div style=text-align:center>(20v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
-21v1["<div style=text-align:center>(21v1)</div> <code><br>tee()</code>"]:::otherClass
-22v1["<div style=text-align:center>(22v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-23v1["<div style=text-align:center>(23v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (p2a, max_ballot) | (p2a.sender, ((p2a.slot, p2a.ballot.clone()), if<br>        p2a.ballot == max_ballot { Ok(()) } else { Err(max_ballot) }))]<br>    )<br>})</code>"]:::otherClass
-24v1["<div style=text-align:center>(24v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-25v1["<div style=text-align:center>(25v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-26v1["<div style=text-align:center>(26v1)</div> <code><br>tee()</code>"]:::otherClass
-27v1["<div style=text-align:center>(27v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
-28v1["<div style=text-align:center>(28v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-29v1["<div style=text-align:center>(29v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-30v1["<div style=text-align:center>(30v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-31v1["<div style=text-align:center>(31v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-32v1["<div style=text-align:center>(32v1)</div> <code><br>filter_map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (p2a, max_ballot) | if p2a.ballot &gt;= max_ballot { Some((p2a.slot,<br>        LogValue { ballot : p2a.ballot, value : p2a.value, })) } else { None }]<br>    )<br>})</code>"]:::otherClass
-33v1["<div style=text-align:center>(33v1)</div> <code><br>chain()</code>"]:::otherClass
-34v1["<div style=text-align:center>(34v1)</div> <code><br>map(|x| (Some(x), None))</code>"]:::otherClass
-35v1["<div style=text-align:center>(35v1)</div> <code><br>map(|watermark| (None, Some(watermark)))</code>"]:::otherClass
-36v1["<div style=text-align:center>(36v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    || (::std::collections::HashMap::new(), None),<br>    {<br>        let __reduce_keyed_fn = {<br>            crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>                [] [| prev_entry, entry | { if entry.ballot &gt; prev_entry.ballot { *<br>                prev_entry = LogValue { ballot : entry.ballot, value : entry.value,<br>                }; } }]<br>            )<br>        };<br>        move |(map, opt_curr_watermark), (opt_payload, opt_watermark)| {<br>            if let Some((k, v)) = opt_payload {<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if k &lt; curr_watermark {<br>                        return;<br>                    }<br>                }<br>                match map.entry(k) {<br>                    ::std::collections::hash_map::Entry::Vacant(e) =&gt; {<br>                        e.insert(v);<br>                    }<br>                    ::std::collections::hash_map::Entry::Occupied(mut e) =&gt; {<br>                        __reduce_keyed_fn(e.get_mut(), v);<br>                    }<br>                }<br>            } else {<br>                let watermark = opt_watermark.unwrap();<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if watermark &lt;= curr_watermark {<br>                        return;<br>                    }<br>                }<br>                map.retain(|k, _| *k &gt;= watermark);<br>                *opt_curr_watermark = Some(watermark);<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
-37v1["<div style=text-align:center>(37v1)</div> <code><br>flat_map(|(map, _curr_watermark)| map)</code>"]:::otherClass
-38v1["<div style=text-align:center>(38v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>            [] [| | HashMap::new()]<br>        )<br>    },<br>    {<br>        crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>            [] [| map, (slot, entry) | { map.insert(slot, entry); }]<br>        )<br>    },<br>)</code>"]:::otherClass
-39v1["<div style=text-align:center>(39v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-40v1["<div style=text-align:center>(40v1)</div> <code><br>identity::&lt;<br>    (<br>        core::option::Option&lt;usize&gt;,<br>        std::collections::hash_map::HashMap&lt;<br>            usize,<br>            hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>            &gt;,<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
-41v1["<div style=text-align:center>(41v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-42v1["<div style=text-align:center>(42v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::kv_replica::Replica,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;usize&gt;(&amp;b).unwrap(),<br>    )<br>})</code>"]:::otherClass
-43v1["<div style=text-align:center>(43v1)</div> <code><br>reduce_keyed::&lt;<br>    'static,<br>&gt;({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_bench_rs_LINE_COL!(<br>        [] [| curr_seq, seq | { if seq &gt; * curr_seq { * curr_seq = seq; } }]<br>    )<br>})</code>"]:::otherClass
-44v1["<div style=text-align:center>(44v1)</div> <code><br>tee()</code>"]:::otherClass
-45v1["<div style=text-align:center>(45v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| | 0usize]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| count, _ | * count += 1]<br>        )<br>    },<br>)</code>"]:::otherClass
-46v1["<div style=text-align:center>(46v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_bench_rs_LINE_COL!(<br>        [f__free = 1usize,] [move | num_received | num_received == f__free + 1]<br>    )<br>})</code>"]:::otherClass
-47v1["<div style=text-align:center>(47v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-48v1["<div style=text-align:center>(48v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-49v1["<div style=text-align:center>(49v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-50v1["<div style=text-align:center>(50v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_bench_rs_LINE_COL!(<br>        [] [| (_sender, seq) | seq]<br>    )<br>})</code>"]:::otherClass
-51v1["<div style=text-align:center>(51v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| curr, new | { if new &lt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
-52v1["<div style=text-align:center>(52v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
+15v1["<div style=text-align:center>(15v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+16v1["<div style=text-align:center>(16v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| ((ballot, max_ballot), log) | (ballot.proposer_id.clone(), (ballot<br>        .clone(), if Some(ballot) == max_ballot { Ok(log) } else { Err(max_ballot)<br>        }))]<br>    )<br>})</code>"]:::otherClass
+17v1["<div style=text-align:center>(17v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+18v1["<div style=text-align:center>(18v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+19v1["<div style=text-align:center>(19v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+20v1["<div style=text-align:center>(20v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::P2a&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>                hydro_test::__staged::cluster::paxos::Proposer,<br>            &gt;,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+21v1["<div style=text-align:center>(21v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
+22v1["<div style=text-align:center>(22v1)</div> <code><br>tee()</code>"]:::otherClass
+23v1["<div style=text-align:center>(23v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+24v1["<div style=text-align:center>(24v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (p2a, max_ballot) | (p2a.sender, ((p2a.slot, p2a.ballot.clone()), if<br>        Some(p2a.ballot) == max_ballot { Ok(()) } else { Err(max_ballot) }))]<br>    )<br>})</code>"]:::otherClass
+25v1["<div style=text-align:center>(25v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+26v1["<div style=text-align:center>(26v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+27v1["<div style=text-align:center>(27v1)</div> <code><br>tee()</code>"]:::otherClass
+28v1["<div style=text-align:center>(28v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+29v1["<div style=text-align:center>(29v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+30v1["<div style=text-align:center>(30v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+31v1["<div style=text-align:center>(31v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+32v1["<div style=text-align:center>(32v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+33v1["<div style=text-align:center>(33v1)</div> <code><br>filter_map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (p2a, max_ballot) | if Some(&amp; p2a.ballot) &gt;= max_ballot.as_ref() {<br>        Some((p2a.slot, LogValue { ballot : p2a.ballot, value : p2a.value, })) } else<br>        { None }]<br>    )<br>})</code>"]:::otherClass
+34v1["<div style=text-align:center>(34v1)</div> <code><br>chain()</code>"]:::otherClass
+35v1["<div style=text-align:center>(35v1)</div> <code><br>map(|x| (Some(x), None))</code>"]:::otherClass
+36v1["<div style=text-align:center>(36v1)</div> <code><br>map(|watermark| (None, Some(watermark)))</code>"]:::otherClass
+37v1["<div style=text-align:center>(37v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    || (::std::collections::HashMap::new(), None),<br>    {<br>        let __reduce_keyed_fn = {<br>            crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>                [] [| prev_entry, entry | { if entry.ballot &gt; prev_entry.ballot { *<br>                prev_entry = LogValue { ballot : entry.ballot, value : entry.value,<br>                }; } }]<br>            )<br>        };<br>        move |(map, opt_curr_watermark), (opt_payload, opt_watermark)| {<br>            if let Some((k, v)) = opt_payload {<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if k &lt; curr_watermark {<br>                        return;<br>                    }<br>                }<br>                match map.entry(k) {<br>                    ::std::collections::hash_map::Entry::Vacant(e) =&gt; {<br>                        e.insert(v);<br>                    }<br>                    ::std::collections::hash_map::Entry::Occupied(mut e) =&gt; {<br>                        __reduce_keyed_fn(e.get_mut(), v);<br>                    }<br>                }<br>            } else {<br>                let watermark = opt_watermark.unwrap();<br>                if let Some(curr_watermark) = *opt_curr_watermark {<br>                    if watermark &lt;= curr_watermark {<br>                        return;<br>                    }<br>                }<br>                map.retain(|k, _| *k &gt;= watermark);<br>                *opt_curr_watermark = Some(watermark);<br>            }<br>        }<br>    },<br>)</code>"]:::otherClass
+38v1["<div style=text-align:center>(38v1)</div> <code><br>flat_map(|(map, _curr_watermark)| map)</code>"]:::otherClass
+39v1["<div style=text-align:center>(39v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>            [] [| | HashMap::new()]<br>        )<br>    },<br>    {<br>        crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>            [] [| map, (slot, entry) | { map.insert(slot, entry); }]<br>        )<br>    },<br>)</code>"]:::otherClass
+40v1["<div style=text-align:center>(40v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+41v1["<div style=text-align:center>(41v1)</div> <code><br>identity::&lt;<br>    (<br>        core::option::Option&lt;usize&gt;,<br>        std::collections::hash_map::HashMap&lt;<br>            usize,<br>            hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                (<br>                    u32,<br>                    (<br>                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                        &gt;,<br>                        i32,<br>                    ),<br>                ),<br>            &gt;,<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
+42v1["<div style=text-align:center>(42v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+43v1["<div style=text-align:center>(43v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::kv_replica::Replica,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;usize&gt;(&amp;b).unwrap(),<br>    )<br>})</code>"]:::otherClass
+44v1["<div style=text-align:center>(44v1)</div> <code><br>reduce_keyed::&lt;<br>    'static,<br>&gt;({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_bench_rs_LINE_COL!(<br>        [] [| curr_seq, seq | { if seq &gt; * curr_seq { * curr_seq = seq; } }]<br>    )<br>})</code>"]:::otherClass
+45v1["<div style=text-align:center>(45v1)</div> <code><br>tee()</code>"]:::otherClass
+46v1["<div style=text-align:center>(46v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| | 0usize]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| count, _ | * count += 1]<br>        )<br>    },<br>)</code>"]:::otherClass
+47v1["<div style=text-align:center>(47v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_bench_rs_LINE_COL!(<br>        [f__free = 1usize,] [move | num_received | num_received == f__free + 1]<br>    )<br>})</code>"]:::otherClass
+48v1["<div style=text-align:center>(48v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+49v1["<div style=text-align:center>(49v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+50v1["<div style=text-align:center>(50v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+51v1["<div style=text-align:center>(51v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_bench_rs_LINE_COL!(<br>        [] [| (_sender, seq) | seq]<br>    )<br>})</code>"]:::otherClass
+52v1["<div style=text-align:center>(52v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| curr, new | { if new &lt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
+53v1["<div style=text-align:center>(53v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
 1v1-->2v1
 3v1-->4v1
 4v1-->5v1
 5v1-->6v1
 6v1-->7v1
 7v1-->8v1
-9v1-->10v1
-8v1-->|0|11v1
-10v1-->|1|11v1
-11v1-->12v1
-6v1-->|input|13v1
-12v1-->|single|13v1
-13v1-->|input|14v1
-40v1-->|single|14v1
-14v1-->15v1
-16v1-->17v1
+8v1-->9v1
+10v1-->11v1
+9v1-->|0|12v1
+11v1-->|1|12v1
+12v1-->13v1
+6v1-->|input|14v1
+13v1-->|single|14v1
+14v1-->|input|15v1
+41v1-->|single|15v1
 15v1-->16v1
-18v1-->19v1
+17v1-->18v1
+16v1-->17v1
 19v1-->20v1
 20v1-->21v1
-21v1-->|input|22v1
-12v1-->|single|22v1
-22v1-->23v1
-24v1-->25v1
+21v1-->22v1
+22v1-->|input|23v1
+13v1-->|single|23v1
 23v1-->24v1
-52v1-->26v1
-26v1-->27v1
-28v1-->29v1
-27v1-->|0|30v1
-29v1-->|1|30v1
-21v1-->|input|31v1
-12v1-->|single|31v1
-31v1-->32v1
-34v1-->|0|33v1
-32v1-->34v1
-35v1-->|1|33v1
-26v1-->35v1
-36v1-->37v1
-33v1-->36v1
+25v1-->26v1
+24v1-->25v1
+53v1-->27v1
+27v1-->28v1
+29v1-->30v1
+28v1-->|0|31v1
+30v1-->|1|31v1
+22v1-->|input|32v1
+13v1-->|single|32v1
+32v1-->33v1
+35v1-->|0|34v1
+33v1-->35v1
+36v1-->|1|34v1
+27v1-->36v1
 37v1-->38v1
-30v1-->|input|39v1
-38v1-->|single|39v1
-39v1-->40v1
-41v1-->42v1
+34v1-->37v1
+38v1-->39v1
+31v1-->|input|40v1
+39v1-->|single|40v1
+40v1-->41v1
 42v1-->43v1
 43v1-->44v1
 44v1-->45v1
 45v1-->46v1
 46v1-->47v1
-44v1-->|input|48v1
-47v1-->|single|48v1
-48v1-->49v1
+47v1-->48v1
+45v1-->|input|49v1
+48v1-->|single|49v1
 49v1-->50v1
 50v1-->51v1
 51v1-->52v1
+52v1-->53v1
 2v1
+36v1
 35v1
-34v1
-16v1
 17v1
-24v1
+18v1
 25v1
+26v1
 subgraph var_cycle_2 ["var <tt>cycle_2</tt>"]
     style var_cycle_2 fill:transparent
-    52v1
+    53v1
 end
 subgraph var_cycle_4 ["var <tt>cycle_4</tt>"]
     style var_cycle_4 fill:transparent
-    40v1
+    41v1
 end
-subgraph var_reduce_keyed_watermark_chain_524 ["var <tt>reduce_keyed_watermark_chain_524</tt>"]
-    style var_reduce_keyed_watermark_chain_524 fill:transparent
-    33v1
+subgraph var_reduce_keyed_watermark_chain_525 ["var <tt>reduce_keyed_watermark_chain_525</tt>"]
+    style var_reduce_keyed_watermark_chain_525 fill:transparent
+    34v1
 end
 subgraph var_stream_162 ["var <tt>stream_162</tt>"]
     style var_stream_162 fill:transparent
@@ -158,56 +160,56 @@ end
 subgraph var_stream_173 ["var <tt>stream_173</tt>"]
     style var_stream_173 fill:transparent
     9v1
-    10v1
 end
-subgraph var_stream_175 ["var <tt>stream_175</tt>"]
-    style var_stream_175 fill:transparent
+subgraph var_stream_174 ["var <tt>stream_174</tt>"]
+    style var_stream_174 fill:transparent
+    10v1
     11v1
 end
-subgraph var_stream_177 ["var <tt>stream_177</tt>"]
-    style var_stream_177 fill:transparent
+subgraph var_stream_176 ["var <tt>stream_176</tt>"]
+    style var_stream_176 fill:transparent
     12v1
 end
-subgraph var_stream_179 ["var <tt>stream_179</tt>"]
-    style var_stream_179 fill:transparent
+subgraph var_stream_178 ["var <tt>stream_178</tt>"]
+    style var_stream_178 fill:transparent
     13v1
 end
-subgraph var_stream_182 ["var <tt>stream_182</tt>"]
-    style var_stream_182 fill:transparent
+subgraph var_stream_180 ["var <tt>stream_180</tt>"]
+    style var_stream_180 fill:transparent
     14v1
 end
 subgraph var_stream_183 ["var <tt>stream_183</tt>"]
     style var_stream_183 fill:transparent
     15v1
 end
+subgraph var_stream_184 ["var <tt>stream_184</tt>"]
+    style var_stream_184 fill:transparent
+    16v1
+end
 subgraph var_stream_24 ["var <tt>stream_24</tt>"]
     style var_stream_24 fill:transparent
     1v1
 end
-subgraph var_stream_454 ["var <tt>stream_454</tt>"]
-    style var_stream_454 fill:transparent
-    18v1
+subgraph var_stream_455 ["var <tt>stream_455</tt>"]
+    style var_stream_455 fill:transparent
     19v1
-end
-subgraph var_stream_456 ["var <tt>stream_456</tt>"]
-    style var_stream_456 fill:transparent
     20v1
 end
-subgraph var_stream_458 ["var <tt>stream_458</tt>"]
-    style var_stream_458 fill:transparent
+subgraph var_stream_457 ["var <tt>stream_457</tt>"]
+    style var_stream_457 fill:transparent
     21v1
 end
-subgraph var_stream_461 ["var <tt>stream_461</tt>"]
-    style var_stream_461 fill:transparent
+subgraph var_stream_459 ["var <tt>stream_459</tt>"]
+    style var_stream_459 fill:transparent
     22v1
 end
 subgraph var_stream_462 ["var <tt>stream_462</tt>"]
     style var_stream_462 fill:transparent
     23v1
 end
-subgraph var_stream_509 ["var <tt>stream_509</tt>"]
-    style var_stream_509 fill:transparent
-    26v1
+subgraph var_stream_463 ["var <tt>stream_463</tt>"]
+    style var_stream_463 fill:transparent
+    24v1
 end
 subgraph var_stream_510 ["var <tt>stream_510</tt>"]
     style var_stream_510 fill:transparent
@@ -216,48 +218,48 @@ end
 subgraph var_stream_511 ["var <tt>stream_511</tt>"]
     style var_stream_511 fill:transparent
     28v1
-    29v1
 end
-subgraph var_stream_513 ["var <tt>stream_513</tt>"]
-    style var_stream_513 fill:transparent
+subgraph var_stream_512 ["var <tt>stream_512</tt>"]
+    style var_stream_512 fill:transparent
+    29v1
     30v1
 end
-subgraph var_stream_518 ["var <tt>stream_518</tt>"]
-    style var_stream_518 fill:transparent
+subgraph var_stream_514 ["var <tt>stream_514</tt>"]
+    style var_stream_514 fill:transparent
     31v1
 end
 subgraph var_stream_519 ["var <tt>stream_519</tt>"]
     style var_stream_519 fill:transparent
     32v1
 end
-subgraph var_stream_524 ["var <tt>stream_524</tt>"]
-    style var_stream_524 fill:transparent
-    36v1
-    37v1
+subgraph var_stream_520 ["var <tt>stream_520</tt>"]
+    style var_stream_520 fill:transparent
+    33v1
 end
-subgraph var_stream_528 ["var <tt>stream_528</tt>"]
-    style var_stream_528 fill:transparent
+subgraph var_stream_525 ["var <tt>stream_525</tt>"]
+    style var_stream_525 fill:transparent
+    37v1
     38v1
 end
 subgraph var_stream_529 ["var <tt>stream_529</tt>"]
     style var_stream_529 fill:transparent
     39v1
 end
-subgraph var_stream_641 ["var <tt>stream_641</tt>"]
-    style var_stream_641 fill:transparent
-    41v1
-    42v1
+subgraph var_stream_530 ["var <tt>stream_530</tt>"]
+    style var_stream_530 fill:transparent
+    40v1
 end
 subgraph var_stream_642 ["var <tt>stream_642</tt>"]
     style var_stream_642 fill:transparent
+    42v1
     43v1
 end
-subgraph var_stream_644 ["var <tt>stream_644</tt>"]
-    style var_stream_644 fill:transparent
+subgraph var_stream_643 ["var <tt>stream_643</tt>"]
+    style var_stream_643 fill:transparent
     44v1
 end
-subgraph var_stream_651 ["var <tt>stream_651</tt>"]
-    style var_stream_651 fill:transparent
+subgraph var_stream_645 ["var <tt>stream_645</tt>"]
+    style var_stream_645 fill:transparent
     45v1
 end
 subgraph var_stream_652 ["var <tt>stream_652</tt>"]
@@ -280,7 +282,11 @@ subgraph var_stream_656 ["var <tt>stream_656</tt>"]
     style var_stream_656 fill:transparent
     50v1
 end
-subgraph var_stream_658 ["var <tt>stream_658</tt>"]
-    style var_stream_658 fill:transparent
+subgraph var_stream_657 ["var <tt>stream_657</tt>"]
+    style var_stream_657 fill:transparent
     51v1
+end
+subgraph var_stream_659 ["var <tt>stream_659</tt>"]
+    style var_stream_659 fill:transparent
+    52v1
 end

--- a/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
@@ -13,443 +13,444 @@ linkStyle default stroke:#aaa
 3v1["<div style=text-align:center>(3v1)</div> <code><br>chain()</code>"]:::otherClass
 4v1["<div style=text-align:center>(4v1)</div> <code><br>chain()</code>"]:::otherClass
 5v1["<div style=text-align:center>(5v1)</div> <code><br>reduce::&lt;<br>    'static,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
-6v1["<div style=text-align:center>(6v1)</div> <code><br>source_iter([<br>    {<br>        crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>            [] [Ballot { num : 0, proposer_id : MemberId::from_raw_id(0) }]<br>        )<br>    },<br>])</code>"]:::otherClass
-7v1["<div style=text-align:center>(7v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-8v1["<div style=text-align:center>(8v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-9v1["<div style=text-align:center>(9v1)</div> <code><br>tee()</code>"]:::otherClass
-10v1["<div style=text-align:center>(10v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-11v1["<div style=text-align:center>(11v1)</div> <code><br>source_iter([<br>    {<br>        crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([] [0])<br>    },<br>])</code>"]:::otherClass
-12v1["<div style=text-align:center>(12v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-13v1["<div style=text-align:center>(13v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-14v1["<div style=text-align:center>(14v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-15v1["<div style=text-align:center>(15v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),] [move |<br>        (received_max_ballot, ballot_num) | { if received_max_ballot &gt; (Ballot { num<br>        : ballot_num, proposer_id : CLUSTER_SELF_ID__free.clone(), }) {<br>        received_max_ballot.num + 1 } else { ballot_num } }]<br>    )<br>})</code>"]:::otherClass
-16v1["<div style=text-align:center>(16v1)</div> <code><br>tee()</code>"]:::otherClass
-17v1["<div style=text-align:center>(17v1)</div> <code><br>identity::&lt;u32&gt;()</code>"]:::otherClass
-18v1["<div style=text-align:center>(18v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-19v1["<div style=text-align:center>(19v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_LINE_COL!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
-20v1["<div style=text-align:center>(20v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-21v1["<div style=text-align:center>(21v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-22v1["<div style=text-align:center>(22v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-23v1["<div style=text-align:center>(23v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),] [move | num |<br>        Ballot { num, proposer_id : CLUSTER_SELF_ID__free.clone() }]<br>    )<br>})</code>"]:::otherClass
-24v1["<div style=text-align:center>(24v1)</div> <code><br>tee()</code>"]:::otherClass
+6v1["<div style=text-align:center>(6v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+7v1["<div style=text-align:center>(7v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+8v1["<div style=text-align:center>(8v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+9v1["<div style=text-align:center>(9v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+10v1["<div style=text-align:center>(10v1)</div> <code><br>tee()</code>"]:::otherClass
+11v1["<div style=text-align:center>(11v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+12v1["<div style=text-align:center>(12v1)</div> <code><br>source_iter([<br>    {<br>        crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([] [0])<br>    },<br>])</code>"]:::otherClass
+13v1["<div style=text-align:center>(13v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+14v1["<div style=text-align:center>(14v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+15v1["<div style=text-align:center>(15v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+16v1["<div style=text-align:center>(16v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),] [move |<br>        (received_max_ballot, ballot_num) | { if let Some(received_max_ballot) =<br>        received_max_ballot &amp;&amp; (Ballot { num : ballot_num, proposer_id :<br>        CLUSTER_SELF_ID__free.clone(), }) &lt; received_max_ballot { received_max_ballot<br>        .num + 1 } else { ballot_num } }]<br>    )<br>})</code>"]:::otherClass
+17v1["<div style=text-align:center>(17v1)</div> <code><br>tee()</code>"]:::otherClass
+18v1["<div style=text-align:center>(18v1)</div> <code><br>identity::&lt;u32&gt;()</code>"]:::otherClass
+19v1["<div style=text-align:center>(19v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+20v1["<div style=text-align:center>(20v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_LINE_COL!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
+21v1["<div style=text-align:center>(21v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+22v1["<div style=text-align:center>(22v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+23v1["<div style=text-align:center>(23v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+24v1["<div style=text-align:center>(24v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),] [move | num |<br>        Ballot { num, proposer_id : CLUSTER_SELF_ID__free.clone() }]<br>    )<br>})</code>"]:::otherClass
 25v1["<div style=text-align:center>(25v1)</div> <code><br>tee()</code>"]:::otherClass
 26v1["<div style=text-align:center>(26v1)</div> <code><br>tee()</code>"]:::otherClass
-27v1["<div style=text-align:center>(27v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-28v1["<div style=text-align:center>(28v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-29v1["<div style=text-align:center>(29v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-30v1["<div style=text-align:center>(30v1)</div> <code><br>source_stream({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_LINE_COL!(<br>        [interval__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; crate<br>        ::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([i_am_leader_send_timeout__free<br>        = 5u64,] [Duration::from_secs(i_am_leader_send_timeout__free)]) },]<br>        [tokio_stream::StreamExt::map(tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(interval__free)),<br>        | _ | ())]<br>    )<br>})</code>"]:::otherClass
-31v1["<div style=text-align:center>(31v1)</div> <code><br>scan::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| | None]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [f__free = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt; (),<br>            (),<br>            hydro_test::__staged::__deps::hydro_lang::live_collections::keyed_stream::Generate<br>            &lt; () &gt; &gt; ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!([]<br>            [| _, item | Generate::Return(item)]) }), init__free =<br>            stageleft::runtime_support::fn0_type_hint:: &lt; () &gt; ({ use<br>            hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!([]<br>            [| | ()]) }),] [move | state : &amp; mut Option &lt; Option &lt; _ &gt; &gt;, v | { if<br>            state.is_none() { * state = Some(Some(init__free())); } match state {<br>            Some(Some(state_value)) =&gt; match f__free(state_value, v) {<br>            Generate::Yield(out) =&gt; Some(Some(out)), Generate::Return(out) =&gt; { *<br>            state = Some(None); Some(Some(out)) } Generate::Break =&gt; None,<br>            Generate::Continue =&gt; Some(None), }, _ =&gt; None, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-32v1["<div style=text-align:center>(32v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
-33v1["<div style=text-align:center>(33v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| _, _ | {}]<br>    )<br>})</code>"]:::otherClass
-34v1["<div style=text-align:center>(34v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
-35v1["<div style=text-align:center>(35v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
-36v1["<div style=text-align:center>(36v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-37v1["<div style=text-align:center>(37v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-38v1["<div style=text-align:center>(38v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-39v1["<div style=text-align:center>(39v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
-40v1["<div style=text-align:center>(40v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-41v1["<div style=text-align:center>(41v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-42v1["<div style=text-align:center>(42v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-43v1["<div style=text-align:center>(43v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-44v1["<div style=text-align:center>(44v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-45v1["<div style=text-align:center>(45v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-46v1["<div style=text-align:center>(46v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-47v1["<div style=text-align:center>(47v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::Ballot,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-48v1["<div style=text-align:center>(48v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
-49v1["<div style=text-align:center>(49v1)</div> <code><br>tee()</code>"]:::otherClass
-50v1["<div style=text-align:center>(50v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
-51v1["<div style=text-align:center>(51v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-52v1["<div style=text-align:center>(52v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-53v1["<div style=text-align:center>(53v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_LINE_COL!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
-54v1["<div style=text-align:center>(54v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-55v1["<div style=text-align:center>(55v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-56v1["<div style=text-align:center>(56v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-57v1["<div style=text-align:center>(57v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| | None]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| latest, _ | { * latest = Some(Instant::now()); }]<br>        )<br>    },<br>)</code>"]:::otherClass
-58v1["<div style=text-align:center>(58v1)</div> <code><br>filter_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [duration__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; crate<br>        ::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([i_am_leader_check_timeout__free<br>        = 10u64,] [Duration::from_secs(i_am_leader_check_timeout__free)]) },] [move |<br>        latest_received | { if let Some(latest_received) = latest_received { if<br>        Instant::now().duration_since(latest_received) &gt; duration__free { Some(()) }<br>        else { None } } else { Some(()) } }]<br>    )<br>})</code>"]:::otherClass
-59v1["<div style=text-align:center>(59v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| b | ! b]<br>    )<br>})</code>"]:::otherClass
-60v1["<div style=text-align:center>(60v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-61v1["<div style=text-align:center>(61v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-62v1["<div style=text-align:center>(62v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-63v1["<div style=text-align:center>(63v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
-64v1["<div style=text-align:center>(64v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
-65v1["<div style=text-align:center>(65v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-66v1["<div style=text-align:center>(66v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-67v1["<div style=text-align:center>(67v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-68v1["<div style=text-align:center>(68v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
-69v1["<div style=text-align:center>(69v1)</div> <code><br>source_stream({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_LINE_COL!(<br>        [delay__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; crate<br>        ::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([CLUSTER_SELF_ID__free<br>        = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),<br>        i_am_leader_check_timeout_delay_multiplier__free = 15usize,]<br>        [Duration::from_secs((CLUSTER_SELF_ID__free.get_raw_id() *<br>        i_am_leader_check_timeout_delay_multiplier__free as u32).into())]) },<br>        interval__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; crate<br>        ::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([i_am_leader_check_timeout__free<br>        = 10u64,] [Duration::from_secs(i_am_leader_check_timeout__free)]) },]<br>        [tokio_stream::StreamExt::map(tokio_stream::wrappers::IntervalStream::new(tokio::time::interval_at(tokio::time::Instant::now()<br>        + delay__free, interval__free,)), | _ | ())]<br>    )<br>})</code>"]:::otherClass
-70v1["<div style=text-align:center>(70v1)</div> <code><br>scan::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| | None]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [f__free = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt; (),<br>            (),<br>            hydro_test::__staged::__deps::hydro_lang::live_collections::keyed_stream::Generate<br>            &lt; () &gt; &gt; ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!([]<br>            [| _, item | Generate::Return(item)]) }), init__free =<br>            stageleft::runtime_support::fn0_type_hint:: &lt; () &gt; ({ use<br>            hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!([]<br>            [| | ()]) }),] [move | state : &amp; mut Option &lt; Option &lt; _ &gt; &gt;, v | { if<br>            state.is_none() { * state = Some(Some(init__free())); } match state {<br>            Some(Some(state_value)) =&gt; match f__free(state_value, v) {<br>            Generate::Yield(out) =&gt; Some(Some(out)), Generate::Return(out) =&gt; { *<br>            state = Some(None); Some(Some(out)) } Generate::Break =&gt; None,<br>            Generate::Continue =&gt; Some(None), }, _ =&gt; None, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-71v1["<div style=text-align:center>(71v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
-72v1["<div style=text-align:center>(72v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| _, _ | {}]<br>    )<br>})</code>"]:::otherClass
-73v1["<div style=text-align:center>(73v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
-74v1["<div style=text-align:center>(74v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
-75v1["<div style=text-align:center>(75v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-76v1["<div style=text-align:center>(76v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-77v1["<div style=text-align:center>(77v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-78v1["<div style=text-align:center>(78v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
-79v1["<div style=text-align:center>(79v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-80v1["<div style=text-align:center>(80v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| (a, b) | a &amp;&amp; b]<br>    )<br>})</code>"]:::otherClass
-81v1["<div style=text-align:center>(81v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-82v1["<div style=text-align:center>(82v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-83v1["<div style=text-align:center>(83v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-84v1["<div style=text-align:center>(84v1)</div> <code><br>inspect({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| _ | println!(&quot;Proposer leader expired, sending P1a&quot;)]<br>    )<br>})</code>"]:::otherClass
-85v1["<div style=text-align:center>(85v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-86v1["<div style=text-align:center>(86v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-87v1["<div style=text-align:center>(87v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-88v1["<div style=text-align:center>(88v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-89v1["<div style=text-align:center>(89v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                hydro_test::__staged::cluster::paxos::Ballot,<br>                core::result::Result&lt;<br>                    (<br>                        core::option::Option&lt;usize&gt;,<br>                        std::collections::hash_map::HashMap&lt;<br>                            usize,<br>                            hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                                (<br>                                    u32,<br>                                    (<br>                                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                                        &gt;,<br>                                        i32,<br>                                    ),<br>                                ),<br>                            &gt;,<br>                        &gt;,<br>                    ),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-90v1["<div style=text-align:center>(90v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
-91v1["<div style=text-align:center>(91v1)</div> <code><br>inspect({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| p1b | println!(&quot;Proposer received P1b: {:?}&quot;, p1b)]<br>    )<br>})</code>"]:::otherClass
-92v1["<div style=text-align:center>(92v1)</div> <code><br>tee()</code>"]:::otherClass
-93v1["<div style=text-align:center>(93v1)</div> <code><br>chain()</code>"]:::otherClass
-94v1["<div style=text-align:center>(94v1)</div> <code><br>tee()</code>"]:::otherClass
-95v1["<div style=text-align:center>(95v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!([] [move | | (0, 0)])<br>    },<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!(<br>            [] [move | accum, value | { if value.is_ok() { accum.0 += 1; } else {<br>            accum.1 += 1; } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-96v1["<div style=text-align:center>(96v1)</div> <code><br>tee()</code>"]:::otherClass
-97v1["<div style=text-align:center>(97v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; (usize,<br>        usize), bool &gt; ({ use hydro_std::__staged::__deps:: *; use<br>        hydro_std::__staged::quorum:: *;<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!([max__free = 3usize,] [move<br>        | (success, error) | (success + error) &gt;= max__free]) }),] [{ let orig =<br>        f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-98v1["<div style=text-align:center>(98v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-99v1["<div style=text-align:center>(99v1)</div> <code><br>tee()</code>"]:::otherClass
-100v1["<div style=text-align:center>(100v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-101v1["<div style=text-align:center>(101v1)</div> <code><br>identity::&lt;<br>    (<br>        hydro_test::__staged::cluster::paxos::Ballot,<br>        core::result::Result&lt;<br>            (<br>                core::option::Option&lt;usize&gt;,<br>                std::collections::hash_map::HashMap&lt;<br>                    usize,<br>                    hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                        (<br>                            u32,<br>                            (<br>                                hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                                    hydro_test::__staged::cluster::paxos_bench::Client,<br>                                &gt;,<br>                                i32,<br>                            ),<br>                        ),<br>                    &gt;,<br>                &gt;,<br>            ),<br>            hydro_test::__staged::cluster::paxos::Ballot,<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
-102v1["<div style=text-align:center>(102v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; (usize,<br>        usize), bool &gt; ({ use hydro_std::__staged::__deps:: *; use<br>        hydro_std::__staged::quorum:: *;<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!([min__free = 2usize,] [move<br>        | (success, _error) | success &gt;= &amp; min__free]) }),] [{ let orig = f__free;<br>        move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-103v1["<div style=text-align:center>(103v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-104v1["<div style=text-align:center>(104v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-105v1["<div style=text-align:center>(105v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
-106v1["<div style=text-align:center>(106v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; (usize,<br>        usize), bool &gt; ({ use hydro_std::__staged::__deps:: *; use<br>        hydro_std::__staged::quorum:: *;<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!([min__free = 2usize,] [move<br>        | (success, _error) | success &lt; &amp; min__free]) }),] [{ let orig = f__free;<br>        move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-107v1["<div style=text-align:center>(107v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-108v1["<div style=text-align:center>(108v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-109v1["<div style=text-align:center>(109v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-110v1["<div style=text-align:center>(110v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-111v1["<div style=text-align:center>(111v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!(<br>        [] [move | (key, res) | match res { Ok(v) =&gt; Some((key, v)), Err(_) =&gt; None,<br>        }]<br>    )<br>})</code>"]:::otherClass
-112v1["<div style=text-align:center>(112v1)</div> <code><br>scan::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>            [] [| | HashMap::new()]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>            [f__free = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt;<br>            core::option::Option &lt; std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt;,<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;),<br>            hydro_test::__staged::__deps::hydro_lang::live_collections::keyed_stream::Generate<br>            &lt; std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; &gt;<br>            ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::keyed_stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!([f__free<br>            = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt; std::vec::Vec<br>            &lt; (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt;,<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), bool<br>            &gt; ({ use crate ::__staged::__deps:: *; use crate<br>            ::__staged::cluster::paxos:: *; crate<br>            ::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([quorum_size__free<br>            = 2usize,] [move | logs, log | { logs.push(log); logs.len() &gt;=<br>            quorum_size__free }]) }),] [move | key_state, v | { if let<br>            Some(key_state_value) = key_state.as_mut() { if f__free(key_state_value,<br>            v) { Generate::Return(key_state.take().unwrap()) } else {<br>            Generate::Continue } } else { unreachable!() } }]) }), init__free =<br>            stageleft::runtime_support::fn0_type_hint:: &lt; core::option::Option &lt;<br>            std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; &gt;<br>            ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::keyed_stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!([init__free<br>            = stageleft::runtime_support::fn0_type_hint:: &lt; std::vec::Vec &lt;<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; ({<br>            *; crate ::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([] [|<br>            | vec![]]) }),] [move | | Some(init__free())]) }),] [move | acc : &amp; mut<br>            HashMap &lt; _, _ &gt;, (k, v) | { let existing_state = acc<br>            .entry(Clone::clone(&amp; k)).or_insert_with(| | Some(init__free())); if let<br>            Some(existing_state_value) = existing_state { match<br>            f__free(existing_state_value, v) { Generate::Yield(out) =&gt; Some(Some((k,<br>            out))), Generate::Return(out) =&gt; { let _ = existing_state.take();<br>            Some(Some((k, out))) } Generate::Break =&gt; { let _ = existing_state<br>            .take(); Some(None) } Generate::Continue =&gt; Some(None), } } else {<br>            Some(None) } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-113v1["<div style=text-align:center>(113v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
-114v1["<div style=text-align:center>(114v1)</div> <code><br>reduce::&lt;<br>    'static,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [move | curr, new | { if new.0 &gt; curr.0 { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
-115v1["<div style=text-align:center>(115v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-116v1["<div style=text-align:center>(116v1)</div> <code><br>filter_map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [move | ((quorum_ballot, quorum_accepted), my_ballot) | if quorum_ballot<br>        == my_ballot { Some(quorum_accepted) } else { None }]<br>    )<br>})</code>"]:::otherClass
-117v1["<div style=text-align:center>(117v1)</div> <code><br>tee()</code>"]:::otherClass
-118v1["<div style=text-align:center>(118v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
-119v1["<div style=text-align:center>(119v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
-120v1["<div style=text-align:center>(120v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-121v1["<div style=text-align:center>(121v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-122v1["<div style=text-align:center>(122v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-123v1["<div style=text-align:center>(123v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
-124v1["<div style=text-align:center>(124v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-125v1["<div style=text-align:center>(125v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (received_max_ballot, cur_ballot) | received_max_ballot &lt;= cur_ballot]<br>    )<br>})</code>"]:::otherClass
-126v1["<div style=text-align:center>(126v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-127v1["<div style=text-align:center>(127v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| (a, b) | a &amp;&amp; b]<br>    )<br>})</code>"]:::otherClass
-128v1["<div style=text-align:center>(128v1)</div> <code><br>tee()</code>"]:::otherClass
-129v1["<div style=text-align:center>(129v1)</div> <code><br>identity::&lt;bool&gt;()</code>"]:::otherClass
-130v1["<div style=text-align:center>(130v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!(<br>        [] [move | (key, res) | match res { Ok(_) =&gt; None, Err(e) =&gt; Some((key, e)),<br>        }]<br>    )<br>})</code>"]:::otherClass
-131v1["<div style=text-align:center>(131v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (_, ballot) | ballot]<br>    )<br>})</code>"]:::otherClass
-132v1["<div style=text-align:center>(132v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
-133v1["<div style=text-align:center>(133v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-134v1["<div style=text-align:center>(134v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_LINE_COL!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
-135v1["<div style=text-align:center>(135v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-136v1["<div style=text-align:center>(136v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-137v1["<div style=text-align:center>(137v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-138v1["<div style=text-align:center>(138v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| is_leader | is_leader.then_some(())]<br>    )<br>})</code>"]:::otherClass
-139v1["<div style=text-align:center>(139v1)</div> <code><br>filter_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| v | v]<br>    )<br>})</code>"]:::otherClass
-140v1["<div style=text-align:center>(140v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-141v1["<div style=text-align:center>(141v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
-142v1["<div style=text-align:center>(142v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
-143v1["<div style=text-align:center>(143v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-144v1["<div style=text-align:center>(144v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-145v1["<div style=text-align:center>(145v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-146v1["<div style=text-align:center>(146v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| o | o.is_none()]<br>    )<br>})</code>"]:::otherClass
-147v1["<div style=text-align:center>(147v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-148v1["<div style=text-align:center>(148v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| (a, b) | a &amp;&amp; b]<br>    )<br>})</code>"]:::otherClass
-149v1["<div style=text-align:center>(149v1)</div> <code><br>tee()</code>"]:::otherClass
-150v1["<div style=text-align:center>(150v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-151v1["<div style=text-align:center>(151v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-152v1["<div style=text-align:center>(152v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-153v1["<div style=text-align:center>(153v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-154v1["<div style=text-align:center>(154v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-155v1["<div style=text-align:center>(155v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-156v1["<div style=text-align:center>(156v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-157v1["<div style=text-align:center>(157v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos_bench::Client,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-158v1["<div style=text-align:center>(158v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
-159v1["<div style=text-align:center>(159v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-160v1["<div style=text-align:center>(160v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-161v1["<div style=text-align:center>(161v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-162v1["<div style=text-align:center>(162v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
-163v1["<div style=text-align:center>(163v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | v]<br>    )<br>})</code>"]:::otherClass
-164v1["<div style=text-align:center>(164v1)</div> <code><br>tee()</code>"]:::otherClass
-165v1["<div style=text-align:center>(165v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (_checkpoint, log) | log]<br>    )<br>})</code>"]:::otherClass
-166v1["<div style=text-align:center>(166v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
-167v1["<div style=text-align:center>(167v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>            [] [| | (0, None)]<br>        )<br>    },<br>    {<br>        crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>            [] [| curr_entry, new_entry | { if let Some(curr_entry_payload) = &amp; mut<br>            curr_entry.1 { let same_values = new_entry.value == curr_entry_payload<br>            .value; let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>            if same_values { curr_entry.0 += 1; } if higher_ballot {<br>            curr_entry_payload.ballot = new_entry.ballot; if ! same_values {<br>            curr_entry.0 = 1; curr_entry_payload.value = new_entry.value; } } } else<br>            { * curr_entry = (1, Some(new_entry)); } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-168v1["<div style=text-align:center>(168v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_type_hint:: &lt; (usize,<br>        core::option::Option &lt; hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), (usize,<br>        hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt;) &gt; ({ use crate<br>        ::__staged::__deps:: *; use crate ::__staged::cluster::paxos:: *; crate<br>        ::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([] [| (count,<br>        entry) | (count, entry.unwrap())]) }),] [{ let orig = f__free; move | (k, v)<br>        | (k, orig(v)) }]<br>    )<br>})</code>"]:::otherClass
-169v1["<div style=text-align:center>(169v1)</div> <code><br>tee()</code>"]:::otherClass
-170v1["<div style=text-align:center>(170v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-171v1["<div style=text-align:center>(171v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
-172v1["<div style=text-align:center>(172v1)</div> <code><br>tee()</code>"]:::otherClass
-173v1["<div style=text-align:center>(173v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([] [| s | s + 1])<br>})</code>"]:::otherClass
-174v1["<div style=text-align:center>(174v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-175v1["<div style=text-align:center>(175v1)</div> <code><br>source_iter([<br>    {<br>        crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([] [0])<br>    },<br>])</code>"]:::otherClass
-176v1["<div style=text-align:center>(176v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-177v1["<div style=text-align:center>(177v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+27v1["<div style=text-align:center>(27v1)</div> <code><br>tee()</code>"]:::otherClass
+28v1["<div style=text-align:center>(28v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+29v1["<div style=text-align:center>(29v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+30v1["<div style=text-align:center>(30v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+31v1["<div style=text-align:center>(31v1)</div> <code><br>source_stream({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_LINE_COL!(<br>        [interval__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; crate<br>        ::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([i_am_leader_send_timeout__free<br>        = 5u64,] [Duration::from_secs(i_am_leader_send_timeout__free)]) },]<br>        [tokio_stream::StreamExt::map(tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(interval__free)),<br>        | _ | ())]<br>    )<br>})</code>"]:::otherClass
+32v1["<div style=text-align:center>(32v1)</div> <code><br>scan::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| | None]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [f__free = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt; (),<br>            (),<br>            hydro_test::__staged::__deps::hydro_lang::live_collections::keyed_stream::Generate<br>            &lt; () &gt; &gt; ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!([]<br>            [| _, item | Generate::Return(item)]) }), init__free =<br>            stageleft::runtime_support::fn0_type_hint:: &lt; () &gt; ({ use<br>            hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!([]<br>            [| | ()]) }),] [move | state : &amp; mut Option &lt; Option &lt; _ &gt; &gt;, v | { if<br>            state.is_none() { * state = Some(Some(init__free())); } match state {<br>            Some(Some(state_value)) =&gt; match f__free(state_value, v) {<br>            Generate::Yield(out) =&gt; Some(Some(out)), Generate::Return(out) =&gt; { *<br>            state = Some(None); Some(Some(out)) } Generate::Break =&gt; None,<br>            Generate::Continue =&gt; Some(None), }, _ =&gt; None, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+33v1["<div style=text-align:center>(33v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
+34v1["<div style=text-align:center>(34v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| _, _ | {}]<br>    )<br>})</code>"]:::otherClass
+35v1["<div style=text-align:center>(35v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
+36v1["<div style=text-align:center>(36v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+37v1["<div style=text-align:center>(37v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+38v1["<div style=text-align:center>(38v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+39v1["<div style=text-align:center>(39v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+40v1["<div style=text-align:center>(40v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
+41v1["<div style=text-align:center>(41v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+42v1["<div style=text-align:center>(42v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+43v1["<div style=text-align:center>(43v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+44v1["<div style=text-align:center>(44v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+45v1["<div style=text-align:center>(45v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+46v1["<div style=text-align:center>(46v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+47v1["<div style=text-align:center>(47v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+48v1["<div style=text-align:center>(48v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Proposer,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            hydro_test::__staged::cluster::paxos::Ballot,<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+49v1["<div style=text-align:center>(49v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
+50v1["<div style=text-align:center>(50v1)</div> <code><br>tee()</code>"]:::otherClass
+51v1["<div style=text-align:center>(51v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
+52v1["<div style=text-align:center>(52v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+53v1["<div style=text-align:center>(53v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+54v1["<div style=text-align:center>(54v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_LINE_COL!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
+55v1["<div style=text-align:center>(55v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+56v1["<div style=text-align:center>(56v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+57v1["<div style=text-align:center>(57v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+58v1["<div style=text-align:center>(58v1)</div> <code><br>fold::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| | None]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| latest, _ | { * latest = Some(Instant::now()); }]<br>        )<br>    },<br>)</code>"]:::otherClass
+59v1["<div style=text-align:center>(59v1)</div> <code><br>filter_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [duration__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; crate<br>        ::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([i_am_leader_check_timeout__free<br>        = 10u64,] [Duration::from_secs(i_am_leader_check_timeout__free)]) },] [move |<br>        latest_received | { if let Some(latest_received) = latest_received { if<br>        Instant::now().duration_since(latest_received) &gt; duration__free { Some(()) }<br>        else { None } } else { Some(()) } }]<br>    )<br>})</code>"]:::otherClass
+60v1["<div style=text-align:center>(60v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| b | ! b]<br>    )<br>})</code>"]:::otherClass
+61v1["<div style=text-align:center>(61v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+62v1["<div style=text-align:center>(62v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+63v1["<div style=text-align:center>(63v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+64v1["<div style=text-align:center>(64v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
+65v1["<div style=text-align:center>(65v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+66v1["<div style=text-align:center>(66v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+67v1["<div style=text-align:center>(67v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+68v1["<div style=text-align:center>(68v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+69v1["<div style=text-align:center>(69v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
+70v1["<div style=text-align:center>(70v1)</div> <code><br>source_stream({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_LINE_COL!(<br>        [delay__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; crate<br>        ::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([CLUSTER_SELF_ID__free<br>        = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),<br>        i_am_leader_check_timeout_delay_multiplier__free = 15usize,]<br>        [Duration::from_secs((CLUSTER_SELF_ID__free.get_raw_id() *<br>        i_am_leader_check_timeout_delay_multiplier__free as u32).into())]) },<br>        interval__free = { use crate ::__staged::__deps:: *; use crate<br>        ::__staged::cluster::paxos:: *; crate<br>        ::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([i_am_leader_check_timeout__free<br>        = 10u64,] [Duration::from_secs(i_am_leader_check_timeout__free)]) },]<br>        [tokio_stream::StreamExt::map(tokio_stream::wrappers::IntervalStream::new(tokio::time::interval_at(tokio::time::Instant::now()<br>        + delay__free, interval__free,)), | _ | ())]<br>    )<br>})</code>"]:::otherClass
+71v1["<div style=text-align:center>(71v1)</div> <code><br>scan::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| | None]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [f__free = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt; (),<br>            (),<br>            hydro_test::__staged::__deps::hydro_lang::live_collections::keyed_stream::Generate<br>            &lt; () &gt; &gt; ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!([]<br>            [| _, item | Generate::Return(item)]) }), init__free =<br>            stageleft::runtime_support::fn0_type_hint:: &lt; () &gt; ({ use<br>            hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!([]<br>            [| | ()]) }),] [move | state : &amp; mut Option &lt; Option &lt; _ &gt; &gt;, v | { if<br>            state.is_none() { * state = Some(Some(init__free())); } match state {<br>            Some(Some(state_value)) =&gt; match f__free(state_value, v) {<br>            Generate::Yield(out) =&gt; Some(Some(out)), Generate::Return(out) =&gt; { *<br>            state = Some(None); Some(Some(out)) } Generate::Break =&gt; None,<br>            Generate::Continue =&gt; Some(None), }, _ =&gt; None, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+72v1["<div style=text-align:center>(72v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
+73v1["<div style=text-align:center>(73v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| _, _ | {}]<br>    )<br>})</code>"]:::otherClass
+74v1["<div style=text-align:center>(74v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
+75v1["<div style=text-align:center>(75v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+76v1["<div style=text-align:center>(76v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+77v1["<div style=text-align:center>(77v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+78v1["<div style=text-align:center>(78v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+79v1["<div style=text-align:center>(79v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
+80v1["<div style=text-align:center>(80v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+81v1["<div style=text-align:center>(81v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| (a, b) | a &amp;&amp; b]<br>    )<br>})</code>"]:::otherClass
+82v1["<div style=text-align:center>(82v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+83v1["<div style=text-align:center>(83v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+84v1["<div style=text-align:center>(84v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+85v1["<div style=text-align:center>(85v1)</div> <code><br>inspect({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| _ | println!(&quot;Proposer leader expired, sending P1a&quot;)]<br>    )<br>})</code>"]:::otherClass
+86v1["<div style=text-align:center>(86v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+87v1["<div style=text-align:center>(87v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+88v1["<div style=text-align:center>(88v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+89v1["<div style=text-align:center>(89v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+90v1["<div style=text-align:center>(90v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                hydro_test::__staged::cluster::paxos::Ballot,<br>                core::result::Result&lt;<br>                    (<br>                        core::option::Option&lt;usize&gt;,<br>                        std::collections::hash_map::HashMap&lt;<br>                            usize,<br>                            hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                                (<br>                                    u32,<br>                                    (<br>                                        hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                                            hydro_test::__staged::cluster::paxos_bench::Client,<br>                                        &gt;,<br>                                        i32,<br>                                    ),<br>                                ),<br>                            &gt;,<br>                        &gt;,<br>                    ),<br>                    core::option::Option&lt;<br>                        hydro_test::__staged::cluster::paxos::Ballot,<br>                    &gt;,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+91v1["<div style=text-align:center>(91v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
+92v1["<div style=text-align:center>(92v1)</div> <code><br>inspect({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| p1b | println!(&quot;Proposer received P1b: {:?}&quot;, p1b)]<br>    )<br>})</code>"]:::otherClass
+93v1["<div style=text-align:center>(93v1)</div> <code><br>tee()</code>"]:::otherClass
+94v1["<div style=text-align:center>(94v1)</div> <code><br>chain()</code>"]:::otherClass
+95v1["<div style=text-align:center>(95v1)</div> <code><br>tee()</code>"]:::otherClass
+96v1["<div style=text-align:center>(96v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!([] [move | | (0, 0)])<br>    },<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!(<br>            [] [move | accum, value | { if value.is_ok() { accum.0 += 1; } else {<br>            accum.1 += 1; } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+97v1["<div style=text-align:center>(97v1)</div> <code><br>tee()</code>"]:::otherClass
+98v1["<div style=text-align:center>(98v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; (usize,<br>        usize), bool &gt; ({ use hydro_std::__staged::__deps:: *; use<br>        hydro_std::__staged::quorum:: *;<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!([max__free = 3usize,] [move<br>        | (success, error) | (success + error) &gt;= max__free]) }),] [{ let orig =<br>        f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+99v1["<div style=text-align:center>(99v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+100v1["<div style=text-align:center>(100v1)</div> <code><br>tee()</code>"]:::otherClass
+101v1["<div style=text-align:center>(101v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+102v1["<div style=text-align:center>(102v1)</div> <code><br>identity::&lt;<br>    (<br>        hydro_test::__staged::cluster::paxos::Ballot,<br>        core::result::Result&lt;<br>            (<br>                core::option::Option&lt;usize&gt;,<br>                std::collections::hash_map::HashMap&lt;<br>                    usize,<br>                    hydro_test::__staged::cluster::paxos::LogValue&lt;<br>                        (<br>                            u32,<br>                            (<br>                                hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                                    hydro_test::__staged::cluster::paxos_bench::Client,<br>                                &gt;,<br>                                i32,<br>                            ),<br>                        ),<br>                    &gt;,<br>                &gt;,<br>            ),<br>            core::option::Option&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;,<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
+103v1["<div style=text-align:center>(103v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; (usize,<br>        usize), bool &gt; ({ use hydro_std::__staged::__deps:: *; use<br>        hydro_std::__staged::quorum:: *;<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!([min__free = 2usize,] [move<br>        | (success, _error) | success &gt;= &amp; min__free]) }),] [{ let orig = f__free;<br>        move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+104v1["<div style=text-align:center>(104v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+105v1["<div style=text-align:center>(105v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+106v1["<div style=text-align:center>(106v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
+107v1["<div style=text-align:center>(107v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; (usize,<br>        usize), bool &gt; ({ use hydro_std::__staged::__deps:: *; use<br>        hydro_std::__staged::quorum:: *;<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!([min__free = 2usize,] [move<br>        | (success, _error) | success &lt; &amp; min__free]) }),] [{ let orig = f__free;<br>        move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+108v1["<div style=text-align:center>(108v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+109v1["<div style=text-align:center>(109v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+110v1["<div style=text-align:center>(110v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+111v1["<div style=text-align:center>(111v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+112v1["<div style=text-align:center>(112v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!(<br>        [] [move | (key, res) | match res { Ok(v) =&gt; Some((key, v)), Err(_) =&gt; None,<br>        }]<br>    )<br>})</code>"]:::otherClass
+113v1["<div style=text-align:center>(113v1)</div> <code><br>scan::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>            [] [| | HashMap::new()]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>            [f__free = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt;<br>            core::option::Option &lt; std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt;,<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;),<br>            hydro_test::__staged::__deps::hydro_lang::live_collections::keyed_stream::Generate<br>            &lt; std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; &gt;<br>            ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::keyed_stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!([f__free<br>            = stageleft::runtime_support::fn2_borrow_mut_type_hint:: &lt; std::vec::Vec<br>            &lt; (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt;,<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), bool<br>            &gt; ({ use crate ::__staged::__deps:: *; use crate<br>            ::__staged::cluster::paxos:: *; crate<br>            ::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([quorum_size__free<br>            = 2usize,] [move | logs, log | { logs.push(log); logs.len() &gt;=<br>            quorum_size__free }]) }),] [move | key_state, v | { if let<br>            Some(key_state_value) = key_state.as_mut() { if f__free(key_state_value,<br>            v) { Generate::Return(key_state.take().unwrap()) } else {<br>            Generate::Continue } } else { unreachable!() } }]) }), init__free =<br>            stageleft::runtime_support::fn0_type_hint:: &lt; core::option::Option &lt;<br>            std::vec::Vec &lt; (core::option::Option &lt; usize &gt;,<br>            std::collections::hash_map::HashMap &lt; usize,<br>            hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; &gt;<br>            ({ use hydro_lang::__staged::__deps:: *; use<br>            hydro_lang::__staged::live_collections::keyed_stream:: *;<br>            hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!([init__free<br>            = stageleft::runtime_support::fn0_type_hint:: &lt; std::vec::Vec &lt;<br>            (core::option::Option &lt; usize &gt;, std::collections::hash_map::HashMap &lt;<br>            usize, hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>            (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId<br>            &lt; hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;) &gt; &gt; ({<br>            *; crate ::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([] [|<br>            | vec![]]) }),] [move | | Some(init__free())]) }),] [move | acc : &amp; mut<br>            HashMap &lt; _, _ &gt;, (k, v) | { let existing_state = acc<br>            .entry(Clone::clone(&amp; k)).or_insert_with(| | Some(init__free())); if let<br>            Some(existing_state_value) = existing_state { match<br>            f__free(existing_state_value, v) { Generate::Yield(out) =&gt; Some(Some((k,<br>            out))), Generate::Return(out) =&gt; { let _ = existing_state.take();<br>            Some(Some((k, out))) } Generate::Break =&gt; { let _ = existing_state<br>            .take(); Some(None) } Generate::Continue =&gt; Some(None), } } else {<br>            Some(None) } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+114v1["<div style=text-align:center>(114v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
+115v1["<div style=text-align:center>(115v1)</div> <code><br>reduce::&lt;<br>    'static,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [move | curr, new | { if new.0 &gt; curr.0 { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
+116v1["<div style=text-align:center>(116v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+117v1["<div style=text-align:center>(117v1)</div> <code><br>filter_map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [move | ((quorum_ballot, quorum_accepted), my_ballot) | if quorum_ballot<br>        == my_ballot { Some(quorum_accepted) } else { None }]<br>    )<br>})</code>"]:::otherClass
+118v1["<div style=text-align:center>(118v1)</div> <code><br>tee()</code>"]:::otherClass
+119v1["<div style=text-align:center>(119v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
+120v1["<div style=text-align:center>(120v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+121v1["<div style=text-align:center>(121v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+122v1["<div style=text-align:center>(122v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+123v1["<div style=text-align:center>(123v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+124v1["<div style=text-align:center>(124v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| o | o.is_some()]<br>    )<br>})</code>"]:::otherClass
+125v1["<div style=text-align:center>(125v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+126v1["<div style=text-align:center>(126v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (received_max_ballot, cur_ballot) | received_max_ballot &lt;=<br>        Some(cur_ballot)]<br>    )<br>})</code>"]:::otherClass
+127v1["<div style=text-align:center>(127v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+128v1["<div style=text-align:center>(128v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| (a, b) | a &amp;&amp; b]<br>    )<br>})</code>"]:::otherClass
+129v1["<div style=text-align:center>(129v1)</div> <code><br>tee()</code>"]:::otherClass
+130v1["<div style=text-align:center>(130v1)</div> <code><br>identity::&lt;bool&gt;()</code>"]:::otherClass
+131v1["<div style=text-align:center>(131v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!(<br>        [] [move | (key, res) | match res { Ok(_) =&gt; None, Err(e) =&gt; Some((key, e)),<br>        }]<br>    )<br>})</code>"]:::otherClass
+132v1["<div style=text-align:center>(132v1)</div> <code><br>flat_map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (_, ballot) | ballot]<br>    )<br>})</code>"]:::otherClass
+133v1["<div style=text-align:center>(133v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
+134v1["<div style=text-align:center>(134v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+135v1["<div style=text-align:center>(135v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_LINE_COL!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
+136v1["<div style=text-align:center>(136v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+137v1["<div style=text-align:center>(137v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+138v1["<div style=text-align:center>(138v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+139v1["<div style=text-align:center>(139v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| is_leader | is_leader.then_some(())]<br>    )<br>})</code>"]:::otherClass
+140v1["<div style=text-align:center>(140v1)</div> <code><br>filter_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| v | v]<br>    )<br>})</code>"]:::otherClass
+141v1["<div style=text-align:center>(141v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+142v1["<div style=text-align:center>(142v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| _ | ()]<br>    )<br>})</code>"]:::otherClass
+143v1["<div style=text-align:center>(143v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+144v1["<div style=text-align:center>(144v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+145v1["<div style=text-align:center>(145v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+146v1["<div style=text-align:center>(146v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+147v1["<div style=text-align:center>(147v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| o | o.is_none()]<br>    )<br>})</code>"]:::otherClass
+148v1["<div style=text-align:center>(148v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+149v1["<div style=text-align:center>(149v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| (a, b) | a &amp;&amp; b]<br>    )<br>})</code>"]:::otherClass
+150v1["<div style=text-align:center>(150v1)</div> <code><br>tee()</code>"]:::otherClass
+151v1["<div style=text-align:center>(151v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+152v1["<div style=text-align:center>(152v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+153v1["<div style=text-align:center>(153v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+154v1["<div style=text-align:center>(154v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+155v1["<div style=text-align:center>(155v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+156v1["<div style=text-align:center>(156v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+157v1["<div style=text-align:center>(157v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+158v1["<div style=text-align:center>(158v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos_bench::Client,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+159v1["<div style=text-align:center>(159v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
+160v1["<div style=text-align:center>(160v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+161v1["<div style=text-align:center>(161v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+162v1["<div style=text-align:center>(162v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+163v1["<div style=text-align:center>(163v1)</div> <code><br>enumerate::&lt;'tick&gt;()</code>"]:::otherClass
+164v1["<div style=text-align:center>(164v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | v]<br>    )<br>})</code>"]:::otherClass
+165v1["<div style=text-align:center>(165v1)</div> <code><br>tee()</code>"]:::otherClass
+166v1["<div style=text-align:center>(166v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (_checkpoint, log) | log]<br>    )<br>})</code>"]:::otherClass
+167v1["<div style=text-align:center>(167v1)</div> <code><br>flat_map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| d | d]<br>    )<br>})</code>"]:::otherClass
+168v1["<div style=text-align:center>(168v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>            [] [| | (0, None)]<br>        )<br>    },<br>    {<br>        crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>            [] [| curr_entry, new_entry | { if let Some(curr_entry_payload) = &amp; mut<br>            curr_entry.1 { let same_values = new_entry.value == curr_entry_payload<br>            .value; let higher_ballot = new_entry.ballot &gt; curr_entry_payload.ballot;<br>            if same_values { curr_entry.0 += 1; } if higher_ballot {<br>            curr_entry_payload.ballot = new_entry.ballot; if ! same_values {<br>            curr_entry.0 = 1; curr_entry_payload.value = new_entry.value; } } } else<br>            { * curr_entry = (1, Some(new_entry)); } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+169v1["<div style=text-align:center>(169v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_type_hint:: &lt; (usize,<br>        core::option::Option &lt; hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt; &gt;), (usize,<br>        hydro_test::__staged::cluster::paxos::LogValue &lt; (u32,<br>        (hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId &lt;<br>        hydro_test::__staged::cluster::paxos_bench::Client &gt;, i32)) &gt;) &gt; ({ use crate<br>        ::__staged::__deps:: *; use crate ::__staged::cluster::paxos:: *; crate<br>        ::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([] [| (count,<br>        entry) | (count, entry.unwrap())]) }),] [{ let orig = f__free; move | (k, v)<br>        | (k, orig(v)) }]<br>    )<br>})</code>"]:::otherClass
+170v1["<div style=text-align:center>(170v1)</div> <code><br>tee()</code>"]:::otherClass
+171v1["<div style=text-align:center>(171v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+172v1["<div style=text-align:center>(172v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
+173v1["<div style=text-align:center>(173v1)</div> <code><br>tee()</code>"]:::otherClass
+174v1["<div style=text-align:center>(174v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([] [| s | s + 1])<br>})</code>"]:::otherClass
+175v1["<div style=text-align:center>(175v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+176v1["<div style=text-align:center>(176v1)</div> <code><br>source_iter([<br>    {<br>        crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!([] [0])<br>    },<br>])</code>"]:::otherClass
+177v1["<div style=text-align:center>(177v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
 178v1["<div style=text-align:center>(178v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-179v1["<div style=text-align:center>(179v1)</div> <code><br>tee()</code>"]:::otherClass
-180v1["<div style=text-align:center>(180v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-181v1["<div style=text-align:center>(181v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| ((index, payload), base_slot) | (base_slot + index, payload)]<br>    )<br>})</code>"]:::otherClass
-182v1["<div style=text-align:center>(182v1)</div> <code><br>tee()</code>"]:::otherClass
-183v1["<div style=text-align:center>(183v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| | 0usize]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| count, _ | * count += 1]<br>        )<br>    },<br>)</code>"]:::otherClass
-184v1["<div style=text-align:center>(184v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-185v1["<div style=text-align:center>(185v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (num_payloads, base_slot) | base_slot + num_payloads]<br>    )<br>})</code>"]:::otherClass
-186v1["<div style=text-align:center>(186v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
-187v1["<div style=text-align:center>(187v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-188v1["<div style=text-align:center>(188v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-189v1["<div style=text-align:center>(189v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_LINE_COL!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
-190v1["<div style=text-align:center>(190v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-191v1["<div style=text-align:center>(191v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-192v1["<div style=text-align:center>(192v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-193v1["<div style=text-align:center>(193v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-194v1["<div style=text-align:center>(194v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| ((slot, payload), ballot) | ((slot, ballot), Some(payload))]<br>    )<br>})</code>"]:::otherClass
-195v1["<div style=text-align:center>(195v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-196v1["<div style=text-align:center>(196v1)</div> <code><br>filter_map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (checkpoint, _log) | checkpoint]<br>    )<br>})</code>"]:::otherClass
-197v1["<div style=text-align:center>(197v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
-198v1["<div style=text-align:center>(198v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
-199v1["<div style=text-align:center>(199v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
-200v1["<div style=text-align:center>(200v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
-201v1["<div style=text-align:center>(201v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
-202v1["<div style=text-align:center>(202v1)</div> <code><br>tee()</code>"]:::otherClass
-203v1["<div style=text-align:center>(203v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-204v1["<div style=text-align:center>(204v1)</div> <code><br>filter_map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [f__free = 1usize,] [move | (((slot, (count, entry)), ballot), checkpoint) |<br>        { if count &gt; f__free { return None; } else if let Some(checkpoint) =<br>        checkpoint &amp;&amp; slot &lt;= checkpoint { return None; } Some(((slot, ballot), entry<br>        .value)) }]<br>    )<br>})</code>"]:::otherClass
-205v1["<div style=text-align:center>(205v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-206v1["<div style=text-align:center>(206v1)</div> <code><br>flat_map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (max_slot, checkpoint) | { if let Some(checkpoint) = checkpoint {<br>        (checkpoint + 1)..max_slot } else { 0..max_slot } }]<br>    )<br>})</code>"]:::otherClass
-207v1["<div style=text-align:center>(207v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-208v1["<div style=text-align:center>(208v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-209v1["<div style=text-align:center>(209v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-210v1["<div style=text-align:center>(210v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [move | (slot, ballot) | ((slot, ballot), None)]<br>    )<br>})</code>"]:::otherClass
-211v1["<div style=text-align:center>(211v1)</div> <code><br>chain()</code>"]:::otherClass
+179v1["<div style=text-align:center>(179v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+180v1["<div style=text-align:center>(180v1)</div> <code><br>tee()</code>"]:::otherClass
+181v1["<div style=text-align:center>(181v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+182v1["<div style=text-align:center>(182v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| ((index, payload), base_slot) | (base_slot + index, payload)]<br>    )<br>})</code>"]:::otherClass
+183v1["<div style=text-align:center>(183v1)</div> <code><br>tee()</code>"]:::otherClass
+184v1["<div style=text-align:center>(184v1)</div> <code><br>fold::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| | 0usize]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>            [] [| count, _ | * count += 1]<br>        )<br>    },<br>)</code>"]:::otherClass
+185v1["<div style=text-align:center>(185v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+186v1["<div style=text-align:center>(186v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (num_payloads, base_slot) | base_slot + num_payloads]<br>    )<br>})</code>"]:::otherClass
+187v1["<div style=text-align:center>(187v1)</div> <code><br>identity::&lt;usize&gt;()</code>"]:::otherClass
+188v1["<div style=text-align:center>(188v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+189v1["<div style=text-align:center>(189v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+190v1["<div style=text-align:center>(190v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_LINE_COL!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
+191v1["<div style=text-align:center>(191v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+192v1["<div style=text-align:center>(192v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+193v1["<div style=text-align:center>(193v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+194v1["<div style=text-align:center>(194v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+195v1["<div style=text-align:center>(195v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| ((slot, payload), ballot) | ((slot, ballot), Some(payload))]<br>    )<br>})</code>"]:::otherClass
+196v1["<div style=text-align:center>(196v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+197v1["<div style=text-align:center>(197v1)</div> <code><br>filter_map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (checkpoint, _log) | checkpoint]<br>    )<br>})</code>"]:::otherClass
+198v1["<div style=text-align:center>(198v1)</div> <code><br>reduce::&lt;<br>    'tick,<br>&gt;({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| curr, new | { if new &gt; * curr { * curr = new; } }]<br>    )<br>})</code>"]:::otherClass
+199v1["<div style=text-align:center>(199v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_optional_rs_LINE_COL!(<br>        [] [| v | Some(v)]<br>    )<br>})</code>"]:::otherClass
+200v1["<div style=text-align:center>(200v1)</div> <code><br>source_iter([::std::option::Option::None])</code>"]:::otherClass
+201v1["<div style=text-align:center>(201v1)</div> <code><br>persist::&lt;'static&gt;()</code>"]:::otherClass
+202v1["<div style=text-align:center>(202v1)</div> <code><br>chain_first_n(1)</code>"]:::otherClass
+203v1["<div style=text-align:center>(203v1)</div> <code><br>tee()</code>"]:::otherClass
+204v1["<div style=text-align:center>(204v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+205v1["<div style=text-align:center>(205v1)</div> <code><br>filter_map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [f__free = 1usize,] [move | (((slot, (count, entry)), ballot), checkpoint) |<br>        { if count &gt; f__free { return None; } else if let Some(checkpoint) =<br>        checkpoint &amp;&amp; slot &lt;= checkpoint { return None; } Some(((slot, ballot), entry<br>        .value)) }]<br>    )<br>})</code>"]:::otherClass
+206v1["<div style=text-align:center>(206v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+207v1["<div style=text-align:center>(207v1)</div> <code><br>flat_map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (max_slot, checkpoint) | { if let Some(checkpoint) = checkpoint {<br>        (checkpoint + 1)..max_slot } else { 0..max_slot } }]<br>    )<br>})</code>"]:::otherClass
+208v1["<div style=text-align:center>(208v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+209v1["<div style=text-align:center>(209v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+210v1["<div style=text-align:center>(210v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+211v1["<div style=text-align:center>(211v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [move | (slot, ballot) | ((slot, ballot), None)]<br>    )<br>})</code>"]:::otherClass
 212v1["<div style=text-align:center>(212v1)</div> <code><br>chain()</code>"]:::otherClass
-213v1["<div style=text-align:center>(213v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-214v1["<div style=text-align:center>(214v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-215v1["<div style=text-align:center>(215v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-216v1["<div style=text-align:center>(216v1)</div> <code><br>tee()</code>"]:::otherClass
-217v1["<div style=text-align:center>(217v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),] [move |<br>        ((slot, ballot), value) | P2a { sender : CLUSTER_SELF_ID__free.clone(),<br>        ballot, slot, value }]<br>    )<br>})</code>"]:::otherClass
-218v1["<div style=text-align:center>(218v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-219v1["<div style=text-align:center>(219v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-220v1["<div style=text-align:center>(220v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
-221v1["<div style=text-align:center>(221v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
-222v1["<div style=text-align:center>(222v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>                core::result::Result&lt;<br>                    (),<br>                    hydro_test::__staged::cluster::paxos::Ballot,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
-223v1["<div style=text-align:center>(223v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
-224v1["<div style=text-align:center>(224v1)</div> <code><br>tee()</code>"]:::otherClass
-225v1["<div style=text-align:center>(225v1)</div> <code><br>chain()</code>"]:::otherClass
-226v1["<div style=text-align:center>(226v1)</div> <code><br>tee()</code>"]:::otherClass
-227v1["<div style=text-align:center>(227v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!([] [move | | (0, 0)])<br>    },<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!(<br>            [] [move | accum, value | { if value.is_ok() { accum.0 += 1; } else {<br>            accum.1 += 1; } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-228v1["<div style=text-align:center>(228v1)</div> <code><br>tee()</code>"]:::otherClass
-229v1["<div style=text-align:center>(229v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; (usize,<br>        usize), bool &gt; ({ use hydro_std::__staged::__deps:: *; use<br>        hydro_std::__staged::quorum:: *;<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!([max__free = 3usize,]<br>        [move | (success, error) | (success + error) &gt;= max__free]) }),] [{ let orig<br>        = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-230v1["<div style=text-align:center>(230v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-231v1["<div style=text-align:center>(231v1)</div> <code><br>tee()</code>"]:::otherClass
-232v1["<div style=text-align:center>(232v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-233v1["<div style=text-align:center>(233v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::result::Result&lt;(), hydro_test::__staged::cluster::paxos::Ballot&gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
-234v1["<div style=text-align:center>(234v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!(<br>        [min__free = 2usize,] [move | (key, (success, _error)) | if success &gt;=<br>        min__free { Some(key) } else { None }]<br>    )<br>})</code>"]:::otherClass
-235v1["<div style=text-align:center>(235v1)</div> <code><br>tee()</code>"]:::otherClass
-236v1["<div style=text-align:center>(236v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-237v1["<div style=text-align:center>(237v1)</div> <code><br>identity::&lt;(usize, hydro_test::__staged::cluster::paxos::Ballot)&gt;()</code>"]:::otherClass
-238v1["<div style=text-align:center>(238v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-239v1["<div style=text-align:center>(239v1)</div> <code><br>chain()</code>"]:::otherClass
-240v1["<div style=text-align:center>(240v1)</div> <code><br>tee()</code>"]:::otherClass
-241v1["<div style=text-align:center>(241v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
-242v1["<div style=text-align:center>(242v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-243v1["<div style=text-align:center>(243v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| k | (k, ())]<br>    )<br>})</code>"]:::otherClass
-244v1["<div style=text-align:center>(244v1)</div> <code><br>tee()</code>"]:::otherClass
-245v1["<div style=text-align:center>(245v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_LINE_COL!(<br>        [] [| (key, _) | key]<br>    )<br>})</code>"]:::otherClass
-246v1["<div style=text-align:center>(246v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-247v1["<div style=text-align:center>(247v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::option::Option&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
-248v1["<div style=text-align:center>(248v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!(<br>        [] [move | (key, res) | match res { Ok(_) =&gt; None, Err(e) =&gt; Some((key, e)),<br>        }]<br>    )<br>})</code>"]:::otherClass
-249v1["<div style=text-align:center>(249v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (_, ballot) | ballot]<br>    )<br>})</code>"]:::otherClass
-250v1["<div style=text-align:center>(250v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
-251v1["<div style=text-align:center>(251v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
-252v1["<div style=text-align:center>(252v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
-253v1["<div style=text-align:center>(253v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
-254v1["<div style=text-align:center>(254v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
-255v1["<div style=text-align:center>(255v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
-256v1["<div style=text-align:center>(256v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_LINE_COL!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
-257v1["<div style=text-align:center>(257v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
-258v1["<div style=text-align:center>(258v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
-259v1["<div style=text-align:center>(259v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
-260v1["<div style=text-align:center>(260v1)</div> <code><br>join_multiset_half::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-261v1["<div style=text-align:center>(261v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_LINE_COL!(<br>        [] [| (key, (meta, resp)) | (key, (meta, resp))]<br>    )<br>})</code>"]:::otherClass
-262v1["<div style=text-align:center>(262v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| ((slot, _ballot), (value, _)) | (slot, value)]<br>    )<br>})</code>"]:::otherClass
-263v1["<div style=text-align:center>(263v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
-264v1["<div style=text-align:center>(264v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
-265v1["<div style=text-align:center>(265v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+213v1["<div style=text-align:center>(213v1)</div> <code><br>chain()</code>"]:::otherClass
+214v1["<div style=text-align:center>(214v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+215v1["<div style=text-align:center>(215v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+216v1["<div style=text-align:center>(216v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+217v1["<div style=text-align:center>(217v1)</div> <code><br>tee()</code>"]:::otherClass
+218v1["<div style=text-align:center>(218v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [CLUSTER_SELF_ID__free = hydro_lang::__staged::location::MemberId:: &lt;<br>        hydro_test::__staged::cluster::paxos::Proposer &gt;<br>        ::from_tagless((__hydro_lang_cluster_self_id_loc1v1).clone()),] [move |<br>        ((slot, ballot), value) | P2a { sender : CLUSTER_SELF_ID__free.clone(),<br>        ballot, slot, value }]<br>    )<br>})</code>"]:::otherClass
+219v1["<div style=text-align:center>(219v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+220v1["<div style=text-align:center>(220v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+221v1["<div style=text-align:center>(221v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
+222v1["<div style=text-align:center>(222v1)</div> <code><br>source_stream(DUMMY_SOURCE)</code>"]:::otherClass
+223v1["<div style=text-align:center>(223v1)</div> <code><br>map(|res| {<br>    let (id, b) = res.unwrap();<br>    (<br>        hydro_lang::__staged::location::MemberId::&lt;<br>            hydro_test::__staged::cluster::paxos::Acceptor,<br>        &gt;::from_tagless(id as hydro_lang::__staged::location::TaglessMemberId),<br>        hydro_lang::runtime_support::bincode::deserialize::&lt;<br>            (<br>                (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>                core::result::Result&lt;<br>                    (),<br>                    core::option::Option&lt;<br>                        hydro_test::__staged::cluster::paxos::Ballot,<br>                    &gt;,<br>                &gt;,<br>            ),<br>        &gt;(&amp;b)<br>            .unwrap(),<br>    )<br>})</code>"]:::otherClass
+224v1["<div style=text-align:center>(224v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL!(<br>        [] [| (_, v) | v]<br>    )<br>})</code>"]:::otherClass
+225v1["<div style=text-align:center>(225v1)</div> <code><br>tee()</code>"]:::otherClass
+226v1["<div style=text-align:center>(226v1)</div> <code><br>chain()</code>"]:::otherClass
+227v1["<div style=text-align:center>(227v1)</div> <code><br>tee()</code>"]:::otherClass
+228v1["<div style=text-align:center>(228v1)</div> <code><br>fold_keyed::&lt;<br>    'tick,<br>&gt;(<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!([] [move | | (0, 0)])<br>    },<br>    {<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!(<br>            [] [move | accum, value | { if value.is_ok() { accum.0 += 1; } else {<br>            accum.1 += 1; } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+229v1["<div style=text-align:center>(229v1)</div> <code><br>tee()</code>"]:::otherClass
+230v1["<div style=text-align:center>(230v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; (usize,<br>        usize), bool &gt; ({ use hydro_std::__staged::__deps:: *; use<br>        hydro_std::__staged::quorum:: *;<br>        hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!([max__free = 3usize,]<br>        [move | (success, error) | (success + error) &gt;= max__free]) }),] [{ let orig<br>        = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+231v1["<div style=text-align:center>(231v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+232v1["<div style=text-align:center>(232v1)</div> <code><br>tee()</code>"]:::otherClass
+233v1["<div style=text-align:center>(233v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+234v1["<div style=text-align:center>(234v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::result::Result&lt;<br>            (),<br>            core::option::Option&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;,<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
+235v1["<div style=text-align:center>(235v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!(<br>        [min__free = 2usize,] [move | (key, (success, _error)) | if success &gt;=<br>        min__free { Some(key) } else { None }]<br>    )<br>})</code>"]:::otherClass
+236v1["<div style=text-align:center>(236v1)</div> <code><br>tee()</code>"]:::otherClass
+237v1["<div style=text-align:center>(237v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+238v1["<div style=text-align:center>(238v1)</div> <code><br>identity::&lt;(usize, hydro_test::__staged::cluster::paxos::Ballot)&gt;()</code>"]:::otherClass
+239v1["<div style=text-align:center>(239v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+240v1["<div style=text-align:center>(240v1)</div> <code><br>chain()</code>"]:::otherClass
+241v1["<div style=text-align:center>(241v1)</div> <code><br>tee()</code>"]:::otherClass
+242v1["<div style=text-align:center>(242v1)</div> <code><br>defer_tick_lazy()</code>"]:::otherClass
+243v1["<div style=text-align:center>(243v1)</div> <code><br>difference::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+244v1["<div style=text-align:center>(244v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| k | (k, ())]<br>    )<br>})</code>"]:::otherClass
+245v1["<div style=text-align:center>(245v1)</div> <code><br>tee()</code>"]:::otherClass
+246v1["<div style=text-align:center>(246v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_LINE_COL!(<br>        [] [| (key, _) | key]<br>    )<br>})</code>"]:::otherClass
+247v1["<div style=text-align:center>(247v1)</div> <code><br>anti_join::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+248v1["<div style=text-align:center>(248v1)</div> <code><br>identity::&lt;<br>    (<br>        (usize, hydro_test::__staged::cluster::paxos::Ballot),<br>        core::option::Option&lt;<br>            (<br>                u32,<br>                (<br>                    hydro_test::__staged::__deps::hydro_lang::location::member_id::MemberId&lt;<br>                        hydro_test::__staged::cluster::paxos_bench::Client,<br>                    &gt;,<br>                    i32,<br>                ),<br>            ),<br>        &gt;,<br>    ),<br>&gt;()</code>"]:::otherClass
+249v1["<div style=text-align:center>(249v1)</div> <code><br>filter_map({<br>    hydro_std::__stageleft_quote_src_quorum_rs_LINE_COL!(<br>        [] [move | (key, res) | match res { Ok(_) =&gt; None, Err(e) =&gt; Some((key, e)),<br>        }]<br>    )<br>})</code>"]:::otherClass
+250v1["<div style=text-align:center>(250v1)</div> <code><br>flat_map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| (_, ballot) | ballot]<br>    )<br>})</code>"]:::otherClass
+251v1["<div style=text-align:center>(251v1)</div> <code><br>identity::&lt;hydro_test::__staged::cluster::paxos::Ballot&gt;()</code>"]:::otherClass
+252v1["<div style=text-align:center>(252v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| b | * b]<br>    )<br>})</code>"]:::otherClass
+253v1["<div style=text-align:center>(253v1)</div> <code><br>cross_singleton()</code>"]:::otherClass
+254v1["<div style=text-align:center>(254v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_singleton_rs_LINE_COL!(<br>        [] [| (d, _) | d]<br>    )<br>})</code>"]:::otherClass
+255v1["<div style=text-align:center>(255v1)</div> <code><br>for_each(|_| {})</code>"]:::otherClass
+256v1["<div style=text-align:center>(256v1)</div> <code><br>source_stream(DUMMY)</code>"]:::otherClass
+257v1["<div style=text-align:center>(257v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_location_mod_rs_LINE_COL!(<br>        [] [| (k, v) | (MemberId::from_tagless(k), v)]<br>    )<br>})</code>"]:::otherClass
+258v1["<div style=text-align:center>(258v1)</div> <code><br>fold_keyed::&lt;<br>    'static,<br>&gt;(<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| | false]<br>        )<br>    },<br>    {<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!(<br>            [] [| present, event | { match event { MembershipEvent::Joined =&gt; *<br>            present = true, MembershipEvent::Left =&gt; * present = false, } }]<br>        )<br>    },<br>)</code>"]:::otherClass
+259v1["<div style=text-align:center>(259v1)</div> <code><br>filter({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [f__free = stageleft::runtime_support::fn1_borrow_type_hint:: &lt; bool, bool &gt;<br>        ({ use hydro_lang::__staged::__deps:: *; use<br>        hydro_lang::__staged::live_collections::stream::networking:: *;<br>        hydro_lang::__stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL!([]<br>        [| b | * b]) }),] [{ let orig = f__free; move | t : &amp; (_, _) | orig(&amp; t.1) }]<br>    )<br>})</code>"]:::otherClass
+260v1["<div style=text-align:center>(260v1)</div> <code><br>map({<br>    hydro_lang::__stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL!(<br>        [] [| (k, _) | k]<br>    )<br>})</code>"]:::otherClass
+261v1["<div style=text-align:center>(261v1)</div> <code><br>join_multiset_half::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+262v1["<div style=text-align:center>(262v1)</div> <code><br>map({<br>    hydro_std::__stageleft_quote_src_request_response_rs_LINE_COL!(<br>        [] [| (key, (meta, resp)) | (key, (meta, resp))]<br>    )<br>})</code>"]:::otherClass
+263v1["<div style=text-align:center>(263v1)</div> <code><br>map({<br>    crate::__staged::__stageleft_quote_src_cluster_paxos_rs_LINE_COL!(<br>        [] [| ((slot, _ballot), (value, _)) | (slot, value)]<br>    )<br>})</code>"]:::otherClass
+264v1["<div style=text-align:center>(264v1)</div> <code><br>cross_join_multiset::&lt;'tick, 'tick&gt;()</code>"]:::otherClass
+265v1["<div style=text-align:center>(265v1)</div> <code><br>map(|(id, data)| {<br>    (<br>        id.into_tagless(),<br>        hydro_lang::runtime_support::bincode::serialize(&amp;data).unwrap().into(),<br>    )<br>})</code>"]:::otherClass
+266v1["<div style=text-align:center>(266v1)</div> <code><br>dest_sink(DUMMY_SINK)</code>"]:::otherClass
 1v1-->2v1
-132v1-->|0|3v1
-250v1-->|1|3v1
+133v1-->|0|3v1
+251v1-->|1|3v1
 3v1-->|0|4v1
-50v1-->|1|4v1
+51v1-->|1|4v1
 4v1-->5v1
-6v1-->7v1
-5v1-->|0|8v1
-7v1-->|1|8v1
-8v1-->9v1
-17v1--o10v1; linkStyle 10 stroke:red
-11v1-->12v1
-10v1-->|0|13v1
-12v1-->|1|13v1
-9v1-->|input|14v1
-13v1-->|single|14v1
-14v1-->15v1
+5v1-->6v1
+7v1-->8v1
+6v1-->|0|9v1
+8v1-->|1|9v1
+9v1-->10v1
+18v1--o11v1; linkStyle 11 stroke:red
+12v1-->13v1
+11v1-->|0|14v1
+13v1-->|1|14v1
+10v1-->|input|15v1
+14v1-->|single|15v1
 15v1-->16v1
 16v1-->17v1
-18v1-->19v1
+17v1-->18v1
 19v1-->20v1
 20v1-->21v1
 21v1-->22v1
-16v1-->23v1
-23v1-->24v1
+22v1-->23v1
+17v1-->24v1
 24v1-->25v1
-129v1-->26v1
-26v1-->27v1
-25v1-->|input|28v1
-27v1-->|single|28v1
-28v1-->29v1
-30v1-->31v1
+25v1-->26v1
+130v1-->27v1
+27v1-->28v1
+26v1-->|input|29v1
+28v1-->|single|29v1
+29v1-->30v1
 31v1-->32v1
 32v1-->33v1
 33v1-->34v1
 34v1-->35v1
-36v1-->37v1
-35v1-->|0|38v1
-37v1-->|1|38v1
-38v1-->39v1
+35v1-->36v1
+37v1-->38v1
+36v1-->|0|39v1
+38v1-->|1|39v1
 39v1-->40v1
-29v1-->|input|41v1
-40v1-->|single|41v1
-41v1-->42v1
-22v1-->|0|43v1
-42v1-->|1|43v1
+40v1-->41v1
+30v1-->|input|42v1
+41v1-->|single|42v1
+42v1-->43v1
+23v1-->|0|44v1
+43v1-->|1|44v1
+45v1-->46v1
 44v1-->45v1
-43v1-->44v1
-46v1-->47v1
 47v1-->48v1
 48v1-->49v1
 49v1-->50v1
-101v1--o51v1; linkStyle 52 stroke:red
-52v1-->53v1
+50v1-->51v1
+102v1--o52v1; linkStyle 53 stroke:red
 53v1-->54v1
 54v1-->55v1
 55v1-->56v1
-49v1-->57v1
-57v1-->58v1
-26v1-->59v1
-59v1-->60v1
-58v1-->|input|61v1
-60v1-->|single|61v1
-61v1-->62v1
+56v1-->57v1
+50v1-->58v1
+58v1-->59v1
+27v1-->60v1
+60v1-->61v1
+59v1-->|input|62v1
+61v1-->|single|62v1
 62v1-->63v1
 63v1-->64v1
-65v1-->66v1
-64v1-->|0|67v1
-66v1-->|1|67v1
-67v1-->68v1
-69v1-->70v1
+64v1-->65v1
+66v1-->67v1
+65v1-->|0|68v1
+67v1-->|1|68v1
+68v1-->69v1
 70v1-->71v1
 71v1-->72v1
 72v1-->73v1
 73v1-->74v1
-75v1-->76v1
-74v1-->|0|77v1
-76v1-->|1|77v1
-77v1-->78v1
-68v1-->|input|79v1
-78v1-->|single|79v1
-79v1-->80v1
+74v1-->75v1
+76v1-->77v1
+75v1-->|0|78v1
+77v1-->|1|78v1
+78v1-->79v1
+69v1-->|input|80v1
+79v1-->|single|80v1
 80v1-->81v1
-25v1-->|input|82v1
-81v1-->|single|82v1
-82v1-->83v1
+81v1-->82v1
+26v1-->|input|83v1
+82v1-->|single|83v1
 83v1-->84v1
-56v1-->|0|85v1
-84v1-->|1|85v1
+84v1-->85v1
+57v1-->|0|86v1
+85v1-->|1|86v1
+87v1-->88v1
 86v1-->87v1
-85v1-->86v1
-88v1-->89v1
 89v1-->90v1
 90v1-->91v1
 91v1-->92v1
-51v1-->|0|93v1
-92v1-->|1|93v1
-93v1-->94v1
+92v1-->93v1
+52v1-->|0|94v1
+93v1-->|1|94v1
 94v1-->95v1
 95v1-->96v1
 96v1-->97v1
 97v1-->98v1
 98v1-->99v1
-94v1-->|pos|100v1
-99v1-->|neg|100v1
-100v1-->101v1
-96v1-->102v1
-102v1-->103v1
-103v1-->|pos|104v1
-99v1-->|neg|104v1
-104v1-->105v1
-96v1-->106v1
-106v1-->107v1
-94v1-->|pos|108v1
-107v1-->|neg|108v1
-105v1--o109v1; linkStyle 115 stroke:red
-108v1-->|pos|110v1
-109v1-->|neg|110v1
-110v1-->111v1
+99v1-->100v1
+95v1-->|pos|101v1
+100v1-->|neg|101v1
+101v1-->102v1
+97v1-->103v1
+103v1-->104v1
+104v1-->|pos|105v1
+100v1-->|neg|105v1
+105v1-->106v1
+97v1-->107v1
+107v1-->108v1
+95v1-->|pos|109v1
+108v1-->|neg|109v1
+106v1--o110v1; linkStyle 116 stroke:red
+109v1-->|pos|111v1
+110v1-->|neg|111v1
 111v1-->112v1
 112v1-->113v1
 113v1-->114v1
-114v1-->|input|115v1
-25v1-->|single|115v1
-115v1-->116v1
+114v1-->115v1
+115v1-->|input|116v1
+26v1-->|single|116v1
 116v1-->117v1
 117v1-->118v1
 118v1-->119v1
-120v1-->121v1
-119v1-->|0|122v1
-121v1-->|1|122v1
-122v1-->123v1
-9v1-->|input|124v1
-24v1-->|single|124v1
-124v1-->125v1
-123v1-->|input|126v1
-125v1-->|single|126v1
-126v1-->127v1
+119v1-->120v1
+121v1-->122v1
+120v1-->|0|123v1
+122v1-->|1|123v1
+123v1-->124v1
+10v1-->|input|125v1
+25v1-->|single|125v1
+125v1-->126v1
+124v1-->|input|127v1
+126v1-->|single|127v1
 127v1-->128v1
 128v1-->129v1
-92v1-->130v1
-130v1-->131v1
+129v1-->130v1
+93v1-->131v1
 131v1-->132v1
-133v1-->134v1
+132v1-->133v1
 134v1-->135v1
 135v1-->136v1
 136v1-->137v1
-128v1-->138v1
-138v1-->139v1
-139v1--o140v1; linkStyle 149 stroke:red
-140v1-->141v1
+137v1-->138v1
+129v1-->139v1
+139v1-->140v1
+140v1--o141v1; linkStyle 150 stroke:red
 141v1-->142v1
-143v1-->144v1
-142v1-->|0|145v1
-144v1-->|1|145v1
-145v1-->146v1
-128v1-->|input|147v1
-146v1-->|single|147v1
-147v1-->148v1
+142v1-->143v1
+144v1-->145v1
+143v1-->|0|146v1
+145v1-->|1|146v1
+146v1-->147v1
+129v1-->|input|148v1
+147v1-->|single|148v1
 148v1-->149v1
 149v1-->150v1
-25v1-->|input|151v1
-150v1-->|single|151v1
-151v1-->152v1
-137v1-->|0|153v1
-152v1-->|1|153v1
+150v1-->151v1
+26v1-->|input|152v1
+151v1-->|single|152v1
+152v1-->153v1
+138v1-->|0|154v1
+153v1-->|1|154v1
+155v1-->156v1
 154v1-->155v1
-153v1-->154v1
-156v1-->157v1
 157v1-->158v1
-128v1-->159v1
-158v1-->|input|160v1
-159v1-->|single|160v1
-160v1-->161v1
+158v1-->159v1
+129v1-->160v1
+159v1-->|input|161v1
+160v1-->|single|161v1
 161v1-->162v1
-117v1-->163v1
-163v1-->164v1
+162v1-->163v1
+118v1-->164v1
 164v1-->165v1
 165v1-->166v1
 166v1-->167v1
@@ -459,327 +460,324 @@ linkStyle default stroke:#aaa
 170v1-->171v1
 171v1-->172v1
 172v1-->173v1
-186v1--o174v1; linkStyle 186 stroke:red
-175v1-->176v1
-174v1-->|0|177v1
-176v1-->|1|177v1
-173v1-->|0|178v1
+173v1-->174v1
+187v1--o175v1; linkStyle 187 stroke:red
+176v1-->177v1
+175v1-->|0|178v1
 177v1-->|1|178v1
-178v1-->179v1
-162v1-->|input|180v1
-179v1-->|single|180v1
-180v1-->181v1
+174v1-->|0|179v1
+178v1-->|1|179v1
+179v1-->180v1
+163v1-->|input|181v1
+180v1-->|single|181v1
 181v1-->182v1
 182v1-->183v1
-183v1-->|input|184v1
-179v1-->|single|184v1
-184v1-->185v1
+183v1-->184v1
+184v1-->|input|185v1
+180v1-->|single|185v1
 185v1-->186v1
-233v1--o187v1; linkStyle 202 stroke:red
-188v1-->189v1
+186v1-->187v1
+234v1--o188v1; linkStyle 203 stroke:red
 189v1-->190v1
 190v1-->191v1
 191v1-->192v1
-182v1-->|input|193v1
-25v1-->|single|193v1
-193v1-->194v1
-169v1-->|input|195v1
-25v1-->|single|195v1
-164v1-->196v1
-196v1-->197v1
+192v1-->193v1
+183v1-->|input|194v1
+26v1-->|single|194v1
+194v1-->195v1
+170v1-->|input|196v1
+26v1-->|single|196v1
+165v1-->197v1
 197v1-->198v1
-199v1-->200v1
-198v1-->|0|201v1
-200v1-->|1|201v1
-201v1-->202v1
-195v1-->|input|203v1
-202v1-->|single|203v1
-203v1-->204v1
-172v1-->|input|205v1
-202v1-->|single|205v1
-205v1-->206v1
-169v1-->207v1
-206v1-->|pos|208v1
-207v1-->|neg|208v1
-208v1-->|input|209v1
-25v1-->|single|209v1
-209v1-->210v1
-204v1-->|0|211v1
-210v1-->|1|211v1
-194v1-->|0|212v1
+198v1-->199v1
+200v1-->201v1
+199v1-->|0|202v1
+201v1-->|1|202v1
+202v1-->203v1
+196v1-->|input|204v1
+203v1-->|single|204v1
+204v1-->205v1
+173v1-->|input|206v1
+203v1-->|single|206v1
+206v1-->207v1
+170v1-->208v1
+207v1-->|pos|209v1
+208v1-->|neg|209v1
+209v1-->|input|210v1
+26v1-->|single|210v1
+210v1-->211v1
+205v1-->|0|212v1
 211v1-->|1|212v1
-128v1-->213v1
-212v1-->|input|214v1
-213v1-->|single|214v1
-214v1-->215v1
+195v1-->|0|213v1
+212v1-->|1|213v1
+129v1-->214v1
+213v1-->|input|215v1
+214v1-->|single|215v1
 215v1-->216v1
 216v1-->217v1
-192v1-->|0|218v1
-217v1-->|1|218v1
+217v1-->218v1
+193v1-->|0|219v1
+218v1-->|1|219v1
+220v1-->221v1
 219v1-->220v1
-218v1-->219v1
-221v1-->222v1
 222v1-->223v1
 223v1-->224v1
-187v1-->|0|225v1
-224v1-->|1|225v1
-225v1-->226v1
+224v1-->225v1
+188v1-->|0|226v1
+225v1-->|1|226v1
 226v1-->227v1
 227v1-->228v1
 228v1-->229v1
 229v1-->230v1
 230v1-->231v1
-226v1-->|pos|232v1
-231v1-->|neg|232v1
-232v1-->233v1
-228v1-->234v1
-234v1-->235v1
-235v1-->|pos|236v1
-231v1-->|neg|236v1
-236v1-->237v1
-247v1--o238v1; linkStyle 264 stroke:red
-238v1-->|0|239v1
-216v1-->|1|239v1
-239v1-->240v1
-237v1--o241v1; linkStyle 268 stroke:red
-235v1-->|pos|242v1
-241v1-->|neg|242v1
-242v1-->243v1
+231v1-->232v1
+227v1-->|pos|233v1
+232v1-->|neg|233v1
+233v1-->234v1
+229v1-->235v1
+235v1-->236v1
+236v1-->|pos|237v1
+232v1-->|neg|237v1
+237v1-->238v1
+248v1--o239v1; linkStyle 265 stroke:red
+239v1-->|0|240v1
+217v1-->|1|240v1
+240v1-->241v1
+238v1--o242v1; linkStyle 269 stroke:red
+236v1-->|pos|243v1
+242v1-->|neg|243v1
 243v1-->244v1
 244v1-->245v1
-240v1-->|pos|246v1
-245v1-->|neg|246v1
-246v1-->247v1
-224v1-->248v1
-248v1-->249v1
+245v1-->246v1
+241v1-->|pos|247v1
+246v1-->|neg|247v1
+247v1-->248v1
+225v1-->249v1
 249v1-->250v1
-149v1-->251v1
-25v1-->|input|252v1
-251v1-->|single|252v1
-252v1-->253v1
+250v1-->251v1
+150v1-->252v1
+26v1-->|input|253v1
+252v1-->|single|253v1
 253v1-->254v1
-255v1-->256v1
+254v1-->255v1
 256v1-->257v1
 257v1-->258v1
 258v1-->259v1
-240v1-->|probe|260v1
-244v1-->|build|260v1
-260v1-->261v1
+259v1-->260v1
+241v1-->|probe|261v1
+245v1-->|build|261v1
 261v1-->262v1
-259v1-->|0|263v1
-262v1-->|1|263v1
+262v1-->263v1
+260v1-->|0|264v1
+263v1-->|1|264v1
+265v1-->266v1
 264v1-->265v1
-263v1-->264v1
 2v1
-44v1
 45v1
-86v1
+46v1
 87v1
-154v1
+88v1
 155v1
-219v1
+156v1
 220v1
-254v1
-264v1
+221v1
+255v1
 265v1
+266v1
 subgraph var_cycle_10 ["var <tt>cycle_10</tt>"]
     style var_cycle_10 fill:transparent
-    105v1
+    106v1
 end
 subgraph var_cycle_12 ["var <tt>cycle_12</tt>"]
     style var_cycle_12 fill:transparent
-    186v1
+    187v1
 end
 subgraph var_cycle_13 ["var <tt>cycle_13</tt>"]
     style var_cycle_13 fill:transparent
-    233v1
+    234v1
 end
 subgraph var_cycle_14 ["var <tt>cycle_14</tt>"]
     style var_cycle_14 fill:transparent
-    237v1
+    238v1
 end
 subgraph var_cycle_15 ["var <tt>cycle_15</tt>"]
     style var_cycle_15 fill:transparent
-    247v1
+    248v1
 end
 subgraph var_cycle_3 ["var <tt>cycle_3</tt>"]
     style var_cycle_3 fill:transparent
-    250v1
+    251v1
 end
 subgraph var_cycle_5 ["var <tt>cycle_5</tt>"]
     style var_cycle_5 fill:transparent
-    132v1
+    133v1
 end
 subgraph var_cycle_6 ["var <tt>cycle_6</tt>"]
     style var_cycle_6 fill:transparent
-    50v1
+    51v1
 end
 subgraph var_cycle_7 ["var <tt>cycle_7</tt>"]
     style var_cycle_7 fill:transparent
-    129v1
+    130v1
 end
 subgraph var_cycle_8 ["var <tt>cycle_8</tt>"]
     style var_cycle_8 fill:transparent
-    17v1
+    18v1
 end
 subgraph var_cycle_9 ["var <tt>cycle_9</tt>"]
     style var_cycle_9 fill:transparent
-    101v1
+    102v1
 end
 subgraph var_stream_101 ["var <tt>stream_101</tt>"]
     style var_stream_101 fill:transparent
-    46v1
     47v1
+    48v1
 end
 subgraph var_stream_103 ["var <tt>stream_103</tt>"]
     style var_stream_103 fill:transparent
-    48v1
+    49v1
 end
 subgraph var_stream_104 ["var <tt>stream_104</tt>"]
     style var_stream_104 fill:transparent
-    49v1
+    50v1
 end
 subgraph var_stream_106 ["var <tt>stream_106</tt>"]
     style var_stream_106 fill:transparent
-    51v1
+    52v1
 end
 subgraph var_stream_107 ["var <tt>stream_107</tt>"]
     style var_stream_107 fill:transparent
-    52v1
+    53v1
 end
 subgraph var_stream_108 ["var <tt>stream_108</tt>"]
     style var_stream_108 fill:transparent
-    53v1
+    54v1
 end
 subgraph var_stream_110 ["var <tt>stream_110</tt>"]
     style var_stream_110 fill:transparent
-    54v1
+    55v1
 end
 subgraph var_stream_112 ["var <tt>stream_112</tt>"]
     style var_stream_112 fill:transparent
-    55v1
+    56v1
 end
 subgraph var_stream_115 ["var <tt>stream_115</tt>"]
     style var_stream_115 fill:transparent
-    56v1
+    57v1
 end
 subgraph var_stream_120 ["var <tt>stream_120</tt>"]
     style var_stream_120 fill:transparent
-    57v1
+    58v1
 end
 subgraph var_stream_122 ["var <tt>stream_122</tt>"]
     style var_stream_122 fill:transparent
-    58v1
+    59v1
 end
 subgraph var_stream_126 ["var <tt>stream_126</tt>"]
     style var_stream_126 fill:transparent
-    59v1
+    60v1
 end
 subgraph var_stream_127 ["var <tt>stream_127</tt>"]
     style var_stream_127 fill:transparent
-    60v1
+    61v1
 end
 subgraph var_stream_128 ["var <tt>stream_128</tt>"]
     style var_stream_128 fill:transparent
-    61v1
+    62v1
 end
 subgraph var_stream_129 ["var <tt>stream_129</tt>"]
     style var_stream_129 fill:transparent
-    62v1
+    63v1
 end
 subgraph var_stream_130 ["var <tt>stream_130</tt>"]
     style var_stream_130 fill:transparent
-    63v1
+    64v1
 end
 subgraph var_stream_131 ["var <tt>stream_131</tt>"]
     style var_stream_131 fill:transparent
-    64v1
+    65v1
 end
 subgraph var_stream_132 ["var <tt>stream_132</tt>"]
     style var_stream_132 fill:transparent
-    65v1
     66v1
+    67v1
 end
 subgraph var_stream_134 ["var <tt>stream_134</tt>"]
     style var_stream_134 fill:transparent
-    67v1
+    68v1
 end
 subgraph var_stream_136 ["var <tt>stream_136</tt>"]
     style var_stream_136 fill:transparent
-    68v1
+    69v1
 end
 subgraph var_stream_137 ["var <tt>stream_137</tt>"]
     style var_stream_137 fill:transparent
-    69v1
+    70v1
 end
 subgraph var_stream_139 ["var <tt>stream_139</tt>"]
     style var_stream_139 fill:transparent
-    70v1
+    71v1
 end
 subgraph var_stream_140 ["var <tt>stream_140</tt>"]
     style var_stream_140 fill:transparent
-    71v1
+    72v1
 end
 subgraph var_stream_141 ["var <tt>stream_141</tt>"]
     style var_stream_141 fill:transparent
-    72v1
+    73v1
 end
 subgraph var_stream_142 ["var <tt>stream_142</tt>"]
     style var_stream_142 fill:transparent
-    73v1
+    74v1
 end
 subgraph var_stream_143 ["var <tt>stream_143</tt>"]
     style var_stream_143 fill:transparent
-    74v1
+    75v1
 end
 subgraph var_stream_144 ["var <tt>stream_144</tt>"]
     style var_stream_144 fill:transparent
-    75v1
     76v1
+    77v1
 end
 subgraph var_stream_146 ["var <tt>stream_146</tt>"]
     style var_stream_146 fill:transparent
-    77v1
+    78v1
 end
 subgraph var_stream_148 ["var <tt>stream_148</tt>"]
     style var_stream_148 fill:transparent
-    78v1
+    79v1
 end
 subgraph var_stream_149 ["var <tt>stream_149</tt>"]
     style var_stream_149 fill:transparent
-    79v1
+    80v1
 end
 subgraph var_stream_151 ["var <tt>stream_151</tt>"]
     style var_stream_151 fill:transparent
-    80v1
+    81v1
 end
 subgraph var_stream_152 ["var <tt>stream_152</tt>"]
     style var_stream_152 fill:transparent
-    81v1
+    82v1
 end
 subgraph var_stream_153 ["var <tt>stream_153</tt>"]
     style var_stream_153 fill:transparent
-    82v1
+    83v1
 end
 subgraph var_stream_154 ["var <tt>stream_154</tt>"]
     style var_stream_154 fill:transparent
-    83v1
+    84v1
 end
 subgraph var_stream_157 ["var <tt>stream_157</tt>"]
     style var_stream_157 fill:transparent
-    84v1
+    85v1
 end
 subgraph var_stream_159 ["var <tt>stream_159</tt>"]
     style var_stream_159 fill:transparent
-    85v1
+    86v1
 end
-subgraph var_stream_186 ["var <tt>stream_186</tt>"]
-    style var_stream_186 fill:transparent
-    88v1
+subgraph var_stream_187 ["var <tt>stream_187</tt>"]
+    style var_stream_187 fill:transparent
     89v1
-end
-subgraph var_stream_188 ["var <tt>stream_188</tt>"]
-    style var_stream_188 fill:transparent
     90v1
 end
 subgraph var_stream_189 ["var <tt>stream_189</tt>"]
@@ -790,16 +788,16 @@ subgraph var_stream_190 ["var <tt>stream_190</tt>"]
     style var_stream_190 fill:transparent
     92v1
 end
-subgraph var_stream_192 ["var <tt>stream_192</tt>"]
-    style var_stream_192 fill:transparent
+subgraph var_stream_191 ["var <tt>stream_191</tt>"]
+    style var_stream_191 fill:transparent
     93v1
 end
 subgraph var_stream_193 ["var <tt>stream_193</tt>"]
     style var_stream_193 fill:transparent
     94v1
 end
-subgraph var_stream_196 ["var <tt>stream_196</tt>"]
-    style var_stream_196 fill:transparent
+subgraph var_stream_194 ["var <tt>stream_194</tt>"]
+    style var_stream_194 fill:transparent
     95v1
 end
 subgraph var_stream_197 ["var <tt>stream_197</tt>"]
@@ -810,8 +808,8 @@ subgraph var_stream_198 ["var <tt>stream_198</tt>"]
     style var_stream_198 fill:transparent
     97v1
 end
-subgraph var_stream_201 ["var <tt>stream_201</tt>"]
-    style var_stream_201 fill:transparent
+subgraph var_stream_199 ["var <tt>stream_199</tt>"]
+    style var_stream_199 fill:transparent
     98v1
 end
 subgraph var_stream_202 ["var <tt>stream_202</tt>"]
@@ -822,32 +820,32 @@ subgraph var_stream_203 ["var <tt>stream_203</tt>"]
     style var_stream_203 fill:transparent
     100v1
 end
-subgraph var_stream_205 ["var <tt>stream_205</tt>"]
-    style var_stream_205 fill:transparent
-    102v1
+subgraph var_stream_204 ["var <tt>stream_204</tt>"]
+    style var_stream_204 fill:transparent
+    101v1
 end
-subgraph var_stream_208 ["var <tt>stream_208</tt>"]
-    style var_stream_208 fill:transparent
+subgraph var_stream_206 ["var <tt>stream_206</tt>"]
+    style var_stream_206 fill:transparent
     103v1
 end
-subgraph var_stream_210 ["var <tt>stream_210</tt>"]
-    style var_stream_210 fill:transparent
+subgraph var_stream_209 ["var <tt>stream_209</tt>"]
+    style var_stream_209 fill:transparent
     104v1
 end
-subgraph var_stream_213 ["var <tt>stream_213</tt>"]
-    style var_stream_213 fill:transparent
-    106v1
+subgraph var_stream_211 ["var <tt>stream_211</tt>"]
+    style var_stream_211 fill:transparent
+    105v1
 end
-subgraph var_stream_216 ["var <tt>stream_216</tt>"]
-    style var_stream_216 fill:transparent
+subgraph var_stream_214 ["var <tt>stream_214</tt>"]
+    style var_stream_214 fill:transparent
     107v1
 end
 subgraph var_stream_217 ["var <tt>stream_217</tt>"]
     style var_stream_217 fill:transparent
     108v1
 end
-subgraph var_stream_219 ["var <tt>stream_219</tt>"]
-    style var_stream_219 fill:transparent
+subgraph var_stream_218 ["var <tt>stream_218</tt>"]
+    style var_stream_218 fill:transparent
     109v1
 end
 subgraph var_stream_22 ["var <tt>stream_22</tt>"]
@@ -862,20 +860,20 @@ subgraph var_stream_221 ["var <tt>stream_221</tt>"]
     style var_stream_221 fill:transparent
     111v1
 end
-subgraph var_stream_225 ["var <tt>stream_225</tt>"]
-    style var_stream_225 fill:transparent
+subgraph var_stream_222 ["var <tt>stream_222</tt>"]
+    style var_stream_222 fill:transparent
     112v1
 end
 subgraph var_stream_226 ["var <tt>stream_226</tt>"]
     style var_stream_226 fill:transparent
     113v1
 end
-subgraph var_stream_231 ["var <tt>stream_231</tt>"]
-    style var_stream_231 fill:transparent
+subgraph var_stream_227 ["var <tt>stream_227</tt>"]
+    style var_stream_227 fill:transparent
     114v1
 end
-subgraph var_stream_235 ["var <tt>stream_235</tt>"]
-    style var_stream_235 fill:transparent
+subgraph var_stream_232 ["var <tt>stream_232</tt>"]
+    style var_stream_232 fill:transparent
     115v1
 end
 subgraph var_stream_236 ["var <tt>stream_236</tt>"]
@@ -897,70 +895,70 @@ end
 subgraph var_stream_240 ["var <tt>stream_240</tt>"]
     style var_stream_240 fill:transparent
     120v1
-    121v1
 end
-subgraph var_stream_242 ["var <tt>stream_242</tt>"]
-    style var_stream_242 fill:transparent
+subgraph var_stream_241 ["var <tt>stream_241</tt>"]
+    style var_stream_241 fill:transparent
+    121v1
     122v1
 end
-subgraph var_stream_244 ["var <tt>stream_244</tt>"]
-    style var_stream_244 fill:transparent
+subgraph var_stream_243 ["var <tt>stream_243</tt>"]
+    style var_stream_243 fill:transparent
     123v1
 end
-subgraph var_stream_247 ["var <tt>stream_247</tt>"]
-    style var_stream_247 fill:transparent
+subgraph var_stream_245 ["var <tt>stream_245</tt>"]
+    style var_stream_245 fill:transparent
     124v1
 end
-subgraph var_stream_249 ["var <tt>stream_249</tt>"]
-    style var_stream_249 fill:transparent
+subgraph var_stream_248 ["var <tt>stream_248</tt>"]
+    style var_stream_248 fill:transparent
     125v1
 end
-subgraph var_stream_252 ["var <tt>stream_252</tt>"]
-    style var_stream_252 fill:transparent
+subgraph var_stream_250 ["var <tt>stream_250</tt>"]
+    style var_stream_250 fill:transparent
     126v1
 end
-subgraph var_stream_254 ["var <tt>stream_254</tt>"]
-    style var_stream_254 fill:transparent
+subgraph var_stream_253 ["var <tt>stream_253</tt>"]
+    style var_stream_253 fill:transparent
     127v1
 end
 subgraph var_stream_255 ["var <tt>stream_255</tt>"]
     style var_stream_255 fill:transparent
     128v1
 end
-subgraph var_stream_257 ["var <tt>stream_257</tt>"]
-    style var_stream_257 fill:transparent
-    130v1
+subgraph var_stream_256 ["var <tt>stream_256</tt>"]
+    style var_stream_256 fill:transparent
+    129v1
 end
 subgraph var_stream_258 ["var <tt>stream_258</tt>"]
     style var_stream_258 fill:transparent
     131v1
 end
-subgraph var_stream_276 ["var <tt>stream_276</tt>"]
-    style var_stream_276 fill:transparent
-    133v1
+subgraph var_stream_259 ["var <tt>stream_259</tt>"]
+    style var_stream_259 fill:transparent
+    132v1
 end
 subgraph var_stream_277 ["var <tt>stream_277</tt>"]
     style var_stream_277 fill:transparent
     134v1
 end
-subgraph var_stream_279 ["var <tt>stream_279</tt>"]
-    style var_stream_279 fill:transparent
+subgraph var_stream_278 ["var <tt>stream_278</tt>"]
+    style var_stream_278 fill:transparent
     135v1
 end
 subgraph var_stream_28 ["var <tt>stream_28</tt>"]
     style var_stream_28 fill:transparent
     3v1
 end
-subgraph var_stream_281 ["var <tt>stream_281</tt>"]
-    style var_stream_281 fill:transparent
+subgraph var_stream_280 ["var <tt>stream_280</tt>"]
+    style var_stream_280 fill:transparent
     136v1
 end
-subgraph var_stream_284 ["var <tt>stream_284</tt>"]
-    style var_stream_284 fill:transparent
+subgraph var_stream_282 ["var <tt>stream_282</tt>"]
+    style var_stream_282 fill:transparent
     137v1
 end
-subgraph var_stream_289 ["var <tt>stream_289</tt>"]
-    style var_stream_289 fill:transparent
+subgraph var_stream_285 ["var <tt>stream_285</tt>"]
+    style var_stream_285 fill:transparent
     138v1
 end
 subgraph var_stream_290 ["var <tt>stream_290</tt>"]
@@ -982,14 +980,14 @@ end
 subgraph var_stream_294 ["var <tt>stream_294</tt>"]
     style var_stream_294 fill:transparent
     143v1
-    144v1
 end
-subgraph var_stream_296 ["var <tt>stream_296</tt>"]
-    style var_stream_296 fill:transparent
+subgraph var_stream_295 ["var <tt>stream_295</tt>"]
+    style var_stream_295 fill:transparent
+    144v1
     145v1
 end
-subgraph var_stream_298 ["var <tt>stream_298</tt>"]
-    style var_stream_298 fill:transparent
+subgraph var_stream_297 ["var <tt>stream_297</tt>"]
+    style var_stream_297 fill:transparent
     146v1
 end
 subgraph var_stream_299 ["var <tt>stream_299</tt>"]
@@ -1000,8 +998,8 @@ subgraph var_stream_30 ["var <tt>stream_30</tt>"]
     style var_stream_30 fill:transparent
     4v1
 end
-subgraph var_stream_301 ["var <tt>stream_301</tt>"]
-    style var_stream_301 fill:transparent
+subgraph var_stream_300 ["var <tt>stream_300</tt>"]
+    style var_stream_300 fill:transparent
     148v1
 end
 subgraph var_stream_302 ["var <tt>stream_302</tt>"]
@@ -1020,25 +1018,29 @@ subgraph var_stream_305 ["var <tt>stream_305</tt>"]
     style var_stream_305 fill:transparent
     152v1
 end
-subgraph var_stream_309 ["var <tt>stream_309</tt>"]
-    style var_stream_309 fill:transparent
+subgraph var_stream_306 ["var <tt>stream_306</tt>"]
+    style var_stream_306 fill:transparent
     153v1
+end
+subgraph var_stream_310 ["var <tt>stream_310</tt>"]
+    style var_stream_310 fill:transparent
+    154v1
 end
 subgraph var_stream_33 ["var <tt>stream_33</tt>"]
     style var_stream_33 fill:transparent
     5v1
 end
-subgraph var_stream_337 ["var <tt>stream_337</tt>"]
-    style var_stream_337 fill:transparent
-    156v1
+subgraph var_stream_338 ["var <tt>stream_338</tt>"]
+    style var_stream_338 fill:transparent
     157v1
-end
-subgraph var_stream_339 ["var <tt>stream_339</tt>"]
-    style var_stream_339 fill:transparent
     158v1
 end
-subgraph var_stream_343 ["var <tt>stream_343</tt>"]
-    style var_stream_343 fill:transparent
+subgraph var_stream_34 ["var <tt>stream_34</tt>"]
+    style var_stream_34 fill:transparent
+    6v1
+end
+subgraph var_stream_340 ["var <tt>stream_340</tt>"]
+    style var_stream_340 fill:transparent
     159v1
 end
 subgraph var_stream_344 ["var <tt>stream_344</tt>"]
@@ -1049,16 +1051,12 @@ subgraph var_stream_345 ["var <tt>stream_345</tt>"]
     style var_stream_345 fill:transparent
     161v1
 end
-subgraph var_stream_348 ["var <tt>stream_348</tt>"]
-    style var_stream_348 fill:transparent
+subgraph var_stream_346 ["var <tt>stream_346</tt>"]
+    style var_stream_346 fill:transparent
     162v1
 end
-subgraph var_stream_35 ["var <tt>stream_35</tt>"]
-    style var_stream_35 fill:transparent
-    6v1
-end
-subgraph var_stream_351 ["var <tt>stream_351</tt>"]
-    style var_stream_351 fill:transparent
+subgraph var_stream_349 ["var <tt>stream_349</tt>"]
+    style var_stream_349 fill:transparent
     163v1
 end
 subgraph var_stream_352 ["var <tt>stream_352</tt>"]
@@ -1073,8 +1071,8 @@ subgraph var_stream_354 ["var <tt>stream_354</tt>"]
     style var_stream_354 fill:transparent
     166v1
 end
-subgraph var_stream_356 ["var <tt>stream_356</tt>"]
-    style var_stream_356 fill:transparent
+subgraph var_stream_355 ["var <tt>stream_355</tt>"]
+    style var_stream_355 fill:transparent
     167v1
 end
 subgraph var_stream_357 ["var <tt>stream_357</tt>"]
@@ -1085,49 +1083,50 @@ subgraph var_stream_358 ["var <tt>stream_358</tt>"]
     style var_stream_358 fill:transparent
     169v1
 end
+subgraph var_stream_359 ["var <tt>stream_359</tt>"]
+    style var_stream_359 fill:transparent
+    170v1
+end
 subgraph var_stream_36 ["var <tt>stream_36</tt>"]
     style var_stream_36 fill:transparent
     7v1
+    8v1
 end
-subgraph var_stream_361 ["var <tt>stream_361</tt>"]
-    style var_stream_361 fill:transparent
-    170v1
-end
-subgraph var_stream_363 ["var <tt>stream_363</tt>"]
-    style var_stream_363 fill:transparent
+subgraph var_stream_362 ["var <tt>stream_362</tt>"]
+    style var_stream_362 fill:transparent
     171v1
 end
 subgraph var_stream_364 ["var <tt>stream_364</tt>"]
     style var_stream_364 fill:transparent
     172v1
 end
-subgraph var_stream_367 ["var <tt>stream_367</tt>"]
-    style var_stream_367 fill:transparent
+subgraph var_stream_365 ["var <tt>stream_365</tt>"]
+    style var_stream_365 fill:transparent
     173v1
 end
-subgraph var_stream_369 ["var <tt>stream_369</tt>"]
-    style var_stream_369 fill:transparent
+subgraph var_stream_368 ["var <tt>stream_368</tt>"]
+    style var_stream_368 fill:transparent
     174v1
 end
 subgraph var_stream_370 ["var <tt>stream_370</tt>"]
     style var_stream_370 fill:transparent
     175v1
-    176v1
 end
-subgraph var_stream_372 ["var <tt>stream_372</tt>"]
-    style var_stream_372 fill:transparent
+subgraph var_stream_371 ["var <tt>stream_371</tt>"]
+    style var_stream_371 fill:transparent
+    176v1
     177v1
 end
-subgraph var_stream_375 ["var <tt>stream_375</tt>"]
-    style var_stream_375 fill:transparent
+subgraph var_stream_373 ["var <tt>stream_373</tt>"]
+    style var_stream_373 fill:transparent
     178v1
 end
-subgraph var_stream_377 ["var <tt>stream_377</tt>"]
-    style var_stream_377 fill:transparent
+subgraph var_stream_376 ["var <tt>stream_376</tt>"]
+    style var_stream_376 fill:transparent
     179v1
 end
-subgraph var_stream_379 ["var <tt>stream_379</tt>"]
-    style var_stream_379 fill:transparent
+subgraph var_stream_378 ["var <tt>stream_378</tt>"]
+    style var_stream_378 fill:transparent
     180v1
 end
 subgraph var_stream_380 ["var <tt>stream_380</tt>"]
@@ -1142,17 +1141,17 @@ subgraph var_stream_382 ["var <tt>stream_382</tt>"]
     style var_stream_382 fill:transparent
     183v1
 end
-subgraph var_stream_384 ["var <tt>stream_384</tt>"]
-    style var_stream_384 fill:transparent
+subgraph var_stream_383 ["var <tt>stream_383</tt>"]
+    style var_stream_383 fill:transparent
     184v1
 end
-subgraph var_stream_386 ["var <tt>stream_386</tt>"]
-    style var_stream_386 fill:transparent
+subgraph var_stream_385 ["var <tt>stream_385</tt>"]
+    style var_stream_385 fill:transparent
     185v1
 end
-subgraph var_stream_388 ["var <tt>stream_388</tt>"]
-    style var_stream_388 fill:transparent
-    187v1
+subgraph var_stream_387 ["var <tt>stream_387</tt>"]
+    style var_stream_387 fill:transparent
+    186v1
 end
 subgraph var_stream_389 ["var <tt>stream_389</tt>"]
     style var_stream_389 fill:transparent
@@ -1160,42 +1159,42 @@ subgraph var_stream_389 ["var <tt>stream_389</tt>"]
 end
 subgraph var_stream_39 ["var <tt>stream_39</tt>"]
     style var_stream_39 fill:transparent
-    8v1
+    9v1
 end
 subgraph var_stream_390 ["var <tt>stream_390</tt>"]
     style var_stream_390 fill:transparent
     189v1
 end
-subgraph var_stream_392 ["var <tt>stream_392</tt>"]
-    style var_stream_392 fill:transparent
+subgraph var_stream_391 ["var <tt>stream_391</tt>"]
+    style var_stream_391 fill:transparent
     190v1
 end
-subgraph var_stream_394 ["var <tt>stream_394</tt>"]
-    style var_stream_394 fill:transparent
+subgraph var_stream_393 ["var <tt>stream_393</tt>"]
+    style var_stream_393 fill:transparent
     191v1
 end
-subgraph var_stream_397 ["var <tt>stream_397</tt>"]
-    style var_stream_397 fill:transparent
+subgraph var_stream_395 ["var <tt>stream_395</tt>"]
+    style var_stream_395 fill:transparent
     192v1
 end
-subgraph var_stream_404 ["var <tt>stream_404</tt>"]
-    style var_stream_404 fill:transparent
+subgraph var_stream_398 ["var <tt>stream_398</tt>"]
+    style var_stream_398 fill:transparent
     193v1
 end
 subgraph var_stream_405 ["var <tt>stream_405</tt>"]
     style var_stream_405 fill:transparent
     194v1
 end
-subgraph var_stream_411 ["var <tt>stream_411</tt>"]
-    style var_stream_411 fill:transparent
+subgraph var_stream_406 ["var <tt>stream_406</tt>"]
+    style var_stream_406 fill:transparent
     195v1
 end
-subgraph var_stream_413 ["var <tt>stream_413</tt>"]
-    style var_stream_413 fill:transparent
+subgraph var_stream_412 ["var <tt>stream_412</tt>"]
+    style var_stream_412 fill:transparent
     196v1
 end
-subgraph var_stream_415 ["var <tt>stream_415</tt>"]
-    style var_stream_415 fill:transparent
+subgraph var_stream_414 ["var <tt>stream_414</tt>"]
+    style var_stream_414 fill:transparent
     197v1
 end
 subgraph var_stream_416 ["var <tt>stream_416</tt>"]
@@ -1205,42 +1204,42 @@ end
 subgraph var_stream_417 ["var <tt>stream_417</tt>"]
     style var_stream_417 fill:transparent
     199v1
-    200v1
 end
-subgraph var_stream_419 ["var <tt>stream_419</tt>"]
-    style var_stream_419 fill:transparent
+subgraph var_stream_418 ["var <tt>stream_418</tt>"]
+    style var_stream_418 fill:transparent
+    200v1
     201v1
 end
-subgraph var_stream_421 ["var <tt>stream_421</tt>"]
-    style var_stream_421 fill:transparent
+subgraph var_stream_420 ["var <tt>stream_420</tt>"]
+    style var_stream_420 fill:transparent
     202v1
 end
-subgraph var_stream_423 ["var <tt>stream_423</tt>"]
-    style var_stream_423 fill:transparent
+subgraph var_stream_422 ["var <tt>stream_422</tt>"]
+    style var_stream_422 fill:transparent
     203v1
 end
 subgraph var_stream_424 ["var <tt>stream_424</tt>"]
     style var_stream_424 fill:transparent
     204v1
 end
-subgraph var_stream_428 ["var <tt>stream_428</tt>"]
-    style var_stream_428 fill:transparent
+subgraph var_stream_425 ["var <tt>stream_425</tt>"]
+    style var_stream_425 fill:transparent
     205v1
 end
-subgraph var_stream_430 ["var <tt>stream_430</tt>"]
-    style var_stream_430 fill:transparent
+subgraph var_stream_429 ["var <tt>stream_429</tt>"]
+    style var_stream_429 fill:transparent
     206v1
 end
-subgraph var_stream_434 ["var <tt>stream_434</tt>"]
-    style var_stream_434 fill:transparent
+subgraph var_stream_431 ["var <tt>stream_431</tt>"]
+    style var_stream_431 fill:transparent
     207v1
 end
 subgraph var_stream_435 ["var <tt>stream_435</tt>"]
     style var_stream_435 fill:transparent
     208v1
 end
-subgraph var_stream_438 ["var <tt>stream_438</tt>"]
-    style var_stream_438 fill:transparent
+subgraph var_stream_436 ["var <tt>stream_436</tt>"]
+    style var_stream_436 fill:transparent
     209v1
 end
 subgraph var_stream_439 ["var <tt>stream_439</tt>"]
@@ -1255,8 +1254,8 @@ subgraph var_stream_441 ["var <tt>stream_441</tt>"]
     style var_stream_441 fill:transparent
     212v1
 end
-subgraph var_stream_443 ["var <tt>stream_443</tt>"]
-    style var_stream_443 fill:transparent
+subgraph var_stream_442 ["var <tt>stream_442</tt>"]
+    style var_stream_442 fill:transparent
     213v1
 end
 subgraph var_stream_444 ["var <tt>stream_444</tt>"]
@@ -1267,49 +1266,49 @@ subgraph var_stream_445 ["var <tt>stream_445</tt>"]
     style var_stream_445 fill:transparent
     215v1
 end
-subgraph var_stream_447 ["var <tt>stream_447</tt>"]
-    style var_stream_447 fill:transparent
+subgraph var_stream_446 ["var <tt>stream_446</tt>"]
+    style var_stream_446 fill:transparent
     216v1
 end
-subgraph var_stream_449 ["var <tt>stream_449</tt>"]
-    style var_stream_449 fill:transparent
+subgraph var_stream_448 ["var <tt>stream_448</tt>"]
+    style var_stream_448 fill:transparent
     217v1
 end
 subgraph var_stream_45 ["var <tt>stream_45</tt>"]
     style var_stream_45 fill:transparent
-    9v1
+    10v1
 end
-subgraph var_stream_451 ["var <tt>stream_451</tt>"]
-    style var_stream_451 fill:transparent
+subgraph var_stream_450 ["var <tt>stream_450</tt>"]
+    style var_stream_450 fill:transparent
     218v1
 end
-subgraph var_stream_465 ["var <tt>stream_465</tt>"]
-    style var_stream_465 fill:transparent
-    221v1
-    222v1
+subgraph var_stream_452 ["var <tt>stream_452</tt>"]
+    style var_stream_452 fill:transparent
+    219v1
 end
-subgraph var_stream_467 ["var <tt>stream_467</tt>"]
-    style var_stream_467 fill:transparent
+subgraph var_stream_466 ["var <tt>stream_466</tt>"]
+    style var_stream_466 fill:transparent
+    222v1
     223v1
 end
 subgraph var_stream_468 ["var <tt>stream_468</tt>"]
     style var_stream_468 fill:transparent
     224v1
 end
+subgraph var_stream_469 ["var <tt>stream_469</tt>"]
+    style var_stream_469 fill:transparent
+    225v1
+end
 subgraph var_stream_47 ["var <tt>stream_47</tt>"]
     style var_stream_47 fill:transparent
-    10v1
-end
-subgraph var_stream_470 ["var <tt>stream_470</tt>"]
-    style var_stream_470 fill:transparent
-    225v1
+    11v1
 end
 subgraph var_stream_471 ["var <tt>stream_471</tt>"]
     style var_stream_471 fill:transparent
     226v1
 end
-subgraph var_stream_474 ["var <tt>stream_474</tt>"]
-    style var_stream_474 fill:transparent
+subgraph var_stream_472 ["var <tt>stream_472</tt>"]
+    style var_stream_472 fill:transparent
     227v1
 end
 subgraph var_stream_475 ["var <tt>stream_475</tt>"]
@@ -1320,14 +1319,14 @@ subgraph var_stream_476 ["var <tt>stream_476</tt>"]
     style var_stream_476 fill:transparent
     229v1
 end
-subgraph var_stream_479 ["var <tt>stream_479</tt>"]
-    style var_stream_479 fill:transparent
+subgraph var_stream_477 ["var <tt>stream_477</tt>"]
+    style var_stream_477 fill:transparent
     230v1
 end
 subgraph var_stream_48 ["var <tt>stream_48</tt>"]
     style var_stream_48 fill:transparent
-    11v1
     12v1
+    13v1
 end
 subgraph var_stream_480 ["var <tt>stream_480</tt>"]
     style var_stream_480 fill:transparent
@@ -1337,48 +1336,48 @@ subgraph var_stream_481 ["var <tt>stream_481</tt>"]
     style var_stream_481 fill:transparent
     232v1
 end
-subgraph var_stream_485 ["var <tt>stream_485</tt>"]
-    style var_stream_485 fill:transparent
-    234v1
+subgraph var_stream_482 ["var <tt>stream_482</tt>"]
+    style var_stream_482 fill:transparent
+    233v1
 end
 subgraph var_stream_486 ["var <tt>stream_486</tt>"]
     style var_stream_486 fill:transparent
     235v1
 end
-subgraph var_stream_488 ["var <tt>stream_488</tt>"]
-    style var_stream_488 fill:transparent
+subgraph var_stream_487 ["var <tt>stream_487</tt>"]
+    style var_stream_487 fill:transparent
     236v1
 end
-subgraph var_stream_490 ["var <tt>stream_490</tt>"]
-    style var_stream_490 fill:transparent
-    238v1
+subgraph var_stream_489 ["var <tt>stream_489</tt>"]
+    style var_stream_489 fill:transparent
+    237v1
 end
-subgraph var_stream_495 ["var <tt>stream_495</tt>"]
-    style var_stream_495 fill:transparent
+subgraph var_stream_491 ["var <tt>stream_491</tt>"]
+    style var_stream_491 fill:transparent
     239v1
 end
 subgraph var_stream_496 ["var <tt>stream_496</tt>"]
     style var_stream_496 fill:transparent
     240v1
 end
-subgraph var_stream_499 ["var <tt>stream_499</tt>"]
-    style var_stream_499 fill:transparent
+subgraph var_stream_497 ["var <tt>stream_497</tt>"]
+    style var_stream_497 fill:transparent
     241v1
 end
 subgraph var_stream_50 ["var <tt>stream_50</tt>"]
     style var_stream_50 fill:transparent
-    13v1
+    14v1
 end
 subgraph var_stream_500 ["var <tt>stream_500</tt>"]
     style var_stream_500 fill:transparent
     242v1
 end
-subgraph var_stream_502 ["var <tt>stream_502</tt>"]
-    style var_stream_502 fill:transparent
+subgraph var_stream_501 ["var <tt>stream_501</tt>"]
+    style var_stream_501 fill:transparent
     243v1
 end
-subgraph var_stream_504 ["var <tt>stream_504</tt>"]
-    style var_stream_504 fill:transparent
+subgraph var_stream_503 ["var <tt>stream_503</tt>"]
+    style var_stream_503 fill:transparent
     244v1
 end
 subgraph var_stream_505 ["var <tt>stream_505</tt>"]
@@ -1389,21 +1388,21 @@ subgraph var_stream_506 ["var <tt>stream_506</tt>"]
     style var_stream_506 fill:transparent
     246v1
 end
+subgraph var_stream_507 ["var <tt>stream_507</tt>"]
+    style var_stream_507 fill:transparent
+    247v1
+end
 subgraph var_stream_52 ["var <tt>stream_52</tt>"]
     style var_stream_52 fill:transparent
-    14v1
-end
-subgraph var_stream_534 ["var <tt>stream_534</tt>"]
-    style var_stream_534 fill:transparent
-    248v1
+    15v1
 end
 subgraph var_stream_535 ["var <tt>stream_535</tt>"]
     style var_stream_535 fill:transparent
     249v1
 end
-subgraph var_stream_538 ["var <tt>stream_538</tt>"]
-    style var_stream_538 fill:transparent
-    251v1
+subgraph var_stream_536 ["var <tt>stream_536</tt>"]
+    style var_stream_536 fill:transparent
+    250v1
 end
 subgraph var_stream_539 ["var <tt>stream_539</tt>"]
     style var_stream_539 fill:transparent
@@ -1411,150 +1410,154 @@ subgraph var_stream_539 ["var <tt>stream_539</tt>"]
 end
 subgraph var_stream_54 ["var <tt>stream_54</tt>"]
     style var_stream_54 fill:transparent
-    15v1
+    16v1
 end
 subgraph var_stream_540 ["var <tt>stream_540</tt>"]
     style var_stream_540 fill:transparent
     253v1
 end
-subgraph var_stream_544 ["var <tt>stream_544</tt>"]
-    style var_stream_544 fill:transparent
-    255v1
+subgraph var_stream_541 ["var <tt>stream_541</tt>"]
+    style var_stream_541 fill:transparent
+    254v1
 end
 subgraph var_stream_545 ["var <tt>stream_545</tt>"]
     style var_stream_545 fill:transparent
     256v1
 end
-subgraph var_stream_547 ["var <tt>stream_547</tt>"]
-    style var_stream_547 fill:transparent
+subgraph var_stream_546 ["var <tt>stream_546</tt>"]
+    style var_stream_546 fill:transparent
     257v1
 end
-subgraph var_stream_549 ["var <tt>stream_549</tt>"]
-    style var_stream_549 fill:transparent
+subgraph var_stream_548 ["var <tt>stream_548</tt>"]
+    style var_stream_548 fill:transparent
     258v1
 end
 subgraph var_stream_55 ["var <tt>stream_55</tt>"]
     style var_stream_55 fill:transparent
-    16v1
+    17v1
 end
-subgraph var_stream_552 ["var <tt>stream_552</tt>"]
-    style var_stream_552 fill:transparent
+subgraph var_stream_550 ["var <tt>stream_550</tt>"]
+    style var_stream_550 fill:transparent
     259v1
 end
-subgraph var_stream_556 ["var <tt>stream_556</tt>"]
-    style var_stream_556 fill:transparent
+subgraph var_stream_553 ["var <tt>stream_553</tt>"]
+    style var_stream_553 fill:transparent
     260v1
 end
 subgraph var_stream_557 ["var <tt>stream_557</tt>"]
     style var_stream_557 fill:transparent
     261v1
 end
-subgraph var_stream_559 ["var <tt>stream_559</tt>"]
-    style var_stream_559 fill:transparent
+subgraph var_stream_558 ["var <tt>stream_558</tt>"]
+    style var_stream_558 fill:transparent
     262v1
 end
 subgraph var_stream_56 ["var <tt>stream_56</tt>"]
     style var_stream_56 fill:transparent
-    18v1
+    19v1
 end
-subgraph var_stream_561 ["var <tt>stream_561</tt>"]
-    style var_stream_561 fill:transparent
+subgraph var_stream_560 ["var <tt>stream_560</tt>"]
+    style var_stream_560 fill:transparent
     263v1
+end
+subgraph var_stream_562 ["var <tt>stream_562</tt>"]
+    style var_stream_562 fill:transparent
+    264v1
 end
 subgraph var_stream_57 ["var <tt>stream_57</tt>"]
     style var_stream_57 fill:transparent
-    19v1
+    20v1
 end
 subgraph var_stream_59 ["var <tt>stream_59</tt>"]
     style var_stream_59 fill:transparent
-    20v1
+    21v1
 end
 subgraph var_stream_61 ["var <tt>stream_61</tt>"]
     style var_stream_61 fill:transparent
-    21v1
+    22v1
 end
 subgraph var_stream_64 ["var <tt>stream_64</tt>"]
     style var_stream_64 fill:transparent
-    22v1
+    23v1
 end
 subgraph var_stream_67 ["var <tt>stream_67</tt>"]
     style var_stream_67 fill:transparent
-    23v1
+    24v1
 end
 subgraph var_stream_68 ["var <tt>stream_68</tt>"]
     style var_stream_68 fill:transparent
-    24v1
+    25v1
 end
 subgraph var_stream_71 ["var <tt>stream_71</tt>"]
     style var_stream_71 fill:transparent
-    25v1
+    26v1
 end
 subgraph var_stream_73 ["var <tt>stream_73</tt>"]
     style var_stream_73 fill:transparent
-    26v1
+    27v1
 end
 subgraph var_stream_74 ["var <tt>stream_74</tt>"]
     style var_stream_74 fill:transparent
-    27v1
+    28v1
 end
 subgraph var_stream_75 ["var <tt>stream_75</tt>"]
     style var_stream_75 fill:transparent
-    28v1
+    29v1
 end
 subgraph var_stream_76 ["var <tt>stream_76</tt>"]
     style var_stream_76 fill:transparent
-    29v1
+    30v1
 end
 subgraph var_stream_79 ["var <tt>stream_79</tt>"]
     style var_stream_79 fill:transparent
-    30v1
+    31v1
 end
 subgraph var_stream_81 ["var <tt>stream_81</tt>"]
     style var_stream_81 fill:transparent
-    31v1
+    32v1
 end
 subgraph var_stream_82 ["var <tt>stream_82</tt>"]
     style var_stream_82 fill:transparent
-    32v1
+    33v1
 end
 subgraph var_stream_83 ["var <tt>stream_83</tt>"]
     style var_stream_83 fill:transparent
-    33v1
+    34v1
 end
 subgraph var_stream_84 ["var <tt>stream_84</tt>"]
     style var_stream_84 fill:transparent
-    34v1
+    35v1
 end
 subgraph var_stream_85 ["var <tt>stream_85</tt>"]
     style var_stream_85 fill:transparent
-    35v1
+    36v1
 end
 subgraph var_stream_86 ["var <tt>stream_86</tt>"]
     style var_stream_86 fill:transparent
-    36v1
     37v1
+    38v1
 end
 subgraph var_stream_88 ["var <tt>stream_88</tt>"]
     style var_stream_88 fill:transparent
-    38v1
+    39v1
 end
 subgraph var_stream_90 ["var <tt>stream_90</tt>"]
     style var_stream_90 fill:transparent
-    39v1
+    40v1
 end
 subgraph var_stream_91 ["var <tt>stream_91</tt>"]
     style var_stream_91 fill:transparent
-    40v1
+    41v1
 end
 subgraph var_stream_92 ["var <tt>stream_92</tt>"]
     style var_stream_92 fill:transparent
-    41v1
+    42v1
 end
 subgraph var_stream_93 ["var <tt>stream_93</tt>"]
     style var_stream_93 fill:transparent
-    42v1
+    43v1
 end
 subgraph var_stream_98 ["var <tt>stream_98</tt>"]
     style var_stream_98 fill:transparent
-    43v1
+    44v1
 end


### PR DESCRIPTION
We are deprecating the ability for arbitrary code to use `from_raw_id` unless it has been explicitly programmed to only support fixed-size "legacy" / localhost cluster deployments. This updates the Paxos implementation to not rely on this API.