### PR TITLE
fix(hydro_lang)!: require matching boundedness to capture `by_ref`/`by_mut` handles in closures

### DIFF
--- a/docs/docs/hydro/reference/state-management/references-mutations.md
+++ b/docs/docs/hydro/reference/state-management/references-mutations.md
@@ -8,7 +8,7 @@ Hydro's dataflow operators like `zip` and `cross_singleton` combine collections 
 
 ## Reference Handles with `by_ref`
 
-Calling `.by_ref()` on a live collection returns a handle that can be captured by any `q!()` closure at the same location. At runtime, the handle resolves to a shared reference to the collection's current contents:
+Calling `.by_ref()` on a live collection returns a handle that can be captured by `q!()` closures operating on collections at the same location with the same boundedness. At runtime, the handle resolves to a shared reference to the collection's current contents:
 
 | Collection | Handle resolves to |
 |---|---|
@@ -41,6 +41,8 @@ let shifted = process
 ```
 
 Reference handles require the collection to be [**bounded**](../correctness/bounded-unbounded.md). A bounded collection's contents are fully determined, so reading it as a whole is deterministic. Reading an *unbounded* collection this way would expose whatever portion happened to have arrived — a non-deterministic result. This restriction is enforced at compile time.
+
+The closure capturing the handle must itself run on a **bounded** collection at the same location. A bounded collection is only materialized on the first tick, while closures on unbounded collections keep running on later ticks — where the referenced value no longer exists, so accessing the handle would crash. This is also enforced at compile time: capturing a handle in a closure on an unbounded collection is rejected.
 
 In practice, most reference handles appear inside [slice blocks](./slices.mdx): the batches and snapshots revealed by [slice hooks](./slice-hooks.md) are bounded, so `by_ref` is the natural way to read a snapshot of state while processing a batch of requests:
 

--- a/hydro_lang/src/handoff_ref.rs
+++ b/hydro_lang/src/handoff_ref.rs
@@ -4,6 +4,13 @@
 //! registers itself with the current capture scope. At codegen time, the IR node is lowered
 //! to the corresponding DFIR pseudo-operator (`singleton()`, `optional()`, or `handoff()`),
 //! and the reference resolves to the appropriate borrow type.
+//!
+//! Each handle tracks the [`Location`] **and** the boundedness of the collection it refers to
+//! (see [`OperatorContext`]). A handle can only be captured inside closures passed to operators
+//! on collections with a matching location and boundedness. This is required for soundness:
+//! a bounded collection is only materialized on the first tick, while closures on unbounded
+//! collections continue to run on later ticks, where the referenced value no longer exists and
+//! accessing it would crash at runtime.
 
 use std::cell::RefCell;
 use std::marker::PhantomData;
@@ -14,6 +21,7 @@ use quote::quote;
 use stageleft::runtime_support::{FreeVariableWithContextWithProps, QuoteTokens};
 
 use crate::compile::ir::{AccessCounter, HydroNode, SharedNode};
+use crate::live_collections::OperatorContext;
 use crate::location::Location;
 
 /// Determines which DFIR pseudo-operator a reference node lowers to.
@@ -128,12 +136,12 @@ macro_rules! define_handoff_ref {
     ) => {
         $(
             $(#[$meta])*
-            pub struct $name<'a, 'slf, T, L> {
+            pub struct $name<'a, 'slf, T, L, B> {
                 pub(crate) ir_node: &'slf RefCell<HydroNode>,
-                _phantom: PhantomData<(&'a T, L)>,
+                _phantom: PhantomData<(&'a T, L, B)>,
             }
 
-            impl<'slf, T, L> $name<'_, 'slf, T, L> {
+            impl<'slf, T, L, B> $name<'_, 'slf, T, L, B> {
                 /// Creates a new reference handle from an IR node cell.
                 pub(crate) fn new(ir_node: &'slf RefCell<HydroNode>) -> Self {
                     Self {
@@ -143,20 +151,21 @@ macro_rules! define_handoff_ref {
                 }
             }
 
-            impl<T, L> Copy for $name<'_, '_, T, L> {}
-            impl<T, L> Clone for $name<'_, '_, T, L> {
+            impl<T, L, B> Copy for $name<'_, '_, T, L, B> {}
+            impl<T, L, B> Clone for $name<'_, '_, T, L, B> {
                 fn clone(&self) -> Self {
                     *self
                 }
             }
 
-            impl<'a, 'slf, T: 'a, L> FreeVariableWithContextWithProps<L, ()> for $name<'a, 'slf, T, L>
+            impl<'a, 'slf, T: 'a, L, B> FreeVariableWithContextWithProps<OperatorContext<L, B>, ()>
+                for $name<'a, 'slf, T, L, B>
             where
                 L: Location<'a>,
             {
                 type O = $output;
 
-                fn to_tokens(self, _ctx: &L) -> (QuoteTokens, ()) {
+                fn to_tokens(self, _ctx: &OperatorContext<L, B>) -> (QuoteTokens, ()) {
                     let ident = register_handoff_ref(
                         self.ir_node,
                         $is_mut,

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -10,6 +10,7 @@ use std::rc::Rc;
 use sealed::sealed;
 use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 
+use super::OperatorContext;
 use super::boundedness::{Bounded, Boundedness, IsBounded, Unbounded};
 use super::keyed_stream::KeyedStream;
 use super::optional::Optional;
@@ -482,17 +483,22 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
     /// ```
     pub fn map<U, F>(
         self,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B::UnderlyingBound>> + Copy,
     ) -> KeyedSingleton<K, U, L, B::EraseMonotonic>
     where
         F: Fn(V) -> U + 'a,
     {
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B::UnderlyingBound>| {
+                f.splice_fn1_ctx(ctx)
+            });
         let map_f = q!({
             let orig = f;
             move |(k, v)| (k, orig(v))
         })
