### PR TITLE
fix(cargo-sim): use -export_dynamic

### DIFF
--- a/cargo-sim
+++ b/cargo-sim
@@ -7,4 +7,14 @@ export CARGO_BUILD_TARGET=$(rustc -vV | grep 'host:' | awk '{print $2}')
 export RUSTFLAGS="$RUSTFLAGS -C prefer-dynamic -Copt-level=3 -Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-inline-8bit-counters -Cllvm-args=-sanitizer-coverage-level=4 -Cllvm-args=-sanitizer-coverage-pc-table -Cllvm-args=-sanitizer-coverage-trace-compares"
 export BOLERO_FUZZER="libfuzzer"
 
+# The test binary hosts the libfuzzer runtime (linked in via bolero), and the simulator dlopens a
+# sancov-instrumented dylib whose coverage hooks (e.g. `__sanitizer_cov_pcs_init`) must resolve
+# against that runtime. Export the binary's symbols dynamically so the loader can find them;
+# without this, loading the dylib fails with "undefined symbol: __sanitizer_cov_pcs_init".
+if [[ "$(uname)" == "Darwin" ]]; then
+  export RUSTFLAGS="$RUSTFLAGS -Clink-arg=-export_dynamic"
+else
+  export RUSTFLAGS="$RUSTFLAGS -Clink-arg=-Wl,-export-dynamic"
+fi
+
 cargo test --lib ${@:2} --nocapture --test-threads=1


### PR DESCRIPTION
This change fixes the following error when a fuzzer is run outside the `hydro_lang` crate

```
"/tmp/.tmpHfZVzn: undefined symbol: __sanitizer_cov_trace_const_cmp8"
```