-        .splice_fn1_ctx::<(K, V), (K, U)>(&self.location)
+        .splice_fn1_ctx::<(K, V), (K, U)>(&OperatorContext::<L, B::UnderlyingBound>::new(
+            &self.location,
+        ))
         .into();
 
         KeyedSingleton::new(
@@ -542,13 +548,16 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
     /// ```
     pub fn map_with_key<U, F>(
         self,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B::UnderlyingBound>> + Copy,
     ) -> KeyedSingleton<K, U, L, B::EraseMonotonic>
     where
         F: Fn((K, V)) -> U + 'a,
         K: Clone,
     {
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B::UnderlyingBound>| {
+                f.splice_fn1_ctx(ctx)
+            });
         let map_f = q!({
             let orig = f;
             move |(k, v)| {
@@ -556,7 +565,9 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound> KeyedSingleton<K, V, L, 
                 (k, out)
             }
         })
-        .splice_fn1_ctx::<(K, V), (K, U)>(&self.location)
+        .splice_fn1_ctx::<(K, V), (K, U)>(&OperatorContext::<L, B::UnderlyingBound>::new(
+            &self.location,
+        ))
         .into();
 
         KeyedSingleton::new(
@@ -1330,7 +1341,9 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
     /// ```
     pub fn values(self) -> Stream<V, L, B::UnderlyingBound, NoOrder, ExactlyOnce> {
         let map_f = q!(|(_, v)| v)
-            .splice_fn1_ctx::<(K, V), V>(&self.location)
+            .splice_fn1_ctx::<(K, V), V>(&OperatorContext::<L, B::UnderlyingBound>::new(
+                &self.location,
+            ))
             .into();
 
         Stream::new(
@@ -1456,16 +1469,24 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
     /// # }));
     /// # }
     /// ```
-    pub fn inspect<F>(self, f: impl IntoQuotedMut<'a, F, L> + Copy) -> Self
+    pub fn inspect<F>(
+        self,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B::UnderlyingBound>> + Copy,
+    ) -> Self
     where
         F: Fn(&V) + 'a,
     {
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_borrow_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B::UnderlyingBound>| {
+                f.splice_fn1_borrow_ctx(ctx)
+            });
         let inspect_f = q!({
             let orig = f;
             move |t: &(_, _)| orig(&t.1)
         })
-        .splice_fn1_borrow_ctx::<(K, V), ()>(&self.location)
+        .splice_fn1_borrow_ctx::<(K, V), ()>(&OperatorContext::<L, B::UnderlyingBound>::new(
+            &self.location,
+        ))
         .into();
 
         KeyedSingleton::new(
@@ -1504,11 +1525,18 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
     /// # }));
     /// # }
     /// ```
-    pub fn inspect_with_key<F>(self, f: impl IntoQuotedMut<'a, F, L>) -> Self
+    pub fn inspect_with_key<F>(
+        self,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B::UnderlyingBound>>,
+    ) -> Self
     where
         F: Fn(&(K, V)) + 'a,
     {
-        let inspect_f = f.splice_fn1_borrow_ctx::<(K, V), ()>(&self.location).into();
+        let inspect_f = f
+            .splice_fn1_borrow_ctx::<(K, V), ()>(&OperatorContext::<L, B::UnderlyingBound>::new(
+                &self.location,
+            ))
+            .into();
 
         KeyedSingleton::new(
             self.location.clone(),
@@ -1813,16 +1841,24 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn filter<F>(self, f: impl IntoQuotedMut<'a, F, L> + Copy) -> KeyedSingleton<K, V, L, B>
+    pub fn filter<F>(
+        self,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B::UnderlyingBound>> + Copy,
+    ) -> KeyedSingleton<K, V, L, B>
     where
         F: Fn(&V) -> bool + 'a,
     {
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_borrow_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B::UnderlyingBound>| {
+                f.splice_fn1_borrow_ctx(ctx)
+            });
         let filter_f = q!({
             let orig = f;
             move |t: &(_, _)| orig(&t.1)
         })
-        .splice_fn1_borrow_ctx::<(K, V), bool>(&self.location)
+        .splice_fn1_borrow_ctx::<(K, V), bool>(&OperatorContext::<L, B::UnderlyingBound>::new(
+            &self.location,
+        ))
         .into();
 
         KeyedSingleton::new(
@@ -1870,17 +1906,22 @@ where
     /// ```
     pub fn filter_map<F, U>(
         self,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B::UnderlyingBound>> + Copy,
     ) -> KeyedSingleton<K, U, L, B::EraseMonotonic>
     where
         F: Fn(V) -> Option<U> + 'a,
     {
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B::UnderlyingBound>| {
+                f.splice_fn1_ctx(ctx)
+            });
         let filter_map_f = q!({
             let orig = f;
             move |(k, v)| orig(v).map(|o| (k, o))
         })
-        .splice_fn1_ctx::<(K, V), Option<(K, U)>>(&self.location)
+        .splice_fn1_ctx::<(K, V), Option<(K, U)>>(&OperatorContext::<L, B::UnderlyingBound>::new(
+            &self.location,
+        ))
         .into();
 
         KeyedSingleton::new(

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -9,6 +9,7 @@ use std::rc::Rc;
 
 use stageleft::{IntoQuotedMut, QuotedWithContext, QuotedWithContextWithProps, q};
 
+use super::OperatorContext;
 use super::boundedness::{Bounded, Boundedness, IsBounded, Unbounded};
 use super::keyed_singleton::KeyedSingleton;
 use super::optional::Optional;
@@ -820,16 +821,20 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// # }));
     /// # }
     /// ```
-    pub fn map<U, F>(self, f: impl IntoQuotedMut<'a, F, L> + Copy) -> KeyedStream<K, U, L, B, O, R>
+    pub fn map<U, F>(
+        self,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>> + Copy,
+    ) -> KeyedStream<K, U, L, B, O, R>
     where
         F: Fn(V) -> U + 'a,
     {
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| f.splice_fn1_ctx(ctx));
         let map_f = q!({
             let orig = f;
             move |(k, v)| (k, orig(v))
         })
-        .splice_fn1_ctx::<(K, V), (K, U)>(&self.location)
+        .splice_fn1_ctx::<(K, V), (K, U)>(&OperatorContext::<L, B>::new(&self.location))
         .into();
 
         KeyedStream::new(
@@ -874,13 +879,14 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// ```
     pub fn map_with_key<U, F>(
         self,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>> + Copy,
     ) -> KeyedStream<K, U, L, B, O, R>
     where
         F: Fn((K, V)) -> U + 'a,
         K: Clone,
     {
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| f.splice_fn1_ctx(ctx));
         let map_f = q!({
             let orig = f;
             move |(k, v)| {
@@ -888,7 +894,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
                 (k, out)
             }
         })
-        .splice_fn1_ctx::<(K, V), (K, U)>(&self.location)
+        .splice_fn1_ctx::<(K, V), (K, U)>(&OperatorContext::<L, B>::new(&self.location))
         .into();
 
         KeyedStream::new(
@@ -931,12 +937,13 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// ```
     pub fn prefix_key<K2, F>(
         self,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>> + Copy,
     ) -> KeyedStream<(K2, K), V, L, B, O, R>
     where
         F: Fn(&(K, V)) -> K2 + 'a,
     {
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_borrow_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| f.splice_fn1_borrow_ctx(ctx));
         let map_f = q!({
             let orig = f;
             move |kv| {
@@ -944,7 +951,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
                 ((out, kv.0), kv.1)
             }
         })
-        .splice_fn1_ctx::<(K, V), ((K2, K), V)>(&self.location)
+        .splice_fn1_ctx::<(K, V), ((K2, K), V)>(&OperatorContext::<L, B>::new(&self.location))
         .into();
 
         KeyedStream::new(
@@ -988,16 +995,20 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// # }));
     /// # }
     /// ```
-    pub fn filter<F>(self, f: impl IntoQuotedMut<'a, F, L> + Copy) -> KeyedStream<K, V, L, B, O, R>
+    pub fn filter<F>(
+        self,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>> + Copy,
+    ) -> KeyedStream<K, V, L, B, O, R>
     where
         F: Fn(&V) -> bool + 'a,
     {
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_borrow_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| f.splice_fn1_borrow_ctx(ctx));
         let filter_f = q!({
             let orig = f;
             move |t: &(_, _)| orig(&t.1)
         })
-        .splice_fn1_borrow_ctx::<(K, V), bool>(&self.location)
+        .splice_fn1_borrow_ctx::<(K, V), bool>(&OperatorContext::<L, B>::new(&self.location))
         .into();
 
         KeyedStream::new(
@@ -1041,13 +1052,13 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// ```
     pub fn filter_with_key<F>(
         self,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>> + Copy,
     ) -> KeyedStream<K, V, L, B, O, R>
     where
         F: Fn(&(K, V)) -> bool + 'a,
     {
         let filter_f = f
-            .splice_fn1_borrow_ctx::<(K, V), bool>(&self.location)
+            .splice_fn1_borrow_ctx::<(K, V), bool>(&OperatorContext::<L, B>::new(&self.location))
             .into();
 
         KeyedStream::new(
@@ -1088,17 +1099,18 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// ```
     pub fn filter_map<U, F>(
         self,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>> + Copy,
     ) -> KeyedStream<K, U, L, B, O, R>
     where
         F: Fn(V) -> Option<U> + 'a,
     {
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| f.splice_fn1_ctx(ctx));
         let filter_map_f = q!({
             let orig = f;
             move |(k, v)| orig(v).map(|o| (k, o))
         })
-        .splice_fn1_ctx::<(K, V), Option<(K, U)>>(&self.location)
+        .splice_fn1_ctx::<(K, V), Option<(K, U)>>(&OperatorContext::<L, B>::new(&self.location))
         .into();
 
         KeyedStream::new(
@@ -1141,13 +1153,14 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// ```
     pub fn filter_map_with_key<U, F>(
         self,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>> + Copy,
     ) -> KeyedStream<K, U, L, B, O, R>
     where
         F: Fn((K, V)) -> Option<U> + 'a,
         K: Clone,
     {
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| f.splice_fn1_ctx(ctx));
         let filter_map_f = q!({
             let orig = f;
             move |(k, v)| {
@@ -1155,7 +1168,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
                 out.map(|o| (k, o))
             }
         })
-        .splice_fn1_ctx::<(K, V), Option<(K, U)>>(&self.location)
+        .splice_fn1_ctx::<(K, V), Option<(K, U)>>(&OperatorContext::<L, B>::new(&self.location))
         .into();
 
         KeyedStream::new(
@@ -1254,19 +1267,20 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// ```
     pub fn flat_map_ordered<U, I, F>(
         self,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>> + Copy,
     ) -> KeyedStream<K, U, L, B, O, R>
     where
         I: IntoIterator<Item = U>,
         F: Fn(V) -> I + 'a,
         K: Clone,
     {
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| f.splice_fn1_ctx(ctx));
         let flat_map_f = q!({
             let orig = f;
             move |(k, v)| orig(v).into_iter().map(move |u| (Clone::clone(&k), u))
         })
-        .splice_fn1_ctx::<(K, V), _>(&self.location)
+        .splice_fn1_ctx::<(K, V), _>(&OperatorContext::<L, B>::new(&self.location))
         .into();
 
         KeyedStream::new(
@@ -1311,19 +1325,20 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// ```
     pub fn flat_map_unordered<U, I, F>(
         self,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>> + Copy,
     ) -> KeyedStream<K, U, L, B, NoOrder, R>
     where
         I: IntoIterator<Item = U>,
         F: Fn(V) -> I + 'a,
         K: Clone,
     {
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| f.splice_fn1_ctx(ctx));
         let flat_map_f = q!({
             let orig = f;
             move |(k, v)| orig(v).into_iter().map(move |u| (Clone::clone(&k), u))
         })
-        .splice_fn1_ctx::<(K, V), _>(&self.location)
+        .splice_fn1_ctx::<(K, V), _>(&OperatorContext::<L, B>::new(&self.location))
         .into();
 
         KeyedStream::new(
@@ -1436,16 +1451,17 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// # }));
     /// # }
     /// ```
-    pub fn inspect<F>(self, f: impl IntoQuotedMut<'a, F, L> + Copy) -> Self
+    pub fn inspect<F>(self, f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>> + Copy) -> Self
     where
         F: Fn(&V) + 'a,
     {
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn1_borrow_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| f.splice_fn1_borrow_ctx(ctx));
         let inspect_f = q!({
             let orig = f;
             move |t: &(_, _)| orig(&t.1)
         })
-        .splice_fn1_borrow_ctx::<(K, V), ()>(&self.location)
+        .splice_fn1_borrow_ctx::<(K, V), ()>(&OperatorContext::<L, B>::new(&self.location))
         .into();
 
         KeyedStream::new(
@@ -1483,11 +1499,13 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// # }));
     /// # }
     /// ```
-    pub fn inspect_with_key<F>(self, f: impl IntoQuotedMut<'a, F, L>) -> Self
+    pub fn inspect_with_key<F>(self, f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>>) -> Self
     where
         F: Fn(&(K, V)) + 'a,
     {
-        let inspect_f = f.splice_fn1_borrow_ctx::<(K, V), ()>(&self.location).into();
+        let inspect_f = f
+            .splice_fn1_borrow_ctx::<(K, V), ()>(&OperatorContext::<L, B>::new(&self.location))
+            .into();
 
         KeyedStream::new(
             self.location.clone(),
@@ -1521,7 +1539,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// If the function returns `None`, the stream is terminated and no more elements are processed.
     ///
     /// The `init` and `f` closures may capture bounded singletons, optionals, or streams by
-    /// reference via [`by_ref()`](crate::live_collections::Singleton::by_ref).
+    /// reference via [`by_ref()`](crate::live_collections::Singleton::by_ref), as long as the
+    /// referenced collection has the same location and boundedness as this stream.
     ///
     /// # Example
     /// ```rust
@@ -1553,8 +1572,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// ```
     pub fn scan<A, U, I, F>(
         self,
-        init: impl IntoQuotedMut<'a, I, L> + Copy,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
+        init: impl IntoQuotedMut<'a, I, OperatorContext<L, B>> + Copy,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>> + Copy,
     ) -> KeyedStream<K, U, L, B, TotalOrder, ExactlyOnce>
     where
         O: IsOrdered,
@@ -1563,7 +1582,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         I: Fn() -> A + 'a,
         F: Fn(&mut A, V) -> Option<U> + 'a,
     {
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn2_borrow_mut_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| f.splice_fn2_borrow_mut_ctx(ctx));
         self.make_totally_ordered().make_exactly_once().generator(
             init,
             q!({
@@ -1590,7 +1610,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// should be processed.
     ///
     /// The `init` and `f` closures may capture bounded singletons, optionals, or streams by
-    /// reference via [`by_ref()`](crate::live_collections::Singleton::by_ref).
+    /// reference via [`by_ref()`](crate::live_collections::Singleton::by_ref), as long as the
+    /// referenced collection has the same location and boundedness as this stream.
     ///
     /// # Example
     /// ```rust
@@ -1632,8 +1653,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// ```
     pub fn generator<A, U, I, F>(
         self,
-        init: impl IntoQuotedMut<'a, I, L> + Copy,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
+        init: impl IntoQuotedMut<'a, I, OperatorContext<L, B>> + Copy,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>> + Copy,
     ) -> KeyedStream<K, U, L, B, TotalOrder, ExactlyOnce>
     where
         O: IsOrdered,
@@ -1642,14 +1663,18 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         I: Fn() -> A + 'a,
         F: Fn(&mut A, V) -> Generate<U> + 'a,
     {
-        let init: ManualExpr<I, _> = ManualExpr::new(move |ctx: &L| init.splice_fn0_ctx(ctx));
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn2_borrow_mut_ctx(ctx));
+        let init: ManualExpr<I, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| init.splice_fn0_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| f.splice_fn2_borrow_mut_ctx(ctx));
 
         let this = self.make_totally_ordered().make_exactly_once();
 
         let scan_init = crate::handoff_ref::with_ref_capture(|| {
             q!(|| HashMap::new())
-                .splice_fn0_ctx::<HashMap<K, Option<A>>>(&this.location)
+                .splice_fn0_ctx::<HashMap<K, Option<A>>>(&OperatorContext::<L, B>::new(
+                    &this.location,
+                ))
                 .into()
         });
         let scan_f = crate::handoff_ref::with_ref_capture(|| {
@@ -1672,7 +1697,9 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
                     Some(None)
                 }
             })
-            .splice_fn2_borrow_mut_ctx::<HashMap<K, Option<A>>, (K, V), _>(&this.location)
+            .splice_fn2_borrow_mut_ctx::<HashMap<K, Option<A>>, (K, V), _>(
+                &OperatorContext::<L, B>::new(&this.location),
+            )
             .into()
         });
 
@@ -1690,7 +1717,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         };
 
         let flatten_f = q!(|d| d)
-            .splice_fn1_ctx::<Option<(K, U)>, _>(&this.location)
+            .splice_fn1_ctx::<Option<(K, U)>, _>(&OperatorContext::<L, B>::new(&this.location))
             .into();
         let flatten_node = HydroNode::FlatMap {
             f: flatten_f,
@@ -1745,8 +1772,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// ```
     pub fn fold_early_stop<A, I, F>(
         self,
-        init: impl IntoQuotedMut<'a, I, L> + Copy,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
+        init: impl IntoQuotedMut<'a, I, OperatorContext<L, B>> + Copy,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>> + Copy,
     ) -> KeyedSingleton<K, A, L, B::WithBoundedValue>
     where
         O: IsOrdered,
@@ -1755,8 +1782,10 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         I: Fn() -> A + 'a,
         F: Fn(&mut A, V) -> bool + 'a,
     {
-        let init: ManualExpr<I, _> = ManualExpr::new(move |ctx: &L| init.splice_fn0_ctx(ctx));
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn2_borrow_mut_ctx(ctx));
+        let init: ManualExpr<I, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| init.splice_fn0_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| f.splice_fn2_borrow_mut_ctx(ctx));
         let out_without_bound_cast = self.generator(
             q!(move || Some(init())),
             q!(move |key_state, v| {
@@ -1851,7 +1880,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// ```
     pub fn limit(
         self,
-        n: impl QuotedWithContext<'a, usize, L> + Copy + 'a,
+        n: impl QuotedWithContext<'a, usize, OperatorContext<L, B>> + Copy + 'a,
     ) -> KeyedStream<K, V, L, B, TotalOrder, ExactlyOnce>
     where
         O: IsOrdered,
@@ -2006,8 +2035,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// ```
     pub fn fold<A, I: Fn() -> A + 'a, F: 'a + Fn(&mut A, V), C, Idemp, M, B2: KeyedSingletonBound>(
         self,
-        init: impl IntoQuotedMut<'a, I, L>,
-        comb: impl IntoQuotedMut<'a, F, L, AggFuncAlgebra<C, Idemp, M>>,
+        init: impl IntoQuotedMut<'a, I, OperatorContext<L, B>>,
+        comb: impl IntoQuotedMut<'a, F, OperatorContext<L, B>, AggFuncAlgebra<C, Idemp, M>>,
     ) -> KeyedSingleton<K, A, L, B2>
     where
         K: Eq + Hash,
@@ -2015,8 +2044,11 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         Idemp: ValidIdempotenceFor<R>,
         B: ApplyMonotoneKeyedStream<M, B2>,
     {
-        let init = init.splice_fn0_ctx(&self.location).into();
-        let (comb, proof) = comb.splice_fn2_borrow_mut_ctx_props(&self.location);
+        let init = init
+            .splice_fn0_ctx(&OperatorContext::<L, B>::new(&self.location))
+            .into();
+        let (comb, proof) =
+            comb.splice_fn2_borrow_mut_ctx_props(&OperatorContext::<L, B>::new(&self.location));
         proof.register_proof(&comb);
 
         let retried = self
@@ -2072,14 +2104,15 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     /// ```
     pub fn reduce<F: Fn(&mut V, V) + 'a, C, Idemp>(
         self,
-        comb: impl IntoQuotedMut<'a, F, L, AggFuncAlgebra<C, Idemp>>,
+        comb: impl IntoQuotedMut<'a, F, OperatorContext<L, B>, AggFuncAlgebra<C, Idemp>>,
     ) -> KeyedSingleton<K, V, L, B>
     where
         K: Eq + Hash,
         C: ValidCommutativityFor<O>,
         Idemp: ValidIdempotenceFor<R>,
     {
-        let (f, proof) = comb.splice_fn2_borrow_mut_ctx_props(&self.location);
+        let (f, proof) =
+            comb.splice_fn2_borrow_mut_ctx_props(&OperatorContext::<L, B>::new(&self.location));
         proof.register_proof(&f);
 
         let ordered = self
@@ -2130,7 +2163,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     pub fn reduce_watermark<O2, F, C, Idemp>(
         self,
         other: impl Into<Optional<O2, Tick<L::Root>, Bounded>>,
-        comb: impl IntoQuotedMut<'a, F, L, AggFuncAlgebra<C, Idemp>>,
+        comb: impl IntoQuotedMut<'a, F, OperatorContext<L, B>, AggFuncAlgebra<C, Idemp>>,
     ) -> KeyedSingleton<K, V, L, B>
     where
         K: Eq + Hash,
@@ -2141,7 +2174,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     {
         let other: Optional<O2, Tick<L::Root>, Bounded> = other.into();
         check_matching_location(&self.location.root(), other.location.outer());
-        let (f, proof) = comb.splice_fn2_borrow_mut_ctx_props(&self.location);
+        let (f, proof) =
+            comb.splice_fn2_borrow_mut_ctx_props(&OperatorContext::<L, B>::new(&self.location));
         proof.register_proof(&f);
 
         let ordered = self

--- a/hydro_lang/src/live_collections/mod.rs
+++ b/hydro_lang/src/live_collections/mod.rs
@@ -16,6 +16,60 @@
 
 pub mod boundedness;
 
+/// The context type for quoted closures (`q!(...)`) passed to operators on live collections.
+///
+/// This bundles the [`crate::location::Location`] where the collection is materialized
+/// with a marker for the [`boundedness::Boundedness`] of the collection the closure operates on.
+/// Free variables captured inside such closures can constrain both components. For example,
+/// reference handles created via `by_ref()` / `by_mut()` (see [`crate::handoff_ref`]) require
+/// that both the location *and* the boundedness of the referenced collection match those of the
+/// collection whose operator captures the reference. This prevents, e.g., a reference to a
+/// [`boundedness::Bounded`] singleton from being accessed inside a `map` over an
+/// [`boundedness::Unbounded`] stream: the singleton is only materialized on the first tick,
+/// while the closure keeps running on later ticks, where accessing the reference would crash.
+pub struct OperatorContext<L, B>(L, std::marker::PhantomData<B>);
+
+impl<L: Clone, B> OperatorContext<L, B> {
+    /// Constructs an [`OperatorContext`] value for splicing quoted closures for an operator on
+    /// a collection materialized at `location` with boundedness `B`.
+    pub(crate) fn new(location: &L) -> Self {
+        OperatorContext(location.clone(), std::marker::PhantomData)
+    }
+}
+
+/// A context type for quoted snippets (`q!(...)`) from which a [`crate::location::Location`]
+/// can be extracted.
+///
+/// This is implemented both for bare locations (used when splicing quoted *values*, such as
+/// the argument to [`crate::location::Location::source_iter`]) and for [`OperatorContext`]
+/// (used when splicing quoted *closures* passed to operators on live collections). Free
+/// variables that only depend on the location of the splice site (such as
+/// [`crate::location::cluster::CLUSTER_SELF_ID`]) are generic over this trait so that they can
+/// be captured in both kinds of quoted snippets.
+pub trait ContextWithLocation<'a> {
+    /// The location type of this context.
+    type Location: crate::location::Location<'a>;
+
+    /// Extracts the location of the splice site from this context.
+    fn context_location(&self) -> &Self::Location;
+}
+
+impl<'a, L: crate::location::Location<'a>> ContextWithLocation<'a> for L {
+    type Location = L;
+
+    fn context_location(&self) -> &L {
+        self
+    }
+}
+
+impl<'a, L: crate::location::Location<'a>, B> ContextWithLocation<'a> for OperatorContext<L, B> {
+    type Location = L;
+
+    fn context_location(&self) -> &L {
+        &self.0
+    }
+}
+
 pub mod keyed_singleton;
 #[doc(inline)]
 pub use keyed_singleton::KeyedSingleton;

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 use syn::parse_quote;
 
+use super::OperatorContext;
 use super::boundedness::{Bounded, Boundedness, IsBounded, Unbounded};
 use super::singleton::Singleton;
 use super::stream::{AtLeastOnce, ExactlyOnce, NoOrder, Stream, TotalOrder};
@@ -304,7 +305,10 @@ where
     /// closures. The handle resolves to `&Option<T>` at runtime.
     ///
     /// The optional must be bounded, otherwise reading it would be non-deterministic.
-    pub fn by_ref(&self) -> crate::handoff_ref::OptionalRef<'a, '_, T, L>
+    /// The handle can only be captured in closures passed to operators on collections at
+    /// the same location with **matching boundedness**; capturing it in a closure over an
+    /// unbounded collection is rejected at compile time.
+    pub fn by_ref(&self) -> crate::handoff_ref::OptionalRef<'a, '_, T, L, B>
     where
         B: IsBounded,
     {
@@ -313,7 +317,7 @@ where
 
     /// Returns a mutable reference handle to this optional that can be captured inside `q!()`
     /// closures. The handle resolves to `&mut Option<T>` at runtime.
-    pub fn by_mut(&self) -> crate::handoff_ref::OptionalMut<'a, '_, T, L>
+    pub fn by_mut(&self) -> crate::handoff_ref::OptionalMut<'a, '_, T, L, B>
     where
         B: IsBounded,
     {
@@ -400,11 +404,13 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn map<U, F>(self, f: impl IntoQuotedMut<'a, F, L>) -> Optional<U, L, B>
+    pub fn map<U, F>(self, f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>>) -> Optional<U, L, B>
     where
         F: Fn(T) -> U + 'a,
     {
-        let f = f.splice_fn1_ctx(&self.location).into();
+        let f = f
+            .splice_fn1_ctx(&OperatorContext::<L, B>::new(&self.location))
+            .into();
         Optional::new(
             self.location.clone(),
             HydroNode::Map {
@@ -447,7 +453,7 @@ where
     /// ```
     pub fn flat_map_ordered<U, I, F, C, Idemp, const WAS_MUT: bool>(
         self,
-        f: impl IntoQuotedMut<'a, F, L, StreamMapFuncAlgebra<C, Idemp>>,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, Bounded>, StreamMapFuncAlgebra<C, Idemp>>,
     ) -> Stream<U, L, Bounded, TotalOrder, ExactlyOnce>
     where
         B: IsBounded,
@@ -490,7 +496,7 @@ where
     /// ```
     pub fn flat_map_unordered<U, I, F, C, Idemp, const WAS_MUT: bool>(
         self,
-        f: impl IntoQuotedMut<'a, F, L, StreamMapFuncAlgebra<C, Idemp>>,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, Bounded>, StreamMapFuncAlgebra<C, Idemp>>,
     ) -> Stream<U, L, Bounded, NoOrder, ExactlyOnce>
     where
         B: IsBounded,
@@ -599,11 +605,13 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn filter<F>(self, f: impl IntoQuotedMut<'a, F, L>) -> Optional<T, L, B>
+    pub fn filter<F>(self, f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>>) -> Optional<T, L, B>
     where
         F: Fn(&T) -> bool + 'a,
     {
-        let f = f.splice_fn1_borrow_ctx(&self.location).into();
+        let f = f
+            .splice_fn1_borrow_ctx(&OperatorContext::<L, B>::new(&self.location))
+            .into();
         Optional::new(
             self.location.clone(),
             HydroNode::Filter {
@@ -638,11 +646,16 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn filter_map<U, F>(self, f: impl IntoQuotedMut<'a, F, L>) -> Optional<U, L, B>
+    pub fn filter_map<U, F>(
+        self,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>>,
+    ) -> Optional<U, L, B>
     where
         F: Fn(T) -> Option<U> + 'a,
     {
-        let f = f.splice_fn1_ctx(&self.location).into();
+        let f = f
+            .splice_fn1_ctx(&OperatorContext::<L, B>::new(&self.location))
+            .into();
         Optional::new(
             self.location.clone(),
             HydroNode::FilterMap {

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 use sealed::sealed;
 use stageleft::{IntoQuotedMut, QuotedWithContext, QuotedWithContextWithProps, q};
 
+use super::OperatorContext;
 use super::boundedness::{Bounded, Boundedness, IsBounded, Unbounded};
 use super::optional::Optional;
 use super::sliced::sliced;
@@ -309,6 +310,11 @@ where
     /// inside `q!()` closures. The handle resolves to `&T` at runtime.
     ///
     /// The singleton must be bounded, otherwise reading it would be non-deterministic.
+    /// The handle can only be captured in closures passed to operators on collections at
+    /// the same location with **matching boundedness**; capturing it in a closure over an
+    /// unbounded collection is rejected at compile time, since the bounded singleton is only
+    /// materialized on the first tick while the closure would keep running on later ticks,
+    /// where accessing the reference would crash.
     ///
     /// ```rust
     /// # #[cfg(feature = "deploy")] {
@@ -343,7 +349,9 @@ where
     /// # });
     /// # }
     /// ```
-    pub fn by_ref(&self) -> crate::handoff_ref::SingletonRef<'a, '_, T, L>
+    pub fn by_ref(
+        &self,
+    ) -> crate::handoff_ref::SingletonRef<'a, '_, T, L, <B as SingletonBound>::UnderlyingBound>
     where
         B: IsBounded,
     {
@@ -392,7 +400,9 @@ where
     /// # });
     /// # }
     /// ```
-    pub fn by_mut(&self) -> crate::handoff_ref::SingletonMut<'a, '_, T, L>
+    pub fn by_mut(
+        &self,
+    ) -> crate::handoff_ref::SingletonMut<'a, '_, T, L, <B as SingletonBound>::UnderlyingBound>
     where
         B: IsBounded,
     {
@@ -502,13 +512,21 @@ where
     /// ```
     pub fn map<U, F, OP, B2: SingletonBound>(
         self,
-        f: impl IntoQuotedMut<'a, F, L, SingletonMapFuncAlgebra<OP>>,
+        f: impl IntoQuotedMut<
+            'a,
+            F,
+            OperatorContext<L, <B as SingletonBound>::UnderlyingBound>,
+            SingletonMapFuncAlgebra<OP>,
+        >,
     ) -> Singleton<U, L, B2>
     where
         F: Fn(T) -> U + 'a,
         B: ApplyOrderPreservingSingleton<OP, B2>,
     {
-        let (f, proof) = f.splice_fn1_ctx_props(&self.location);
+        let (f, proof) = f
+            .splice_fn1_ctx_props(
+                &OperatorContext::<L, <B as SingletonBound>::UnderlyingBound>::new(&self.location),
+            );
         proof.register_proof(&f);
         let f = f.into();
         Singleton::new(
@@ -552,7 +570,7 @@ where
     /// ```
     pub fn flat_map_ordered<U, I, F, C, Idemp, const WAS_MUT: bool>(
         self,
-        f: impl IntoQuotedMut<'a, F, L, StreamMapFuncAlgebra<C, Idemp>>,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, Bounded>, StreamMapFuncAlgebra<C, Idemp>>,
     ) -> Stream<U, L, Bounded, TotalOrder, ExactlyOnce>
     where
         B: IsBounded,
@@ -594,7 +612,7 @@ where
     /// ```
     pub fn flat_map_unordered<U, I, F, C, Idemp, const WAS_MUT: bool>(
         self,
-        f: impl IntoQuotedMut<'a, F, L, StreamMapFuncAlgebra<C, Idemp>>,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, Bounded>, StreamMapFuncAlgebra<C, Idemp>>,
     ) -> Stream<U, L, Bounded, NoOrder, ExactlyOnce>
     where
         B: IsBounded,
@@ -700,11 +718,18 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn filter<F>(self, f: impl IntoQuotedMut<'a, F, L>) -> Optional<T, L, B::UnderlyingBound>
+    pub fn filter<F>(
+        self,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, <B as SingletonBound>::UnderlyingBound>>,
+    ) -> Optional<T, L, B::UnderlyingBound>
     where
         F: Fn(&T) -> bool + 'a,
     {
-        let f = f.splice_fn1_borrow_ctx(&self.location).into();
+        let f = f
+            .splice_fn1_borrow_ctx(
+                &OperatorContext::<L, <B as SingletonBound>::UnderlyingBound>::new(&self.location),
+            )
+            .into();
         Optional::new(
             self.location.clone(),
             HydroNode::Filter {
@@ -742,12 +767,16 @@ where
     /// ```
     pub fn filter_map<U, F>(
         self,
-        f: impl IntoQuotedMut<'a, F, L>,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, <B as SingletonBound>::UnderlyingBound>>,
     ) -> Optional<U, L, B::UnderlyingBound>
     where
         F: Fn(T) -> Option<U> + 'a,
     {
-        let f = f.splice_fn1_ctx(&self.location).into();
+        let f = f
+            .splice_fn1_ctx(
+                &OperatorContext::<L, <B as SingletonBound>::UnderlyingBound>::new(&self.location),
+            )
+            .into();
         Optional::new(
             self.location.clone(),
             HydroNode::FilterMap {

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -11,6 +11,7 @@ use stageleft::{IntoQuotedMut, QuotedWithContext, QuotedWithContextWithProps, q,
 #[cfg(feature = "tokio")]
 use tokio::time::Instant;
 
+use super::OperatorContext;
 use super::boundedness::{Bounded, Boundedness, IsBounded, Unbounded};
 use super::keyed_singleton::KeyedSingleton;
 use super::keyed_stream::{Generate, KeyedStream};
@@ -442,7 +443,7 @@ where
     /// inside `q!()` closures. The handle resolves to `&Vec<T>` at runtime.
     ///
     /// The stream must be bounded, otherwise reading it would be non-deterministic.
-    pub fn by_ref(&self) -> crate::handoff_ref::StreamRef<'a, '_, T, L>
+    pub fn by_ref(&self) -> crate::handoff_ref::StreamRef<'a, '_, T, L, B>
     where
         B: IsBounded,
     {
@@ -451,7 +452,7 @@ where
 
     /// Returns a mutable reference handle to this stream's handoff buffer that can be captured
     /// inside `q!()` closures. The handle resolves to `&mut Vec<T>` at runtime.
-    pub fn by_mut(&self) -> crate::handoff_ref::StreamMut<'a, '_, T, L>
+    pub fn by_mut(&self) -> crate::handoff_ref::StreamMut<'a, '_, T, L, B>
     where
         B: IsBounded,
     {
@@ -581,7 +582,7 @@ where
     /// ```
     pub fn map<U, F, C, I, const WAS_MUT: bool>(
         self,
-        f: impl IntoQuotedMut<'a, F, L, StreamMapFuncAlgebra<C, I>>,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>, StreamMapFuncAlgebra<C, I>>,
     ) -> Stream<U, L, B, O, R>
     where
         F: FnMut(T) -> U + 'a,
@@ -589,7 +590,8 @@ where
         I: ValidMutIdempotenceFor<F, T, U, R, WAS_MUT>,
     {
         let f = crate::handoff_ref::with_ref_capture(|| {
-            let (expr, proof) = f.splice_fnmut1_ctx_props(&self.location);
+            let (expr, proof) =
+                f.splice_fnmut1_ctx_props(&OperatorContext::<L, B>::new(&self.location));
             proof.register_proof(&expr);
             expr.into()
         });
@@ -631,7 +633,7 @@ where
     /// ```
     pub fn flat_map_ordered<U, I, F, C, Idemp, const WAS_MUT: bool>(
         self,
-        f: impl IntoQuotedMut<'a, F, L, StreamMapFuncAlgebra<C, Idemp>>,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>, StreamMapFuncAlgebra<C, Idemp>>,
     ) -> Stream<U, L, B, O, R>
     where
         I: IntoIterator<Item = U>,
@@ -640,7 +642,8 @@ where
         Idemp: ValidMutIdempotenceFor<F, T, I, R, WAS_MUT>,
     {
         let f = crate::handoff_ref::with_ref_capture(|| {
-            let (expr, proof) = f.splice_fnmut1_ctx_props(&self.location);
+            let (expr, proof) =
+                f.splice_fnmut1_ctx_props(&OperatorContext::<L, B>::new(&self.location));
             proof.register_proof(&expr);
             expr.into()
         });
@@ -684,7 +687,7 @@ where
     /// ```
     pub fn flat_map_unordered<U, I, F, C, Idemp, const WAS_MUT: bool>(
         self,
-        f: impl IntoQuotedMut<'a, F, L, StreamMapFuncAlgebra<C, Idemp>>,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>, StreamMapFuncAlgebra<C, Idemp>>,
     ) -> Stream<U, L, B, NoOrder, R>
     where
         I: IntoIterator<Item = U>,
@@ -693,7 +696,8 @@ where
         Idemp: ValidMutIdempotenceFor<F, T, I, R, WAS_MUT>,
     {
         let f = crate::handoff_ref::with_ref_capture(|| {
-            let (expr, proof) = f.splice_fnmut1_ctx_props(&self.location);
+            let (expr, proof) =
+                f.splice_fnmut1_ctx_props(&OperatorContext::<L, B>::new(&self.location));
             proof.register_proof(&expr);
             expr.into()
         });
@@ -776,7 +780,7 @@ where
     /// `Pending`, this operator yields as well.
     pub fn flat_map_stream_blocking<U, S, F, C, Idemp, const WAS_MUT: bool>(
         self,
-        f: impl IntoQuotedMut<'a, F, L, StreamMapFuncAlgebra<C, Idemp>>,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>, StreamMapFuncAlgebra<C, Idemp>>,
     ) -> Stream<U, L, B, O, R>
     where
         S: futures::Stream<Item = U>,
@@ -785,7 +789,8 @@ where
         Idemp: ValidMutIdempotenceFor<F, T, S, R, WAS_MUT>,
     {
         let f = crate::handoff_ref::with_ref_capture(|| {
-            let (expr, proof) = f.splice_fnmut1_ctx_props(&self.location);
+            let (expr, proof) =
+                f.splice_fnmut1_ctx_props(&OperatorContext::<L, B>::new(&self.location));
             proof.register_proof(&expr);
             expr.into()
         });
@@ -837,7 +842,7 @@ where
     /// ```
     pub fn filter<F, C, Idemp, const WAS_MUT: bool>(
         self,
-        f: impl IntoQuotedMut<'a, F, L, StreamMapFuncAlgebra<C, Idemp>>,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>, StreamMapFuncAlgebra<C, Idemp>>,
     ) -> Self
     where
         F: FnMut(&T) -> bool + 'a,
@@ -845,7 +850,8 @@ where
         Idemp: ValidMutBorrowIdempotenceFor<F, T, bool, R, WAS_MUT>,
     {
         let f = crate::handoff_ref::with_ref_capture(|| {
-            let (expr, proof) = f.splice_fnmut1_borrow_ctx_props(&self.location);
+            let (expr, proof) =
+                f.splice_fnmut1_borrow_ctx_props(&OperatorContext::<L, B>::new(&self.location));
             proof.register_proof(&expr);
             expr.into()
         });
@@ -895,7 +901,7 @@ where
     /// ```
     pub fn partition<F, C, Idemp, const WAS_MUT: bool>(
         self,
-        f: impl IntoQuotedMut<'a, F, L, StreamMapFuncAlgebra<C, Idemp>>,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>, StreamMapFuncAlgebra<C, Idemp>>,
     ) -> (Stream<T, L, B, O, R>, Stream<T, L, B, O, R>)
     where
         F: FnMut(&T) -> bool + 'a,
@@ -903,7 +909,8 @@ where
         Idemp: ValidMutBorrowIdempotenceFor<F, T, bool, R, WAS_MUT>,
     {
         let f = crate::handoff_ref::with_ref_capture(|| {
-            let (expr, proof) = f.splice_fnmut1_borrow_ctx_props(&self.location);
+            let (expr, proof) =
+                f.splice_fnmut1_borrow_ctx_props(&OperatorContext::<L, B>::new(&self.location));
             proof.register_proof(&expr);
             expr.into()
         });
@@ -955,7 +962,7 @@ where
     /// ```
     pub fn filter_map<U, F, C, Idemp, const WAS_MUT: bool>(
         self,
-        f: impl IntoQuotedMut<'a, F, L, StreamMapFuncAlgebra<C, Idemp>>,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>, StreamMapFuncAlgebra<C, Idemp>>,
     ) -> Stream<U, L, B, O, R>
     where
         F: FnMut(T) -> Option<U> + 'a,
@@ -963,7 +970,8 @@ where
         Idemp: ValidMutIdempotenceFor<F, T, Option<U>, R, WAS_MUT>,
     {
         let f = crate::handoff_ref::with_ref_capture(|| {
-            let (expr, proof) = f.splice_fnmut1_ctx_props(&self.location);
+            let (expr, proof) =
+                f.splice_fnmut1_ctx_props(&OperatorContext::<L, B>::new(&self.location));
             proof.register_proof(&expr);
             expr.into()
         });
@@ -1276,7 +1284,12 @@ where
     /// ```
     pub fn inspect<F, C, Idemp, const WAS_MUT: bool>(
         self,
-        f: impl IntoQuotedMut<'a, F, L::DropConsistency, StreamMapFuncAlgebra<C, Idemp>>,
+        f: impl IntoQuotedMut<
+            'a,
+            F,
+            OperatorContext<L::DropConsistency, B>,
+            StreamMapFuncAlgebra<C, Idemp>,
+        >,
     ) -> Self
     where
         F: FnMut(&T) + 'a,
@@ -1284,7 +1297,10 @@ where
         Idemp: ValidMutBorrowIdempotenceFor<F, T, (), R, WAS_MUT>,
     {
         let f = crate::handoff_ref::with_ref_capture(|| {
-            let (expr, proof) = f.splice_fnmut1_borrow_ctx_props(&self.location.drop_consistency());
+            let (expr, proof) =
+                f.splice_fnmut1_borrow_ctx_props(&OperatorContext::<L::DropConsistency, B>::new(
+                    &self.location.drop_consistency(),
+                ));
             proof.register_proof(&expr);
             expr.into()
         });
@@ -1313,16 +1329,19 @@ where
     ///
     /// On a `TotalOrder + ExactlyOnce` stream, no annotations are needed.
     ///
-    /// The closure may capture singletons via `by_ref()` or `by_mut()`.
+    /// The closure may capture singletons via `by_ref()` or `by_mut()`, as long as the
+    /// referenced collection lives at the same location and has the same boundedness as this
+    /// stream.
     pub fn for_each<F: FnMut(T) + 'a, C, I>(
         self,
-        f: impl IntoQuotedMut<'a, F, L, AggFuncAlgebra<C, I>>,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>, AggFuncAlgebra<C, I>>,
     ) where
         C: ValidCommutativityFor<O>,
         I: ValidIdempotenceFor<R>,
     {
         let f = crate::handoff_ref::with_ref_capture(|| {
-            let (f, proof) = f.splice_fnmut1_ctx_props(&self.location);
+            let (f, proof) =
+                f.splice_fnmut1_ctx_props(&OperatorContext::<L, B>::new(&self.location));
             proof.register_proof(&f);
             f.into()
         });
@@ -1421,8 +1440,8 @@ where
     /// ```
     pub fn fold<A, I, F, C, Idemp, M, B2: SingletonBound>(
         self,
-        init: impl IntoQuotedMut<'a, I, L>,
-        comb: impl IntoQuotedMut<'a, F, L, AggFuncAlgebra<C, Idemp, M>>,
+        init: impl IntoQuotedMut<'a, I, OperatorContext<L, B>>,
+        comb: impl IntoQuotedMut<'a, F, OperatorContext<L, B>, AggFuncAlgebra<C, Idemp, M>>,
     ) -> Singleton<A, L, B2>
     where
         I: Fn() -> A + 'a,
@@ -1431,8 +1450,11 @@ where
         Idemp: ValidIdempotenceFor<R>,
         B: ApplyMonotoneStream<M, B2>,
     {
-        let init = init.splice_fn0_ctx(&self.location).into();
-        let (comb, proof) = comb.splice_fn2_borrow_mut_ctx_props(&self.location);
+        let init = init
+            .splice_fn0_ctx(&OperatorContext::<L, B>::new(&self.location))
+            .into();
+        let (comb, proof) =
+            comb.splice_fn2_borrow_mut_ctx_props(&OperatorContext::<L, B>::new(&self.location));
         proof.register_proof(&comb);
 
         // Only assume_retries (for idempotence), not assume_ordering.
@@ -1481,14 +1503,15 @@ where
     /// ```
     pub fn reduce<F, C, Idemp>(
         self,
-        comb: impl IntoQuotedMut<'a, F, L, AggFuncAlgebra<C, Idemp>>,
+        comb: impl IntoQuotedMut<'a, F, OperatorContext<L, B>, AggFuncAlgebra<C, Idemp>>,
     ) -> Optional<T, L, B>
     where
         F: Fn(&mut T, T) + 'a,
         C: ValidCommutativityFor<O>,
         Idemp: ValidIdempotenceFor<R>,
     {
-        let (f, proof) = comb.splice_fn2_borrow_mut_ctx_props(&self.location);
+        let (f, proof) =
+            comb.splice_fn2_borrow_mut_ctx_props(&OperatorContext::<L, B>::new(&self.location));
         proof.register_proof(&f);
 
         let nondet = nondet!(/** the combinator function is commutative and idempotent */);
@@ -1662,7 +1685,7 @@ where
     /// ```
     pub fn limit(
         self,
-        n: impl QuotedWithContext<'a, usize, L> + Copy + 'a,
+        n: impl QuotedWithContext<'a, usize, OperatorContext<L, B>> + Copy + 'a,
     ) -> Stream<T, L, B, TotalOrder, ExactlyOnce>
     where
         O: IsOrdered,
@@ -1735,7 +1758,9 @@ where
     /// If the function returns `None`, the stream is terminated and no more elements are processed.
     ///
     /// The `init` and `f` closures may capture bounded singletons, optionals, or streams by
-    /// reference via [`by_ref()`](crate::live_collections::Singleton::by_ref).
+    /// reference via [`by_ref()`](crate::live_collections::Singleton::by_ref), as long as the
+    /// referenced collection lives at the same location and has the same boundedness as this
+    /// stream.
     ///
     /// # Examples
     ///
@@ -1788,8 +1813,8 @@ where
     /// ```
     pub fn scan<A, U, I, F>(
         self,
-        init: impl IntoQuotedMut<'a, I, L>,
-        f: impl IntoQuotedMut<'a, F, L>,
+        init: impl IntoQuotedMut<'a, I, OperatorContext<L, B>>,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>>,
     ) -> Stream<U, L, B, TotalOrder, ExactlyOnce>
     where
         O: IsOrdered,
@@ -1797,10 +1822,13 @@ where
         I: Fn() -> A + 'a,
         F: Fn(&mut A, T) -> Option<U> + 'a,
     {
-        let init =
-            crate::handoff_ref::with_ref_capture(|| init.splice_fn0_ctx(&self.location).into());
+        let init = crate::handoff_ref::with_ref_capture(|| {
+            init.splice_fn0_ctx(&OperatorContext::<L, B>::new(&self.location))
+                .into()
+        });
         let f = crate::handoff_ref::with_ref_capture(|| {
-            f.splice_fn2_borrow_mut_ctx(&self.location).into()
+            f.splice_fn2_borrow_mut_ctx(&OperatorContext::<L, B>::new(&self.location))
+                .into()
         });
 
         Stream::new(
@@ -1825,7 +1853,9 @@ where
     /// emitted. If it resolves to `None`, the item is filtered out.
     ///
     /// The `init` and `f` closures may capture bounded singletons, optionals, or streams by
-    /// reference via [`by_ref()`](crate::live_collections::Singleton::by_ref).
+    /// reference via [`by_ref()`](crate::live_collections::Singleton::by_ref), as long as the
+    /// referenced collection lives at the same location and has the same boundedness as this
+    /// stream.
     ///
     /// # Examples
     ///
@@ -1854,8 +1884,8 @@ where
     /// ```
     pub fn scan_async_blocking<A, U, I, F, Fut>(
         self,
-        init: impl IntoQuotedMut<'a, I, L>,
-        f: impl IntoQuotedMut<'a, F, L>,
+        init: impl IntoQuotedMut<'a, I, OperatorContext<L, B>>,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>>,
     ) -> Stream<U, L, B, TotalOrder, ExactlyOnce>
     where
         O: IsOrdered,
@@ -1864,10 +1894,13 @@ where
         F: Fn(&mut A, T) -> Fut + 'a,
         Fut: Future<Output = Option<U>> + 'a,
     {
-        let init =
-            crate::handoff_ref::with_ref_capture(|| init.splice_fn0_ctx(&self.location).into());
+        let init = crate::handoff_ref::with_ref_capture(|| {
+            init.splice_fn0_ctx(&OperatorContext::<L, B>::new(&self.location))
+                .into()
+        });
         let f = crate::handoff_ref::with_ref_capture(|| {
-            f.splice_fn2_borrow_mut_ctx(&self.location).into()
+            f.splice_fn2_borrow_mut_ctx(&OperatorContext::<L, B>::new(&self.location))
+                .into()
         });
 
         Stream::new(
@@ -1893,7 +1926,9 @@ where
     /// variants define what is emitted and whether further inputs should be processed.
     ///
     /// The `init` and `f` closures may capture bounded singletons, optionals, or streams by
-    /// reference via [`by_ref()`](crate::live_collections::Singleton::by_ref).
+    /// reference via [`by_ref()`](crate::live_collections::Singleton::by_ref), as long as the
+    /// referenced collection lives at the same location and has the same boundedness as this
+    /// stream.
     ///
     /// # Example
     /// ```rust
@@ -1927,8 +1962,8 @@ where
     /// ```
     pub fn generator<A, U, I, F>(
         self,
-        init: impl IntoQuotedMut<'a, I, L> + Copy,
-        f: impl IntoQuotedMut<'a, F, L> + Copy,
+        init: impl IntoQuotedMut<'a, I, OperatorContext<L, B>> + Copy,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>> + Copy,
     ) -> Stream<U, L, B, TotalOrder, ExactlyOnce>
     where
         O: IsOrdered,
@@ -1936,8 +1971,10 @@ where
         I: Fn() -> A + 'a,
         F: Fn(&mut A, T) -> Generate<U> + 'a,
     {
-        let init: ManualExpr<I, _> = ManualExpr::new(move |ctx: &L| init.splice_fn0_ctx(ctx));
-        let f: ManualExpr<F, _> = ManualExpr::new(move |ctx: &L| f.splice_fn2_borrow_mut_ctx(ctx));
+        let init: ManualExpr<I, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| init.splice_fn0_ctx(ctx));
+        let f: ManualExpr<F, _> =
+            ManualExpr::new(move |ctx: &OperatorContext<L, B>| f.splice_fn2_borrow_mut_ctx(ctx));
 
         let this = self.make_totally_ordered().make_exactly_once();
 
@@ -1972,7 +2009,9 @@ where
                     _ => None,
                 }
             })
-            .splice_fn2_borrow_mut_ctx::<Option<Option<A>>, T, _>(&this.location)
+            .splice_fn2_borrow_mut_ctx::<Option<Option<A>>, T, _>(&OperatorContext::<L, B>::new(
+                &this.location,
+            ))
             .into()
         });
 
@@ -2041,7 +2080,12 @@ where
     #[cfg(feature = "tokio")]
     pub fn timeout(
         self,
-        duration: impl QuotedWithContext<'a, std::time::Duration, Tick<L::DropConsistency>> + Copy + 'a,
+        duration: impl QuotedWithContext<
+            'a,
+            std::time::Duration,
+            OperatorContext<Tick<L::DropConsistency>, Bounded>,
+        > + Copy
+        + 'a,
         nondet: NonDet,
     ) -> Optional<(), L::DropConsistency, Unbounded>
     where

--- a/hydro_lang/src/location/cluster.rs
+++ b/hydro_lang/src/location/cluster.rs
@@ -258,18 +258,18 @@ pub struct ClusterSelfId<'a> {
     _private: &'a (),
 }
 
-impl<'a, L> FreeVariableWithContextWithProps<L, ()> for ClusterSelfId<'a>
+impl<'a, Ctx> FreeVariableWithContextWithProps<Ctx, ()> for ClusterSelfId<'a>
 where
-    L: Location<'a>,
-    <L as Location<'a>>::Root: IsCluster,
+    Ctx: crate::live_collections::ContextWithLocation<'a>,
+    <Ctx::Location as Location<'a>>::Root: IsCluster,
 {
-    type O = MemberId<<<L as Location<'a>>::Root as IsCluster>::Tag>;
+    type O = MemberId<<<Ctx::Location as Location<'a>>::Root as IsCluster>::Tag>;
 
-    fn to_tokens(self, ctx: &L) -> (QuoteTokens, ())
+    fn to_tokens(self, ctx: &Ctx) -> (QuoteTokens, ())
     where
         Self: Sized,
     {
-        let LocationId::Cluster(cluster_id) = ctx.root().id() else {
+        let LocationId::Cluster(cluster_id) = ctx.context_location().root().id() else {
             unreachable!()
         };
 
@@ -278,7 +278,8 @@ where
             Span::call_site(),
         );
         let root = get_this_crate();
-        let c_type: syn::Type = quote_type::<<<L as Location<'a>>::Root as IsCluster>::Tag>();
+        let c_type: syn::Type =
+            quote_type::<<<Ctx::Location as Location<'a>>::Root as IsCluster>::Tag>();
 
         (
             QuoteTokens {
@@ -292,12 +293,16 @@ where
     }
 }
 
-impl<'a, L>
-    QuotedWithContextWithProps<'a, MemberId<<<L as Location<'a>>::Root as IsCluster>::Tag>, L, ()>
-    for ClusterSelfId<'a>
+impl<'a, Ctx>
+    QuotedWithContextWithProps<
+        'a,
+        MemberId<<<Ctx::Location as Location<'a>>::Root as IsCluster>::Tag>,
+        Ctx,
+        (),
+    > for ClusterSelfId<'a>
 where
-    L: Location<'a>,
-    <L as Location<'a>>::Root: IsCluster,
+    Ctx: crate::live_collections::ContextWithLocation<'a>,
+    <Ctx::Location as Location<'a>>::Root: IsCluster,
 {
 }
 

--- a/hydro_lang/src/location/tick.rs
+++ b/hydro_lang/src/location/tick.rs
@@ -191,7 +191,15 @@ where
     /// `batch_size` unit values.
     pub fn spin_batch(
         &self,
-        batch_size: impl QuotedWithContext<'a, usize, L> + Copy + 'a,
+        batch_size: impl QuotedWithContext<
+            'a,
+            usize,
+            crate::live_collections::OperatorContext<
+                L,
+                crate::live_collections::boundedness::Unbounded,
+            >,
+        > + Copy
+        + 'a,
     ) -> Stream<(), Self, Bounded, TotalOrder, ExactlyOnce>
     where
         L: TopLevel<'a>,

--- a/hydro_lang/src/runtime_context.rs
+++ b/hydro_lang/src/runtime_context.rs
@@ -4,7 +4,7 @@ use dfir_rs::scheduled::context::Context;
 use quote::quote;
 use stageleft::runtime_support::{FreeVariableWithContextWithProps, QuoteTokens};
 
-use crate::location::Location;
+use crate::live_collections::ContextWithLocation;
 
 /// Exposes the DFIR [`Context`] inside quoted code.
 pub static RUNTIME_CONTEXT: RuntimeContext = RuntimeContext { _private: &() };
@@ -17,13 +17,13 @@ pub struct RuntimeContext<'a> {
     _private: &'a (),
 }
 
-impl<'a, L> FreeVariableWithContextWithProps<L, ()> for RuntimeContext<'a>
+impl<'a, Ctx> FreeVariableWithContextWithProps<Ctx, ()> for RuntimeContext<'a>
 where
-    L: Location<'a>,
+    Ctx: ContextWithLocation<'a>,
 {
     type O = &'a Context;
 
-    fn to_tokens(self, _ctx: &L) -> (QuoteTokens, ()) {
+    fn to_tokens(self, _ctx: &Ctx) -> (QuoteTokens, ()) {
         (
             QuoteTokens {
                 prelude: None,

--- a/hydro_lang/tests/compile-fail/singleton_by_mut_unbounded_for_each.rs
+++ b/hydro_lang/tests/compile-fail/singleton_by_mut_unbounded_for_each.rs
@@ -1,0 +1,23 @@
+#![allow(unexpected_cfgs)]
+
+use hydro_lang::prelude::*;
+
+struct P1 {}
+
+fn test<'a>(p1: &Process<'a, P1>) {
+    // A bounded singleton, materialized only on the first tick.
+    let my_count = p1
+        .source_iter(q!(0..5i32))
+        .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+    let count_mut = my_count.by_mut();
+
+    // An unbounded stream, whose closures run across ticks; a bounded collection is
+    // only materialized on the first tick, so accessing the reference on later ticks
+    // would crash at runtime. This must not compile.
+    let unbounded: Stream<_, _> = p1.source_iter(q!(1..=3i32)).into();
+    unbounded.for_each(q!(|x| {
+        *count_mut += x;
+    }));
+}
+
+fn main() {}

--- a/hydro_lang/tests/compile-fail/singleton_by_ref_unbounded_filter.rs
+++ b/hydro_lang/tests/compile-fail/singleton_by_ref_unbounded_filter.rs
@@ -1,0 +1,21 @@
+#![allow(unexpected_cfgs)]
+
+use hydro_lang::prelude::*;
+
+struct P1 {}
+
+fn test<'a>(p1: &Process<'a, P1>) {
+    // A bounded singleton, materialized only on the first tick.
+    let threshold = p1
+        .source_iter(q!(0..5i32))
+        .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+    let threshold_ref = threshold.by_ref();
+
+    // An unbounded stream, whose closures run across ticks; a bounded collection is
+    // only materialized on the first tick, so accessing the reference on later ticks
+    // would crash at runtime. This must not compile.
+    let unbounded: Stream<_, _> = p1.source_iter(q!(1..=10i32)).into();
+    let _ = unbounded.filter(q!(|&x| x > *threshold_ref));
+}
+
+fn main() {}

--- a/hydro_lang/tests/compile-fail/singleton_by_ref_unbounded_map.rs
+++ b/hydro_lang/tests/compile-fail/singleton_by_ref_unbounded_map.rs
@@ -1,0 +1,21 @@
+#![allow(unexpected_cfgs)]
+
+use hydro_lang::prelude::*;
+
+struct P1 {}
+
+fn test<'a>(p1: &Process<'a, P1>) {
+    // A bounded singleton, materialized only on the first tick.
+    let my_count = p1
+        .source_iter(q!(0..5i32))
+        .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+    let count_ref = my_count.by_ref();
+
+    // An unbounded stream, whose closures run across ticks; a bounded collection is
+    // only materialized on the first tick, so accessing the reference on later ticks
+    // would crash at runtime. This must not compile.
+    let unbounded: Stream<_, _> = p1.source_iter(q!(1..=3i32)).into();
+    let _ = unbounded.map(q!(|x| x + *count_ref));
+}
+
+fn main() {}

--- a/hydro_lang/tests/compile-fail/stable/singleton_by_mut_unbounded_for_each.stderr
+++ b/hydro_lang/tests/compile-fail/stable/singleton_by_mut_unbounded_for_each.stderr
@@ -1,0 +1,41 @@
+error[E0308]: mismatched types
+  --> tests/compile-fail/stable/singleton_by_mut_unbounded_for_each.rs:18:24
+   |
+18 |       unbounded.for_each(q!(|x| {
+   |  ________________________^
+19 | |         *count_mut += x;
+20 | |     }));
+   | |      ^
+   | |      |
+   | |______expected `hydro_lang::prelude::Bounded`, found `hydro_lang::prelude::Unbounded`
+   |        arguments to this function are incorrect
+   |
+   = note: expected reference `&OperatorContext<hydro_lang::prelude::Process<'a, P1>, hydro_lang::prelude::Bounded>`
+              found reference `&OperatorContext<hydro_lang::prelude::Process<'a, P1>, hydro_lang::prelude::Unbounded>`
+note: method defined here
+  --> $CARGO/stageleft-$VERSION/src/runtime_support.rs
+   |
+   |     fn uninitialized(
+   |        ^^^^^^^^^^^^^
+   = note: this error originates in the macro `q` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/compile-fail/stable/singleton_by_mut_unbounded_for_each.rs:18:24
+   |
+18 |       unbounded.for_each(q!(|x| {
+   |  ________________________^
+19 | |         *count_mut += x;
+20 | |     }));
+   | |      ^
+   | |      |
+   | |______expected `hydro_lang::prelude::Bounded`, found `hydro_lang::prelude::Unbounded`
+   |        arguments to this function are incorrect
+   |
+   = note: expected reference `&OperatorContext<hydro_lang::prelude::Process<'a, P1>, hydro_lang::prelude::Bounded>`
+              found reference `&OperatorContext<hydro_lang::prelude::Process<'a, P1>, hydro_lang::prelude::Unbounded>`
+note: method defined here
+  --> $CARGO/stageleft-$VERSION/src/runtime_support.rs
+   |
+   |     fn to_tokens(self, ctx: &Ctx) -> QuoteTokens
+   |        ^^^^^^^^^
+   = note: this error originates in the macro `q` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/hydro_lang/tests/compile-fail/stable/singleton_by_ref_unbounded_filter.stderr
+++ b/hydro_lang/tests/compile-fail/stable/singleton_by_ref_unbounded_filter.stderr
@@ -1,0 +1,35 @@
+error[E0308]: mismatched types
+  --> tests/compile-fail/stable/singleton_by_ref_unbounded_filter.rs:18:30
+   |
+18 |     let _ = unbounded.filter(q!(|&x| x > *threshold_ref));
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              |
+   |                              expected `hydro_lang::prelude::Bounded`, found `hydro_lang::prelude::Unbounded`
+   |                              arguments to this function are incorrect
+   |
+   = note: expected reference `&OperatorContext<hydro_lang::prelude::Process<'a, P1>, hydro_lang::prelude::Bounded>`
+              found reference `&OperatorContext<hydro_lang::prelude::Process<'a, P1>, hydro_lang::prelude::Unbounded>`
+note: method defined here
+  --> $CARGO/stageleft-$VERSION/src/runtime_support.rs
+   |
+   |     fn uninitialized(
+   |        ^^^^^^^^^^^^^
+   = note: this error originates in the macro `q` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/compile-fail/stable/singleton_by_ref_unbounded_filter.rs:18:30
+   |
+18 |     let _ = unbounded.filter(q!(|&x| x > *threshold_ref));
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              |
+   |                              expected `hydro_lang::prelude::Bounded`, found `hydro_lang::prelude::Unbounded`
+   |                              arguments to this function are incorrect
+   |
+   = note: expected reference `&OperatorContext<hydro_lang::prelude::Process<'a, P1>, hydro_lang::prelude::Bounded>`
+              found reference `&OperatorContext<hydro_lang::prelude::Process<'a, P1>, hydro_lang::prelude::Unbounded>`
+note: method defined here
+  --> $CARGO/stageleft-$VERSION/src/runtime_support.rs
+   |
+   |     fn to_tokens(self, ctx: &Ctx) -> QuoteTokens
+   |        ^^^^^^^^^
+   = note: this error originates in the macro `q` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/hydro_lang/tests/compile-fail/stable/singleton_by_ref_unbounded_map.stderr
+++ b/hydro_lang/tests/compile-fail/stable/singleton_by_ref_unbounded_map.stderr
@@ -1,0 +1,35 @@
+error[E0308]: mismatched types
+  --> tests/compile-fail/stable/singleton_by_ref_unbounded_map.rs:18:27
+   |
+18 |     let _ = unbounded.map(q!(|x| x + *count_ref));
+   |                           ^^^^^^^^^^^^^^^^^^^^^^
+   |                           |
+   |                           expected `hydro_lang::prelude::Bounded`, found `hydro_lang::prelude::Unbounded`
+   |                           arguments to this function are incorrect
+   |
+   = note: expected reference `&OperatorContext<hydro_lang::prelude::Process<'a, P1>, hydro_lang::prelude::Bounded>`
+              found reference `&OperatorContext<hydro_lang::prelude::Process<'a, P1>, hydro_lang::prelude::Unbounded>`
+note: method defined here
+  --> $CARGO/stageleft-$VERSION/src/runtime_support.rs
+   |
+   |     fn uninitialized(
+   |        ^^^^^^^^^^^^^
+   = note: this error originates in the macro `q` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/compile-fail/stable/singleton_by_ref_unbounded_map.rs:18:27
+   |
+18 |     let _ = unbounded.map(q!(|x| x + *count_ref));
+   |                           ^^^^^^^^^^^^^^^^^^^^^^
+   |                           |
+   |                           expected `hydro_lang::prelude::Bounded`, found `hydro_lang::prelude::Unbounded`
+   |                           arguments to this function are incorrect
+   |
+   = note: expected reference `&OperatorContext<hydro_lang::prelude::Process<'a, P1>, hydro_lang::prelude::Bounded>`
+              found reference `&OperatorContext<hydro_lang::prelude::Process<'a, P1>, hydro_lang::prelude::Unbounded>`
+note: method defined here
+  --> $CARGO/stageleft-$VERSION/src/runtime_support.rs
+   |
+   |     fn to_tokens(self, ctx: &Ctx) -> QuoteTokens
+   |        ^^^^^^^^^
+   = note: this error originates in the macro `q` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/hydro_lang/tests/compile-fail/stable/stream_by_ref_unbounded.stderr
+++ b/hydro_lang/tests/compile-fail/stable/stream_by_ref_unbounded.stderr
@@ -9,7 +9,7 @@ error[E0277]: The input collection must be bounded (`Bounded`), but has bound `h
 note: required by a bound in `hydro_lang::prelude::Stream::<T, L, B, O, R>::by_ref`
  --> src/live_collections/stream/mod.rs
   |
-  |     pub fn by_ref(&self) -> crate::handoff_ref::StreamRef<'a, '_, T, L>
+  |     pub fn by_ref(&self) -> crate::handoff_ref::StreamRef<'a, '_, T, L, B>
   |            ------ required by a bound in this associated function
   |     where
   |         B: IsBounded,

--- a/hydro_std/src/compartmentalize.rs
+++ b/hydro_std/src/compartmentalize.rs
@@ -1,3 +1,4 @@
+use hydro_lang::live_collections::OperatorContext;
 use hydro_lang::live_collections::boundedness::Boundedness;
 use hydro_lang::live_collections::stream::{NoOrder, Ordering};
 use hydro_lang::location::cluster::CLUSTER_SELF_ID;
@@ -12,7 +13,12 @@ pub trait PartitionStream<'a, T, C1, C2, Order: Ordering> {
     fn send_partitioned<F>(
         self,
         other: &Cluster<'a, C2>,
-        dist_policy: impl IntoQuotedMut<'a, F, Cluster<'a, C1>, StreamMapFuncAlgebra>,
+        dist_policy: impl IntoQuotedMut<
+            'a,
+            F,
+            OperatorContext<Cluster<'a, C1>, Unbounded>,
+            StreamMapFuncAlgebra,
+        >,
     ) -> Stream<T, Cluster<'a, C2>, Unbounded, NoOrder>
     where
         T: Clone + Serialize + DeserializeOwned,
@@ -25,7 +31,12 @@ impl<'a, T, C1, C2, Order: Ordering> PartitionStream<'a, T, C1, C2, Order>
     fn send_partitioned<F>(
         self,
         other: &Cluster<'a, C2>,
-        dist_policy: impl IntoQuotedMut<'a, F, Cluster<'a, C1>, StreamMapFuncAlgebra>,
+        dist_policy: impl IntoQuotedMut<
+            'a,
+            F,
+            OperatorContext<Cluster<'a, C1>, Unbounded>,
+            StreamMapFuncAlgebra,
+        >,
     ) -> Stream<T, Cluster<'a, C2>, Unbounded, NoOrder>
     where
         T: Clone + Serialize + DeserializeOwned,

--- a/hydro_test/src/cluster/simple_cluster.rs
+++ b/hydro_test/src/cluster/simple_cluster.rs
@@ -1,3 +1,4 @@
+use hydro_lang::live_collections::OperatorContext;
 use hydro_lang::live_collections::stream::TotalOrder;
 use hydro_lang::location::MemberId;
 use hydro_lang::location::cluster::CLUSTER_SELF_ID;
@@ -9,7 +10,12 @@ use stageleft::IntoQuotedMut;
 pub fn partition<'a, F>(
     cluster1: Cluster<'a, ()>,
     cluster2: Cluster<'a, ()>,
-    dist_policy: impl IntoQuotedMut<'a, F, Cluster<'a, ()>, StreamMapFuncAlgebra>,
+    dist_policy: impl IntoQuotedMut<
+        'a,
+        F,
+        OperatorContext<Cluster<'a, ()>, Unbounded>,
+        StreamMapFuncAlgebra,
+    >,
 ) -> (Cluster<'a, ()>, Cluster<'a, ()>)
 where
     F: Fn((MemberId<()>, String)) -> (MemberId<()>, String) + 'a,

--- a/hydro_test/src/distributed/versioning.rs
+++ b/hydro_test/src/distributed/versioning.rs
@@ -1,3 +1,4 @@
+use hydro_lang::live_collections::OperatorContext;
 use hydro_lang::live_collections::keyed_stream::KeyedStream;
 use hydro_lang::live_collections::sliced::sliced;
 use hydro_lang::live_collections::stream::{ExactlyOnce, NoOrder, TotalOrder};
@@ -39,7 +40,12 @@ pub struct Logger {}
 fn hash_demux<'a, F, N: NetworkFor<Request>>(
     requests: Stream<Request, Cluster<'a, GossipServer>, Unbounded, TotalOrder>,
     to: &Cluster<'a, GossipServer>,
-    route: impl IntoQuotedMut<'a, F, Tick<Cluster<'a, GossipServer>>, StreamMapFuncAlgebra>,
+    route: impl IntoQuotedMut<
+        'a,
+        F,
+        OperatorContext<Tick<Cluster<'a, GossipServer>>, Bounded>,
+        StreamMapFuncAlgebra,
+    >,
     via: N,
     nondet_membership: NonDet,
 ) -> (
@@ -86,7 +92,12 @@ where
 fn gossip_server<'a, F>(
     requests: Stream<Request, Cluster<'a, GossipServer>, Unbounded, TotalOrder>,
     servers: &Cluster<'a, GossipServer>,
-    route: impl IntoQuotedMut<'a, F, Tick<Cluster<'a, GossipServer>>, StreamMapFuncAlgebra>,
+    route: impl IntoQuotedMut<
+        'a,
+        F,
+        OperatorContext<Tick<Cluster<'a, GossipServer>>, Bounded>,
+        StreamMapFuncAlgebra,
+    >,
 ) -> (
     Stream<Response, Cluster<'a, GossipServer>, Unbounded, NoOrder>,
     Stream<Vec<MemberId<GossipServer>>, Cluster<'a, GossipServer>, Unbounded>,


### PR DESCRIPTION
Fixes #2938, Fixes #3005

Previously, a handle to a bounded collection (e.g. `Singleton<T, L, Bounded>::by_ref()`) could be captured by a `q!()` closure on *any* collection at the same location, including unbounded ones. This is unsound: a bounded collection is only materialized on the first tick, while closures on unbounded collections keep running on later ticks — where the referenced value no longer exists, so accessing the handle would crash at runtime.

The splice context for quoted closures passed to live-collection operators is now a tuple of location *and* boundedness:

- New `hydro_lang::live_collections::OperatorContext<L, B> = (L, PhantomData<B>)`, used as the stageleft context type for every quoted closure parameter on `Stream`, `KeyedStream`, `Singleton`, `Optional`, and `KeyedSingleton` operators (`impl IntoQuotedMut<'a, F, OperatorContext<L, B>, ...>`). `B` is the boundedness of the collection the closure operates on (`B::UnderlyingBound` for `SingletonBound`/`KeyedSingletonBound` collections).
- Reference handles (`SingletonRef`, `SingletonMut`, `OptionalRef`, `OptionalMut`, `StreamRef`, `StreamMut`) gained a `B` type parameter tracking the boundedness of the referenced collection, and now implement `FreeVariableWithContextWithProps<OperatorContext<L, B>, ()>` — so a handle can only be captured when both the location and the boundedness match. Capturing a `Bounded` singleton ref in a `map` over an `Unbounded` stream is now a compile error; capture from closures on bounded collections (e.g. `for_each` on a `source_iter`, batches/snapshots inside `sliced!`) still works. The `B` parameter is kept fully generic (rather than hardcoding `Bounded`) in anticipation of eventually allowing refs to unbounded collections.
- New `ContextWithLocation` trait abstracts over both bare locations and `OperatorContext`, so location-only free variables (`CLUSTER_SELF_ID`, `RUNTIME_CONTEXT`) can be captured in both quoted values (e.g. `source_iter`) and operator closures with a single unambiguous impl.
- Quoted *value* params that are captured inside element closures also moved to `OperatorContext` (`Stream::limit`/`KeyedStream::limit` `n`, `Stream::timeout` `duration`, `Tick::spin_batch` `batch_size`); other quoted value params (sinks, intervals, sources) keep the plain location context, which means ref handles can never be captured there (compile error instead of the previous staging-time panic).
- Downstream generic signatures updated: `hydro_std::compartmentalize::PartitionStream::send_partitioned` (ctx `OperatorContext<Cluster<'a, C1>, Unbounded>`), `hydro_test` `simple_cluster::partition` and `versioning::hash_demux`/`gossip_server` route policies.
- New compile-fail tests (stable + nightly snapshots): `singleton_by_ref_unbounded_map.rs`, `singleton_by_ref_unbounded_filter.rs`, `singleton_by_mut_unbounded_for_each.rs`, covering capture of bounded singleton refs from closures on unbounded streams; `stream_by_ref_unbounded` snapshot refreshed for the new `StreamRef<'a, '_, T, L, B>` signature.

BREAKING CHANGE: `SingletonRef`/`SingletonMut`/`OptionalRef`/`OptionalMut`/`StreamRef`/`StreamMut` take a new boundedness type parameter, and all operator methods accepting quoted closures now use `OperatorContext<L, B>` instead of `L` as the stageleft context type. Code writing generic functions over quoted closures (e.g. `impl IntoQuotedMut<'a, F, L, ...>` parameters) must switch to `OperatorContext<L, B>`; inline `q!(...)` call sites are unaffected. Capturing a bounded collection's ref handle in a closure on an unbounded collection no longer compiles.