### PR TITLE
refactor(hydro_lang): replace sim channels with single-threaded waker-backed queues

### DIFF
--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -148,7 +148,7 @@ impl SimBuilder {
             Span::call_site(),
         );
         self.extra_stmts_global.push(syn::parse_quote! {
-            let #ident: ::std::rc::Rc<::std::cell::RefCell<::std::collections::HashMap<u32, __root_dfir_rs::tokio::sync::mpsc::UnboundedSender<#elem_ty>>>> =
+            let #ident: ::std::rc::Rc<::std::cell::RefCell<::std::collections::HashMap<u32, __root_dfir_rs::util::unsync::mpsc::Sender<#elem_ty>>>> =
                 ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::HashMap::new()));
         });
         self.channel_tables.insert(channel_id, ident.clone());
@@ -205,7 +205,7 @@ impl SimBuilder {
         let send_body: syn::Expr = syn::parse_quote! {
             {
                 if let Some(__s) = #send_table.borrow().get(&#dest_expr) {
-                    let _ = __s.send(#payload_expr);
+                    let _ = __s.try_send(#payload_expr);
                 }
             }
         };
@@ -251,7 +251,7 @@ impl SimBuilder {
         let register_stmt: syn::Stmt = syn::parse_quote! {
             let #channel_source = {
                 let (__channel_sink, __channel_source) =
-                    __root_dfir_rs::util::unbounded_channel::<#elem_ty>();
+                    __root_dfir_rs::util::unsync::mpsc::unbounded::<#elem_ty>();
                 #recv_table.borrow_mut().insert(#member_key_expr, __channel_sink);
                 __channel_source
             };
@@ -367,7 +367,7 @@ impl DfirBuilder for SimBuilder {
                         syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
 
                     self.add_extra_stmt_internal(in_location, syn::parse_quote! {
-                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unsync::mpsc::unbounded();
                     });
                     self.add_extra_stmt_internal(in_location, syn::parse_quote! {
                         let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
@@ -431,7 +431,7 @@ impl DfirBuilder for SimBuilder {
                         syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
 
                     self.add_extra_stmt_internal(in_location, syn::parse_quote! {
-                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unsync::mpsc::unbounded();
                     });
                     self.add_extra_stmt_internal(in_location, syn::parse_quote! {
                         let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(__root_dfir_rs::rustc_hash::FxHashMap::<_, ::std::collections::VecDeque<_>>::default()));
@@ -504,7 +504,7 @@ impl DfirBuilder for SimBuilder {
                     };
 
                     self.add_extra_stmt_internal(in_location, syn::parse_quote! {
-                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unsync::mpsc::unbounded();
                     });
                     self.add_extra_stmt_internal(in_location, syn::parse_quote! {
                         let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
@@ -553,7 +553,7 @@ impl DfirBuilder for SimBuilder {
                         syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
 
                     self.add_extra_stmt_internal(in_location, syn::parse_quote! {
-                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unsync::mpsc::unbounded();
                     });
                     self.add_extra_stmt_internal(in_location, syn::parse_quote! {
                         let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(__root_dfir_rs::rustc_hash::FxHashMap::<_, ::std::collections::VecDeque<_>>::default()));
@@ -630,12 +630,12 @@ impl DfirBuilder for SimBuilder {
                         syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
 
                     self.add_extra_stmt_internal(out_location, syn::parse_quote! {
-                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unsync::mpsc::unbounded();
                     });
 
                     self.get_dfir_mut(in_location).add_dfir(
                         parse_quote! {
-                            #in_ident -> for_each(|v| #hoff_send_ident.send(v).unwrap());
+                            #in_ident -> for_each(|v| #hoff_send_ident.try_send(v).unwrap());
                         },
                         None,
                         None,
@@ -771,11 +771,11 @@ impl DfirBuilder for SimBuilder {
                         syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
 
                     self.add_extra_stmt_internal(location.root(), syn::parse_quote! {
-                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unsync::mpsc::unbounded();
                     });
 
                     self.add_extra_stmt_internal(location.root(), syn::parse_quote! {
-                        let #hoff_recv_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(#hoff_recv_ident.into_inner()));
+                        let #hoff_recv_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(#hoff_recv_ident));
                     });
 
                     self.add_extra_stmt_internal(location.root(), syn::parse_quote! {
@@ -844,11 +844,11 @@ impl DfirBuilder for SimBuilder {
                         syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
 
                     self.add_extra_stmt_internal(location.root(), syn::parse_quote! {
-                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unsync::mpsc::unbounded();
                     });
 
                     self.add_extra_stmt_internal(location.root(), syn::parse_quote! {
-                        let #hoff_recv_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(#hoff_recv_ident.into_inner()));
+                        let #hoff_recv_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(#hoff_recv_ident));
                     });
 
                     self.add_extra_stmt_internal(location.root(), syn::parse_quote! {
@@ -918,11 +918,11 @@ impl DfirBuilder for SimBuilder {
                         syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
 
                     self.add_extra_stmt_internal(location.root(), syn::parse_quote! {
-                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unsync::mpsc::unbounded();
                     });
 
                     self.add_extra_stmt_internal(location.root(), syn::parse_quote! {
-                        let #hoff_recv_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(#hoff_recv_ident.into_inner()));
+                        let #hoff_recv_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(#hoff_recv_ident));
                     });
 
                     self.add_extra_stmt_internal(location.root(), syn::parse_quote! {
@@ -1004,7 +1004,7 @@ impl DfirBuilder for SimBuilder {
                         syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
 
                     self.add_extra_stmt_internal(location, syn::parse_quote! {
-                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unsync::mpsc::unbounded();
                     });
                     self.add_extra_stmt_internal(location, syn::parse_quote! {
                         let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));
@@ -1063,7 +1063,7 @@ impl DfirBuilder for SimBuilder {
                         syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
 
                     self.add_extra_stmt_internal(location, syn::parse_quote! {
-                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unsync::mpsc::unbounded();
                     });
                     self.add_extra_stmt_internal(location, syn::parse_quote! {
                         let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(__root_dfir_rs::rustc_hash::FxHashMap::default()));
@@ -1122,7 +1122,7 @@ impl DfirBuilder for SimBuilder {
                         syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
 
                     self.add_extra_stmt_internal(location, syn::parse_quote! {
-                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                        let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unsync::mpsc::unbounded();
                     });
                     self.add_extra_stmt_internal(location, syn::parse_quote! {
                         let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(__root_dfir_rs::rustc_hash::FxHashMap::default()));
@@ -1228,11 +1228,11 @@ impl DfirBuilder for SimBuilder {
                 syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
 
             self.add_extra_stmt_internal(location.root(), syn::parse_quote! {
-                let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unsync::mpsc::unbounded();
             });
 
             self.add_extra_stmt_internal(location.root(), syn::parse_quote! {
-                let #hoff_recv_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(#hoff_recv_ident.into_inner()));
+                let #hoff_recv_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(#hoff_recv_ident));
             });
 
             self.add_extra_stmt_internal(
@@ -1338,7 +1338,7 @@ impl DfirBuilder for SimBuilder {
                 syn::Ident::new(&format!("__hoff_recv_{hoff_id}"), Span::call_site());
 
             self.add_extra_stmt_internal(location, syn::parse_quote! {
-                let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unsync::mpsc::unbounded();
             });
 
             if is_keyed {
@@ -1495,13 +1495,13 @@ impl DfirBuilder for SimBuilder {
         match (from, to) {
             (LocationId::Process(_), LocationId::Process(_)) => {
                 self.extra_stmts_global.push(syn::parse_quote! {
-                    let (#sink, #source) = __root_dfir_rs::util::unbounded_channel::<#payload>();
+                    let (#sink, #source) = __root_dfir_rs::util::unsync::mpsc::unbounded::<#payload>();
                 });
 
                 if let Some(serialize_pipeline) = serialize {
                     self.get_dfir_mut(from).add_dfir(
                         parse_quote! {
-                            #input_ident -> map(#serialize_pipeline) -> for_each(|v| #sink.send(v).unwrap());
+                            #input_ident -> map(#serialize_pipeline) -> for_each(|v| #sink.try_send(v).unwrap());
                         },
                         None,
                         Some(&format!("send{}", tag_id)),
@@ -1509,7 +1509,7 @@ impl DfirBuilder for SimBuilder {
                 } else {
                     self.get_dfir_mut(from).add_dfir(
                         parse_quote! {
-                            #input_ident -> for_each(|v| #sink.send(v).unwrap());
+                            #input_ident -> for_each(|v| #sink.try_send(v).unwrap());
                         },
                         None,
                         Some(&format!("send{}", tag_id)),
@@ -1536,7 +1536,7 @@ impl DfirBuilder for SimBuilder {
             }
             (LocationId::Cluster(_), LocationId::Process(_)) => {
                 self.extra_stmts_global.push(syn::parse_quote! {
-                    let (#sink, #source) = __root_dfir_rs::util::unbounded_channel::<(#root::__staged::location::TaglessMemberId, #payload)>();
+                    let (#sink, #source) = __root_dfir_rs::util::unsync::mpsc::unbounded::<(#root::__staged::location::TaglessMemberId, #payload)>();
                 });
 
                 self.extra_stmts_cluster
@@ -1549,7 +1549,7 @@ impl DfirBuilder for SimBuilder {
                 if let Some(serialize_pipeline) = serialize {
                     self.get_dfir_mut(from).add_dfir(
                         parse_quote! {
-                            #input_ident -> map(#serialize_pipeline) -> for_each(|v| #sink.send((#root::__staged::location::TaglessMemberId::from_raw_id(__current_cluster_id), v)).unwrap());
+                            #input_ident -> map(#serialize_pipeline) -> for_each(|v| #sink.try_send((#root::__staged::location::TaglessMemberId::from_raw_id(__current_cluster_id), v)).unwrap());
                         },
                         None,
                         Some(&format!("send{}", tag_id)),
@@ -1557,7 +1557,7 @@ impl DfirBuilder for SimBuilder {
                 } else {
                     self.get_dfir_mut(from).add_dfir(
                         parse_quote! {
-                            #input_ident -> for_each(|v| #sink.send((#root::__staged::location::TaglessMemberId::from_raw_id(__current_cluster_id), v)).unwrap());
+                            #input_ident -> for_each(|v| #sink.try_send((#root::__staged::location::TaglessMemberId::from_raw_id(__current_cluster_id), v)).unwrap());
                         },
                         None,
                         Some(&format!("send{}", tag_id)),
@@ -1588,7 +1588,7 @@ impl DfirBuilder for SimBuilder {
                     Span::call_site(),
                 );
                 self.extra_stmts_global.push(syn::parse_quote! {
-                    let #sink: ::std::rc::Rc<::std::cell::RefCell<Vec<__root_dfir_rs::tokio::sync::mpsc::UnboundedSender<#payload>>>> = ::std::rc::Rc::new(::std::cell::RefCell::new(Vec::new()));
+                    let #sink: ::std::rc::Rc<::std::cell::RefCell<Vec<__root_dfir_rs::util::unsync::mpsc::Sender<#payload>>>> = ::std::rc::Rc::new(::std::cell::RefCell::new(Vec::new()));
                 });
 
                 self.extra_stmts_global.push(syn::parse_quote! {
@@ -1600,7 +1600,7 @@ impl DfirBuilder for SimBuilder {
                     .or_default()
                     .push(syn::parse_quote! {
                         let #source = {
-                            let (__sink, __source) = __root_dfir_rs::util::unbounded_channel::<#payload>();
+                            let (__sink, __source) = __root_dfir_rs::util::unsync::mpsc::unbounded::<#payload>();
                             #sink_writer.borrow_mut().push(__sink);
                             __source
                         };
@@ -1609,7 +1609,7 @@ impl DfirBuilder for SimBuilder {
                 if let Some(serialize_pipeline) = serialize {
                     self.get_dfir_mut(from).add_dfir(
                         parse_quote! {
-                            #input_ident -> map(#serialize_pipeline) -> for_each(|(target_member_id, v)| (#sink.borrow())[#root::__staged::location::TaglessMemberId::get_raw_id(&target_member_id) as usize].send(v).unwrap());
+                            #input_ident -> map(#serialize_pipeline) -> for_each(|(target_member_id, v)| (#sink.borrow())[#root::__staged::location::TaglessMemberId::get_raw_id(&target_member_id) as usize].try_send(v).unwrap());
                         },
                         None,
                         Some(&format!("send{}", tag_id)),
@@ -1617,7 +1617,7 @@ impl DfirBuilder for SimBuilder {
                 } else {
                     self.get_dfir_mut(from).add_dfir(
                         parse_quote! {
-                            #input_ident -> for_each(|(target_member_id, v)| (#sink.borrow())[#root::__staged::location::TaglessMemberId::get_raw_id(&target_member_id) as usize].send(v).unwrap());
+                            #input_ident -> for_each(|(target_member_id, v)| (#sink.borrow())[#root::__staged::location::TaglessMemberId::get_raw_id(&target_member_id) as usize].try_send(v).unwrap());
                         },
                         None,
                         Some(&format!("send{}", tag_id)),
@@ -1648,7 +1648,7 @@ impl DfirBuilder for SimBuilder {
                     Span::call_site(),
                 );
                 self.extra_stmts_global.push(syn::parse_quote! {
-                    let #sink: ::std::rc::Rc<::std::cell::RefCell<Vec<__root_dfir_rs::tokio::sync::mpsc::UnboundedSender<(#root::__staged::location::TaglessMemberId, #payload)>>>> = ::std::rc::Rc::new(::std::cell::RefCell::new(Vec::new()));
+                    let #sink: ::std::rc::Rc<::std::cell::RefCell<Vec<__root_dfir_rs::util::unsync::mpsc::Sender<(#root::__staged::location::TaglessMemberId, #payload)>>>> = ::std::rc::Rc::new(::std::cell::RefCell::new(Vec::new()));
                 });
 
                 self.extra_stmts_global.push(syn::parse_quote! {
@@ -1667,7 +1667,7 @@ impl DfirBuilder for SimBuilder {
                     .or_default()
                     .push(syn::parse_quote! {
                         let #source = {
-                            let (__sink, __source) = __root_dfir_rs::util::unbounded_channel::<(#root::__staged::location::TaglessMemberId, #payload)>();
+                            let (__sink, __source) = __root_dfir_rs::util::unsync::mpsc::unbounded::<(#root::__staged::location::TaglessMemberId, #payload)>();
                             #sink_writer.borrow_mut().push(__sink);
                             __source
                         };
@@ -1676,7 +1676,7 @@ impl DfirBuilder for SimBuilder {
                 if let Some(serialize_pipeline) = serialize {
                     self.get_dfir_mut(from).add_dfir(
                         parse_quote! {
-                            #input_ident -> map(#serialize_pipeline) -> for_each(|(target_member_id, v)| (#sink.borrow())[#root::__staged::location::TaglessMemberId::get_raw_id(&target_member_id) as usize].send((#root::__staged::location::TaglessMemberId::from_raw_id(__current_cluster_id), v)).unwrap());
+                            #input_ident -> map(#serialize_pipeline) -> for_each(|(target_member_id, v)| (#sink.borrow())[#root::__staged::location::TaglessMemberId::get_raw_id(&target_member_id) as usize].try_send((#root::__staged::location::TaglessMemberId::from_raw_id(__current_cluster_id), v)).unwrap());
                         },
                         None,
                         Some(&format!("send{}", tag_id)),
@@ -1684,7 +1684,7 @@ impl DfirBuilder for SimBuilder {
                 } else {
                     self.get_dfir_mut(from).add_dfir(
                         parse_quote! {
-                            #input_ident -> for_each(|(target_member_id, v)| (#sink.borrow())[#root::__staged::location::TaglessMemberId::get_raw_id(&target_member_id) as usize].send((#root::__staged::location::TaglessMemberId::from_raw_id(__current_cluster_id), v)).unwrap());
+                            #input_ident -> for_each(|(target_member_id, v)| (#sink.borrow())[#root::__staged::location::TaglessMemberId::get_raw_id(&target_member_id) as usize].try_send((#root::__staged::location::TaglessMemberId::from_raw_id(__current_cluster_id), v)).unwrap());
                         },
                         None,
                         Some(&format!("send{}", tag_id)),
@@ -1764,7 +1764,7 @@ impl DfirBuilder for SimBuilder {
         if let Some(serialize_pipeline) = serialize {
             self.get_dfir_mut(on).add_dfir(
                 parse_quote! {
-                    #input_ident -> map(#serialize_pipeline) -> for_each(|v| #grabbed_ident.send(v).unwrap());
+                    #input_ident -> map(#serialize_pipeline) -> for_each(|v| #grabbed_ident.try_send(v).unwrap());
                 },
                 None,
                 Some(&format!("send{}", tag_id)),
@@ -1772,7 +1772,7 @@ impl DfirBuilder for SimBuilder {
         } else {
             self.get_dfir_mut(on).add_dfir(
                 parse_quote! {
-                    #input_ident -> for_each(|v| #grabbed_ident.send(v).unwrap());
+                    #input_ident -> for_each(|v| #grabbed_ident.try_send(v).unwrap());
                 },
                 None,
                 Some(&format!("send{}", tag_id)),
@@ -1816,11 +1816,11 @@ impl DfirBuilder for SimBuilder {
                 syn::Ident::new(&format!("__fold_hook_out_{hoff_id}"), Span::call_site());
 
             self.add_extra_stmt_internal(tick_location.root(), syn::parse_quote! {
-                let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+                let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unsync::mpsc::unbounded();
             });
 
             self.add_extra_stmt_internal(tick_location.root(), syn::parse_quote! {
-                let #hoff_recv_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(#hoff_recv_ident.into_inner()));
+                let #hoff_recv_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(#hoff_recv_ident));
             });
 
             self.add_extra_stmt_internal(
@@ -1899,7 +1899,7 @@ impl DfirBuilder for SimBuilder {
         let out_ident = syn::Ident::new(&format!("__fold_hook_out_{hoff_id}"), Span::call_site());
 
         self.add_extra_stmt_internal(location, syn::parse_quote! {
-            let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unbounded_channel();
+            let (#hoff_send_ident, #hoff_recv_ident) = __root_dfir_rs::util::unsync::mpsc::unbounded();
         });
         self.add_extra_stmt_internal(location, syn::parse_quote! {
             let #buffered_ident = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::VecDeque::new()));

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -32,14 +32,13 @@ use std::task::ready;
 use bytes::Bytes;
 use colored::Colorize;
 use dfir_rs::scheduled::context::DfirErased;
+use dfir_rs::util::unsync::mpsc::{Receiver as UnsyncReceiver, Sender as UnsyncSender};
 use futures::{Stream, StreamExt};
 use libloading::Library;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tempfile::TempPath;
-use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::{Mutex, Notify};
-use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use super::runtime::{Hooks, InlineHooks};
 use super::{SimClusterReceiver, SimClusterSender, SimReceiver, SimSender};
@@ -85,11 +84,11 @@ impl QuiescenceState {
 }
 
 struct SimConnections {
-    input_senders: HashMap<SimExternalPort, Rc<UnboundedSender<Bytes>>>,
-    output_receivers: HashMap<SimExternalPort, Rc<Mutex<UnboundedReceiverStream<Bytes>>>>,
-    cluster_input_senders: HashMap<SimExternalPort, HashMap<u32, Rc<UnboundedSender<Bytes>>>>,
+    input_senders: HashMap<SimExternalPort, UnsyncSender<Bytes>>,
+    output_receivers: HashMap<SimExternalPort, Rc<Mutex<UnsyncReceiver<Bytes>>>>,
+    cluster_input_senders: HashMap<SimExternalPort, HashMap<u32, UnsyncSender<Bytes>>>,
     cluster_output_receivers:
-        HashMap<SimExternalPort, HashMap<u32, Rc<Mutex<UnboundedReceiverStream<Bytes>>>>>,
+        HashMap<SimExternalPort, HashMap<u32, Rc<Mutex<UnsyncReceiver<Bytes>>>>>,
     external_registered: HashMap<ExternalPortId, SimExternalPort>,
     quiescence: Rc<QuiescenceState>,
     log: bool,
@@ -211,10 +210,10 @@ type SimLoaded<'a> = libloading::Symbol<
     'a,
     unsafe extern "Rust" fn(
         should_color: bool,
-        external_out: &mut HashMap<usize, UnboundedReceiverStream<Bytes>>,
-        external_in: &mut HashMap<usize, UnboundedSender<Bytes>>,
-        cluster_external_out: &mut HashMap<usize, HashMap<u32, UnboundedReceiverStream<Bytes>>>,
-        cluster_external_in: &mut HashMap<usize, HashMap<u32, UnboundedSender<Bytes>>>,
+        external_out: &mut HashMap<usize, UnsyncReceiver<Bytes>>,
+        external_in: &mut HashMap<usize, UnsyncSender<Bytes>>,
+        cluster_external_out: &mut HashMap<usize, HashMap<u32, UnsyncReceiver<Bytes>>>,
+        cluster_external_in: &mut HashMap<usize, HashMap<u32, UnsyncSender<Bytes>>>,
         println_handler: fn(fmt::Arguments<'_>),
         eprintln_handler: fn(fmt::Arguments<'_>),
     ) -> (
@@ -533,11 +532,11 @@ impl<'a> CompiledSimInstance<'a> {
         mut self,
         thunk: impl AsyncFnOnce(CompiledSimInstance) + RefUnwindSafe,
     ) {
-        let mut external_out: HashMap<usize, UnboundedReceiverStream<Bytes>> = HashMap::new();
-        let mut external_in: HashMap<usize, UnboundedSender<Bytes>> = HashMap::new();
-        let mut cluster_external_out: HashMap<usize, HashMap<u32, UnboundedReceiverStream<Bytes>>> =
+        let mut external_out: HashMap<usize, UnsyncReceiver<Bytes>> = HashMap::new();
+        let mut external_in: HashMap<usize, UnsyncSender<Bytes>> = HashMap::new();
+        let mut cluster_external_out: HashMap<usize, HashMap<u32, UnsyncReceiver<Bytes>>> =
             HashMap::new();
-        let mut cluster_external_in: HashMap<usize, HashMap<u32, UnboundedSender<Bytes>>> =
+        let mut cluster_external_in: HashMap<usize, HashMap<u32, UnsyncSender<Bytes>>> =
             HashMap::new();
 
         let dylib_result = unsafe {
@@ -580,19 +579,13 @@ impl<'a> CompiledSimInstance<'a> {
         for sim_port in registered.values() {
             let usize_key = sim_port.into_inner();
             if let Some(sender) = external_in.remove(&usize_key) {
-                input_senders.insert(*sim_port, Rc::new(sender));
+                input_senders.insert(*sim_port, sender);
             }
             if let Some(receiver) = external_out.remove(&usize_key) {
                 output_receivers.insert(*sim_port, Rc::new(Mutex::new(receiver)));
             }
             if let Some(senders) = cluster_external_in.remove(&usize_key) {
-                cluster_input_senders.insert(
-                    *sim_port,
-                    senders
-                        .into_iter()
-                        .map(|(member, s)| (member, Rc::new(s)))
-                        .collect(),
-                );
+                cluster_input_senders.insert(*sim_port, senders);
             }
             if let Some(receivers) = cluster_external_out.remove(&usize_key) {
                 cluster_output_receivers.insert(
@@ -958,10 +951,7 @@ impl<T: Serialize + DeserializeOwned> SimReceiver<T, NoOrder, ExactlyOnce> {
 }
 
 impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimSender<T, O, R> {
-    fn with_sink<Out>(
-        &self,
-        thunk: impl FnOnce(&dyn Fn(T) -> Result<(), tokio::sync::mpsc::error::SendError<Bytes>>) -> Out,
-    ) -> Out {
+    fn with_sink<Out>(&self, thunk: impl FnOnce(&dyn Fn(T)) -> Out) -> Out {
         let (sender, quiescence) = CURRENT_SIM_CONNECTIONS.with(|connections| {
             let connections = connections.borrow();
             (
@@ -975,9 +965,10 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimSender<T, O, R
         });
 
         thunk(&move |t| {
-            let res = sender.send(bincode::serialize(&t).unwrap().into());
+            sender
+                .try_send(bincode::serialize(&t).unwrap().into())
+                .unwrap();
             quiescence.resume();
-            res
         })
     }
 }
@@ -988,7 +979,7 @@ impl<T: Serialize + DeserializeOwned, O: Ordering> SimSender<T, O, ExactlyOnce> 
     pub fn send_many_unordered<I: IntoIterator<Item = T>>(&self, iter: I) {
         self.with_sink(|send| {
             for t in iter {
-                send(t).unwrap();
+                send(t);
             }
         })
     }
@@ -998,7 +989,7 @@ impl<T: Serialize + DeserializeOwned> SimSender<T, TotalOrder, ExactlyOnce> {
     /// Sends a message to the external bincode sink. The message will be asynchronously processed
     /// as part of the simulation.
     pub fn send(&self, t: T) {
-        self.with_sink(|send| send(t)).unwrap();
+        self.with_sink(|send| send(t));
     }
 
     /// Sends several messages to the external bincode sink. The messages will be asynchronously
@@ -1006,7 +997,7 @@ impl<T: Serialize + DeserializeOwned> SimSender<T, TotalOrder, ExactlyOnce> {
     pub fn send_many<I: IntoIterator<Item = T>>(&self, iter: I) {
         self.with_sink(|send| {
             for t in iter {
-                send(t).unwrap();
+                send(t);
             }
         })
     }
@@ -1093,12 +1084,7 @@ impl<T: Serialize + DeserializeOwned> SimClusterReceiver<T, NoOrder, ExactlyOnce
 }
 
 impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterSender<T, O, R> {
-    fn with_sink<Out>(
-        &self,
-        thunk: impl FnOnce(
-            &dyn Fn(u32, T) -> Result<(), tokio::sync::mpsc::error::SendError<Bytes>>,
-        ) -> Out,
-    ) -> Out {
+    fn with_sink<Out>(&self, thunk: impl FnOnce(&dyn Fn(u32, T)) -> Out) -> Out {
         let (senders, quiescence) = CURRENT_SIM_CONNECTIONS.with(|connections| {
             let connections = connections.borrow();
             (
@@ -1113,9 +1099,8 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterSender<
 
         thunk(&move |member_id: u32, t: T| {
             let payload = bincode::serialize(&t).unwrap();
-            let res = senders[&member_id].send(Bytes::from(payload));
+            senders[&member_id].try_send(Bytes::from(payload)).unwrap();
             quiescence.resume();
-            res
         })
     }
 }
@@ -1126,7 +1111,7 @@ impl<T: Serialize + DeserializeOwned, O: Ordering> SimClusterSender<T, O, Exactl
     pub fn send_many_unordered<I: IntoIterator<Item = (u32, T)>>(&self, iter: I) {
         self.with_sink(|send| {
             for (member_id, t) in iter {
-                send(member_id, t).unwrap();
+                send(member_id, t);
             }
         })
     }
@@ -1135,14 +1120,14 @@ impl<T: Serialize + DeserializeOwned, O: Ordering> SimClusterSender<T, O, Exactl
 impl<T: Serialize + DeserializeOwned> SimClusterSender<T, TotalOrder, ExactlyOnce> {
     /// Sends a value to a specific cluster member.
     pub fn send(&self, member_id: u32, t: T) {
-        self.with_sink(|send| send(member_id, t)).unwrap();
+        self.with_sink(|send| send(member_id, t));
     }
 
     /// Sends multiple values to specific cluster members.
     pub fn send_many<I: IntoIterator<Item = (u32, T)>>(&self, iter: I) {
         self.with_sink(|send| {
             for (member_id, t) in iter {
-                send(member_id, t).unwrap();
+                send(member_id, t);
             }
         })
     }

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -328,7 +328,7 @@ impl<'a> Deploy<'a> for SimDeploy {
         let ident = syn::Ident::new("__hydro_external_in", Span::call_site());
         let p1_port_usize = p1_port.0;
         syn::parse_quote!({
-            let (__sender, __receiver) = __root_dfir_rs::util::unbounded_channel::<__root_dfir_rs::bytes::Bytes>();
+            let (__sender, __receiver) = __root_dfir_rs::util::unsync::mpsc::unbounded::<__root_dfir_rs::bytes::Bytes>();
             #ident.insert(#p1_port_usize, __sender);
             __receiver
         })
@@ -355,8 +355,8 @@ impl<'a> Deploy<'a> for SimDeploy {
         let ident = syn::Ident::new("__hydro_external_out", Span::call_site());
         let p2_port_usize = p2_port.0;
         syn::parse_quote!({
-            let (__sender, __receiver) = __root_dfir_rs::util::unbounded_channel::<__root_dfir_rs::bytes::Bytes>();
-            #ident.insert(#p2_port_usize, __root_dfir_rs::tokio_stream::wrappers::UnboundedReceiverStream::new(__receiver.into_inner()));
+            let (__sender, __receiver) = __root_dfir_rs::util::unsync::mpsc::unbounded::<__root_dfir_rs::bytes::Bytes>();
+            #ident.insert(#p2_port_usize, __receiver);
             __sender
         })
     }
@@ -373,7 +373,7 @@ impl<'a> Deploy<'a> for SimDeploy {
         let ident = syn::Ident::new("__hydro_cluster_external_in", Span::call_site());
         let p1_port_usize = p1_port.0;
         syn::parse_quote!({
-            let (__sender, __receiver) = __root_dfir_rs::util::unbounded_channel::<__root_dfir_rs::bytes::Bytes>();
+            let (__sender, __receiver) = __root_dfir_rs::util::unsync::mpsc::unbounded::<__root_dfir_rs::bytes::Bytes>();
             #ident.entry(#p1_port_usize).or_insert_with(::std::collections::HashMap::new).insert(__current_cluster_id, __sender);
             __receiver
         })
@@ -399,8 +399,8 @@ impl<'a> Deploy<'a> for SimDeploy {
         let ident = syn::Ident::new("__hydro_cluster_external_out", Span::call_site());
         let p2_port_usize = p2_port.0;
         syn::parse_quote!({
-            let (__sender, __receiver) = __root_dfir_rs::util::unbounded_channel::<__root_dfir_rs::bytes::Bytes>();
-            #ident.entry(#p2_port_usize).or_insert_with(::std::collections::HashMap::new).insert(__current_cluster_id, __root_dfir_rs::tokio_stream::wrappers::UnboundedReceiverStream::new(__receiver.into_inner()));
+            let (__sender, __receiver) = __root_dfir_rs::util::unsync::mpsc::unbounded::<__root_dfir_rs::bytes::Bytes>();
+            #ident.entry(#p2_port_usize).or_insert_with(::std::collections::HashMap::new).insert(__current_cluster_id, __receiver);
             __sender
         })
     }
@@ -706,10 +706,10 @@ fn compile_sim_graph_trybuild(
         /// TODO(mingwei): enforce/check this, somehow
         #[allow(unused)]
         fn __hydro_runtime_core<'a>(
-            __hydro_external_out: &mut ::std::collections::HashMap<usize, __root_dfir_rs::tokio_stream::wrappers::UnboundedReceiverStream<__root_dfir_rs::bytes::Bytes>>,
-            __hydro_external_in: &mut ::std::collections::HashMap<usize, __root_dfir_rs::tokio::sync::mpsc::UnboundedSender<__root_dfir_rs::bytes::Bytes>>,
-            __hydro_cluster_external_out: &mut ::std::collections::HashMap<usize, ::std::collections::HashMap<u32, __root_dfir_rs::tokio_stream::wrappers::UnboundedReceiverStream<__root_dfir_rs::bytes::Bytes>>>,
-            __hydro_cluster_external_in: &mut ::std::collections::HashMap<usize, ::std::collections::HashMap<u32, __root_dfir_rs::tokio::sync::mpsc::UnboundedSender<__root_dfir_rs::bytes::Bytes>>>,
+            __hydro_external_out: &mut ::std::collections::HashMap<usize, __root_dfir_rs::util::unsync::mpsc::Receiver<__root_dfir_rs::bytes::Bytes>>,
+            __hydro_external_in: &mut ::std::collections::HashMap<usize, __root_dfir_rs::util::unsync::mpsc::Sender<__root_dfir_rs::bytes::Bytes>>,
+            __hydro_cluster_external_out: &mut ::std::collections::HashMap<usize, ::std::collections::HashMap<u32, __root_dfir_rs::util::unsync::mpsc::Receiver<__root_dfir_rs::bytes::Bytes>>>,
+            __hydro_cluster_external_in: &mut ::std::collections::HashMap<usize, ::std::collections::HashMap<u32, __root_dfir_rs::util::unsync::mpsc::Sender<__root_dfir_rs::bytes::Bytes>>>,
             __println_handler: fn(::std::fmt::Arguments<'_>),
             __eprintln_handler: fn(::std::fmt::Arguments<'_>),
         ) -> (
@@ -776,10 +776,10 @@ fn compile_sim_graph_trybuild(
         #[unsafe(no_mangle)]
         unsafe extern "Rust" fn __hydro_runtime(
             should_color: bool,
-            __hydro_external_out: &mut ::std::collections::HashMap<usize, __root_dfir_rs::tokio_stream::wrappers::UnboundedReceiverStream<__root_dfir_rs::bytes::Bytes>>,
-            __hydro_external_in: &mut ::std::collections::HashMap<usize, __root_dfir_rs::tokio::sync::mpsc::UnboundedSender<__root_dfir_rs::bytes::Bytes>>,
-            __hydro_cluster_external_out: &mut ::std::collections::HashMap<usize, ::std::collections::HashMap<u32, __root_dfir_rs::tokio_stream::wrappers::UnboundedReceiverStream<__root_dfir_rs::bytes::Bytes>>>,
-            __hydro_cluster_external_in: &mut ::std::collections::HashMap<usize, ::std::collections::HashMap<u32, __root_dfir_rs::tokio::sync::mpsc::UnboundedSender<__root_dfir_rs::bytes::Bytes>>>,
+            __hydro_external_out: &mut ::std::collections::HashMap<usize, __root_dfir_rs::util::unsync::mpsc::Receiver<__root_dfir_rs::bytes::Bytes>>,
+            __hydro_external_in: &mut ::std::collections::HashMap<usize, __root_dfir_rs::util::unsync::mpsc::Sender<__root_dfir_rs::bytes::Bytes>>,
+            __hydro_cluster_external_out: &mut ::std::collections::HashMap<usize, ::std::collections::HashMap<u32, __root_dfir_rs::util::unsync::mpsc::Receiver<__root_dfir_rs::bytes::Bytes>>>,
+            __hydro_cluster_external_in: &mut ::std::collections::HashMap<usize, ::std::collections::HashMap<u32, __root_dfir_rs::util::unsync::mpsc::Sender<__root_dfir_rs::bytes::Bytes>>>,
             __println_handler: fn(::std::fmt::Arguments<'_>),
             __eprintln_handler: fn(::std::fmt::Arguments<'_>),
         ) -> (

--- a/hydro_lang/src/sim/runtime.rs
+++ b/hydro_lang/src/sim/runtime.rs
@@ -8,7 +8,7 @@ use bolero::generator::bolero_generator::driver::object::Borrowed;
 use bolero::{ValueGenerator, produce};
 use colored::Colorize;
 use dfir_rs::rustc_hash::FxHashMap;
-use tokio::sync::mpsc::UnboundedSender;
+use dfir_rs::util::unsync::mpsc::Sender;
 
 use crate::live_collections::stream::{NoOrder, Ordering, TotalOrder};
 
@@ -183,7 +183,7 @@ type HookLocationMeta = (&'static str, &'static str, &'static str);
 pub struct StreamHook<T, Order: Ordering> {
     pub input: Rc<RefCell<VecDeque<T>>>,
     pub to_release: Option<Vec<T>>,
-    pub output: UnboundedSender<T>,
+    pub output: Sender<T>,
     pub batch_location: HookLocationMeta,
     pub format_item_debug: fn(&T) -> Option<String>,
     pub _order: std::marker::PhantomData<Order>,
@@ -248,7 +248,7 @@ impl<T> SimHook for StreamHook<T, TotalOrder> {
             }
 
             for item in to_release {
-                self.output.send(item).unwrap();
+                self.output.try_send(item).unwrap();
             }
         } else {
             panic!("No decision to release");
@@ -334,7 +334,7 @@ impl<T> SimHook for StreamHook<T, NoOrder> {
             }
 
             for item in to_release {
-                self.output.send(item).unwrap();
+                self.output.try_send(item).unwrap();
             }
         } else {
             panic!("No decision to release");
@@ -345,7 +345,7 @@ impl<T> SimHook for StreamHook<T, NoOrder> {
 pub struct KeyedStreamHook<K: Hash + Eq + Clone, V, Order: Ordering> {
     pub input: Rc<RefCell<FxHashMap<K, VecDeque<V>>>>, // FxHasher is deterministic
     pub to_release: Option<Vec<(K, V)>>,
-    pub output: UnboundedSender<(K, V)>,
+    pub output: Sender<(K, V)>,
     pub batch_location: HookLocationMeta,
     pub format_item_debug: fn(&(K, V)) -> Option<String>,
     pub _order: std::marker::PhantomData<Order>,
@@ -435,7 +435,7 @@ impl<K: Hash + Eq + Clone, V> SimHook for KeyedStreamHook<K, V, TotalOrder> {
             }
 
             for item in to_release {
-                self.output.send(item).unwrap();
+                self.output.try_send(item).unwrap();
             }
         } else {
             panic!("No decision to release");
@@ -534,7 +534,7 @@ impl<K: Hash + Eq + Clone, V> SimHook for KeyedStreamHook<K, V, NoOrder> {
             }
 
             for item in to_release {
-                self.output.send(item).unwrap();
+                self.output.try_send(item).unwrap();
             }
         } else {
             panic!("No decision to release");
@@ -547,7 +547,7 @@ pub struct SingletonHook<T> {
     to_release: Option<(T, bool)>, // (data, is new)
     last_released: Option<T>,
     skipped_states: Vec<T>,
-    output: UnboundedSender<T>,
+    output: Sender<T>,
     batch_location: HookLocationMeta,
     format_item_debug: fn(&T) -> Option<String>,
 }
@@ -555,7 +555,7 @@ pub struct SingletonHook<T> {
 impl<T: Clone> SingletonHook<T> {
     pub fn new(
         input: Rc<RefCell<VecDeque<T>>>,
-        output: UnboundedSender<T>,
+        output: Sender<T>,
         batch_location: HookLocationMeta,
         format_item_debug: fn(&T) -> Option<String>,
     ) -> Self {
@@ -666,7 +666,7 @@ impl<T: Clone> SimHook for SingletonHook<T> {
                 );
             }
 
-            self.output.send(to_release).unwrap();
+            self.output.try_send(to_release).unwrap();
         } else {
             panic!("No decision to release");
         }
@@ -680,7 +680,7 @@ impl<T: Clone> SimHook for SingletonHook<T> {
 pub struct PassthroughSingletonHook<T> {
     input: Rc<RefCell<VecDeque<T>>>,
     to_release: Option<T>,
-    output: UnboundedSender<T>,
+    output: Sender<T>,
     batch_location: HookLocationMeta,
     format_item_debug: fn(&T) -> Option<String>,
 }
@@ -688,7 +688,7 @@ pub struct PassthroughSingletonHook<T> {
 impl<T> PassthroughSingletonHook<T> {
     pub fn new(
         input: Rc<RefCell<VecDeque<T>>>,
-        output: UnboundedSender<T>,
+        output: Sender<T>,
         batch_location: HookLocationMeta,
         format_item_debug: fn(&T) -> Option<String>,
     ) -> Self {
@@ -754,7 +754,7 @@ impl<T> SimHook for PassthroughSingletonHook<T> {
                 );
             }
 
-            self.output.send(to_release).unwrap();
+            self.output.try_send(to_release).unwrap();
         } else {
             panic!("No decision to release");
         }
@@ -766,7 +766,7 @@ pub struct KeyedSingletonHook<K: Hash + Eq + Clone, V: Clone> {
     to_release: Option<Vec<(K, V, bool)>>,         // (key, data, is new)
     last_released: FxHashMap<K, V>,
     skipped_states: FxHashMap<K, Vec<V>>,
-    output: UnboundedSender<(K, V)>,
+    output: Sender<(K, V)>,
     batch_location: HookLocationMeta,
     format_key_debug: fn(&K) -> Option<String>,
     format_value_debug: fn(&V) -> Option<String>,
@@ -775,7 +775,7 @@ pub struct KeyedSingletonHook<K: Hash + Eq + Clone, V: Clone> {
 impl<K: Hash + Eq + Clone, V: Clone> KeyedSingletonHook<K, V> {
     pub fn new(
         input: Rc<RefCell<FxHashMap<K, VecDeque<V>>>>,
-        output: UnboundedSender<(K, V)>,
+        output: Sender<(K, V)>,
         batch_location: HookLocationMeta,
         format_key_debug: fn(&K) -> Option<String>,
         format_value_debug: fn(&V) -> Option<String>,
@@ -918,7 +918,7 @@ impl<K: Hash + Eq + Clone, V: Clone> SimHook for KeyedSingletonHook<K, V> {
             }
 
             for (key, value, _) in to_release {
-                self.output.send((key, value)).unwrap();
+                self.output.try_send((key, value)).unwrap();
             }
         } else {
             panic!("No decision to release");
@@ -929,7 +929,7 @@ impl<K: Hash + Eq + Clone, V: Clone> SimHook for KeyedSingletonHook<K, V> {
 pub struct StreamOrderHook<T> {
     input: Rc<RefCell<Option<Vec<T>>>>,
     to_release: Option<Vec<T>>,
-    output: UnboundedSender<Vec<T>>,
+    output: Sender<Vec<T>>,
     batch_location: HookLocationMeta,
     format_debug: fn(&T) -> Option<String>,
 }
@@ -937,7 +937,7 @@ pub struct StreamOrderHook<T> {
 impl<T> StreamOrderHook<T> {
     pub fn new(
         input: Rc<RefCell<Option<Vec<T>>>>,
-        output: UnboundedSender<Vec<T>>,
+        output: Sender<Vec<T>>,
         batch_location: HookLocationMeta,
         format_debug: fn(&T) -> Option<String>,
     ) -> Self {
@@ -1002,7 +1002,7 @@ impl<T> SimInlineHook for StreamOrderHook<T> {
                 );
             }
 
-            self.output.send(to_release).unwrap();
+            self.output.try_send(to_release).unwrap();
         } else {
             panic!("No decision to release");
         }
@@ -1014,7 +1014,7 @@ pub struct MergeOrderedHook<T> {
     second: Rc<RefCell<Option<Vec<T>>>>,
     to_release: Option<Vec<T>>,
     release_sources: Option<Vec<bool>>,
-    output: UnboundedSender<Vec<T>>,
+    output: Sender<Vec<T>>,
     batch_location: HookLocationMeta,
     format_debug: fn(&T) -> Option<String>,
 }
@@ -1023,7 +1023,7 @@ impl<T> MergeOrderedHook<T> {
     pub fn new(
         first: Rc<RefCell<Option<Vec<T>>>>,
         second: Rc<RefCell<Option<Vec<T>>>>,
-        output: UnboundedSender<Vec<T>>,
+        output: Sender<Vec<T>>,
         batch_location: HookLocationMeta,
         format_debug: fn(&T) -> Option<String>,
     ) -> Self {
@@ -1133,7 +1133,7 @@ impl<T> SimInlineHook for MergeOrderedHook<T> {
                 );
             }
 
-            self.output.send(to_release).unwrap();
+            self.output.try_send(to_release).unwrap();
         } else {
             panic!("No decision to release");
         }
@@ -1145,7 +1145,7 @@ type KeyedStreamOrderHookInput<K, V> = Rc<RefCell<Option<Vec<(K, V)>>>>;
 pub struct KeyedStreamOrderHook<K: Hash + Eq + Clone, V> {
     input: KeyedStreamOrderHookInput<K, V>,
     to_release: Option<FxHashMap<K, Vec<V>>>,
-    output: UnboundedSender<Vec<(K, V)>>,
+    output: Sender<Vec<(K, V)>>,
     batch_location: HookLocationMeta,
     format_key_debug: fn(&K) -> Option<String>,
     format_value_debug: fn(&V) -> Option<String>,
@@ -1154,7 +1154,7 @@ pub struct KeyedStreamOrderHook<K: Hash + Eq + Clone, V> {
 impl<K: Hash + Eq + Clone, V> KeyedStreamOrderHook<K, V> {
     pub fn new(
         input: KeyedStreamOrderHookInput<K, V>,
-        output: UnboundedSender<Vec<(K, V)>>,
+        output: Sender<Vec<(K, V)>>,
         batch_location: HookLocationMeta,
         format_key_debug: fn(&K) -> Option<String>,
         format_value_debug: fn(&V) -> Option<String>,
@@ -1249,7 +1249,7 @@ impl<K: Hash + Eq + Clone, V> SimInlineHook for KeyedStreamOrderHook<K, V> {
                     flat_out.push((k.clone(), v));
                 }
             }
-            self.output.send(flat_out).unwrap();
+            self.output.try_send(flat_out).unwrap();
         } else {
             panic!("No decision to release");
         }
@@ -1261,7 +1261,7 @@ impl<K: Hash + Eq + Clone, V> SimInlineHook for KeyedStreamOrderHook<K, V> {
 pub struct PartiallyOrderedStreamHook<K: Hash + Eq + Clone, V> {
     input: KeyedStreamOrderHookInput<K, V>,
     to_release: Option<Vec<(K, V)>>,
-    output: UnboundedSender<Vec<(K, V)>>,
+    output: Sender<Vec<(K, V)>>,
     batch_location: HookLocationMeta,
     format_key_debug: fn(&K) -> Option<String>,
     format_value_debug: fn(&V) -> Option<String>,
@@ -1270,7 +1270,7 @@ pub struct PartiallyOrderedStreamHook<K: Hash + Eq + Clone, V> {
 impl<K: Hash + Eq + Clone, V> PartiallyOrderedStreamHook<K, V> {
     pub fn new(
         input: KeyedStreamOrderHookInput<K, V>,
-        output: UnboundedSender<Vec<(K, V)>>,
+        output: Sender<Vec<(K, V)>>,
         batch_location: HookLocationMeta,
         format_key_debug: fn(&K) -> Option<String>,
         format_value_debug: fn(&V) -> Option<String>,
@@ -1368,7 +1368,7 @@ impl<K: Hash + Eq + Clone, V> SimInlineHook for PartiallyOrderedStreamHook<K, V>
                 );
             }
 
-            self.output.send(to_release).unwrap();
+            self.output.try_send(to_release).unwrap();
         } else {
             panic!("No decision to release");
         }
@@ -1396,7 +1396,7 @@ impl<K: Hash + Eq + Clone, V> SimInlineHook for PartiallyOrderedStreamHook<K, V>
 pub struct TopLevelStreamOrderHook<T> {
     pub input: Rc<RefCell<VecDeque<T>>>,
     pub to_release: Option<Vec<T>>,
-    pub output: UnboundedSender<T>,
+    pub output: Sender<T>,
     pub location: HookLocationMeta,
     pub format_item_debug: fn(&T) -> Option<String>,
 }
@@ -1470,7 +1470,7 @@ impl<T> SimHook for TopLevelStreamOrderHook<T> {
             }
 
             for item in to_release {
-                self.output.send(item).unwrap();
+                self.output.try_send(item).unwrap();
             }
         } else {
             panic!("No decision to release");
@@ -1484,7 +1484,7 @@ impl<T> SimHook for TopLevelStreamOrderHook<T> {
 pub struct TopLevelFoldHook<T> {
     pub input: Rc<RefCell<VecDeque<T>>>,
     pub to_release: Option<Vec<T>>,
-    pub output: UnboundedSender<Vec<T>>,
+    pub output: Sender<Vec<T>>,
     pub location: HookLocationMeta,
     pub format_item_debug: fn(&T) -> Option<String>,
 }
@@ -1580,7 +1580,7 @@ impl<T> SimHook for TopLevelFoldHook<T> {
                 );
             }
 
-            self.output.send(to_release).unwrap();
+            self.output.try_send(to_release).unwrap();
         } else {
             panic!("No decision to release");
         }
@@ -1593,7 +1593,7 @@ impl<T> SimHook for TopLevelFoldHook<T> {
 pub struct TopLevelKeyedStreamOrderHook<K: Hash + Eq + Clone, V> {
     pub input: Rc<RefCell<FxHashMap<K, VecDeque<V>>>>,
     pub to_release: Option<Vec<(K, V)>>,
-    pub output: UnboundedSender<(K, V)>,
+    pub output: Sender<(K, V)>,
     pub location: HookLocationMeta,
     pub format_item_debug: fn(&(K, V)) -> Option<String>,
 }
@@ -1684,7 +1684,7 @@ impl<K: Hash + Eq + Clone, V> SimHook for TopLevelKeyedStreamOrderHook<K, V> {
             }
 
             for item in to_release {
-                self.output.send(item).unwrap();
+                self.output.try_send(item).unwrap();
             }
         } else {
             panic!("No decision to release");
@@ -1698,7 +1698,7 @@ impl<K: Hash + Eq + Clone, V> SimHook for TopLevelKeyedStreamOrderHook<K, V> {
 pub struct TopLevelPartiallyOrderedStreamHook<K: Hash + Eq + Clone, V> {
     pub input: Rc<RefCell<FxHashMap<K, VecDeque<V>>>>,
     pub to_release: Option<Vec<(K, V)>>,
-    pub output: UnboundedSender<(K, V)>,
+    pub output: Sender<(K, V)>,
     pub location: HookLocationMeta,
     pub format_item_debug: fn(&(K, V)) -> Option<String>,
 }
@@ -1782,7 +1782,7 @@ impl<K: Hash + Eq + Clone, V> SimHook for TopLevelPartiallyOrderedStreamHook<K, 
             }
 
             for item in to_release {
-                self.output.send(item).unwrap();
+                self.output.try_send(item).unwrap();
             }
         } else {
             panic!("No decision to release");
@@ -1798,7 +1798,7 @@ pub struct TopLevelMergeOrderedHook<T> {
     pub second: Rc<RefCell<VecDeque<T>>>,
     pub to_release: Option<Vec<T>>,
     pub release_source: Option<&'static str>,
-    pub output: UnboundedSender<T>,
+    pub output: Sender<T>,
     pub location: HookLocationMeta,
     pub format_item_debug: fn(&T) -> Option<String>,
 }
@@ -1890,7 +1890,7 @@ impl<T> SimHook for TopLevelMergeOrderedHook<T> {
             }
 
             for item in to_release {
-                self.output.send(item).unwrap();
+                self.output.try_send(item).unwrap();
             }
         } else {
             panic!("No decision to release");
@@ -1911,7 +1911,7 @@ pub struct KeyedMergeOrderedHook<K: Hash + Eq + Clone, V> {
     second: KeyedMergeOrderedInput<K, V>,
     to_release: Option<Vec<(K, V)>>,
     release_sources: Option<Vec<bool>>,
-    output: UnboundedSender<Vec<(K, V)>>,
+    output: Sender<Vec<(K, V)>>,
     batch_location: HookLocationMeta,
     format_item_debug: fn(&(K, V)) -> Option<String>,
 }
@@ -1920,7 +1920,7 @@ impl<K: Hash + Eq + Clone, V> KeyedMergeOrderedHook<K, V> {
     pub fn new(
         first: KeyedMergeOrderedInput<K, V>,
         second: KeyedMergeOrderedInput<K, V>,
-        output: UnboundedSender<Vec<(K, V)>>,
+        output: Sender<Vec<(K, V)>>,
         batch_location: HookLocationMeta,
         format_item_debug: fn(&(K, V)) -> Option<String>,
     ) -> Self {
@@ -2046,7 +2046,7 @@ impl<K: Hash + Eq + Clone, V> SimInlineHook for KeyedMergeOrderedHook<K, V> {
                 );
             }
 
-            self.output.send(to_release).unwrap();
+            self.output.try_send(to_release).unwrap();
         } else {
             panic!("No decision to release");
         }
@@ -2064,7 +2064,7 @@ pub struct TopLevelKeyedMergeOrderedHook<K: Hash + Eq + Clone, V> {
     pub second: Rc<RefCell<FxHashMap<K, VecDeque<V>>>>,
     pub to_release: Option<Vec<(K, V)>>,
     pub release_source: Option<&'static str>,
-    pub output: UnboundedSender<(K, V)>,
+    pub output: Sender<(K, V)>,
     pub location: HookLocationMeta,
     pub format_item_debug: fn(&(K, V)) -> Option<String>,
 }
@@ -2182,7 +2182,7 @@ impl<K: Hash + Eq + Clone, V> SimHook for TopLevelKeyedMergeOrderedHook<K, V> {
             }
 
             for item in to_release {
-                self.output.send(item).unwrap();
+                self.output.try_send(item).unwrap();
             }
         } else {
             panic!("No decision to release");


### PR DESCRIPTION
The simulator runs all top-level and tick DFIRs (plus the test harness)
one at a time on a single thread via the scheduler, so the tokio mpsc
channels connecting them were unnecessary synchronization overhead.

Introduce `SimQueue<T>` in `sim::runtime`: a channel backed by a plain
`Rc<RefCell<VecDeque<T>>>` with an associated waker slot. Sending is a
direct push onto the deque; each push wakes the consumer registered by
the most recent empty poll, so the DFIR scheduler's `run_tick` /
quiescence machinery is preserved. The queue implements `Stream` for
direct use as a `source_stream` input and never yields `None`, since
channels are never closed during simulation, which eliminates all the
close-tracking, weak-ref, and capacity logic of a real channel. Both
"ends" are shallow clones of the same queue.

- `sim/runtime.rs`: hook `output` fields are now `SimQueue<T>`;
  releases use `.push(item)` instead of `.send(item).unwrap()`
- `sim/builder.rs`: generated `unbounded_channel()` sites now emit
  `SimQueue::new_split()`; the `Rc<RefCell<receiver.into_inner()>>`
  re-wrapping for inline hooks is deleted since the queue is directly
  clonable, with `recv().await` replacing `borrow_mut().recv().await.unwrap()`
- `sim/graph.rs`: external port codegen (e2o/o2e/e2m/m2e) and the
  `__hydro_runtime` dylib signature use `SimQueue<Bytes>` in both
  directions, dropping the `UnboundedReceiverStream` wrappers
- `sim/compiled.rs`: `SimConnections` / `SimLoaded` use `SimQueue<Bytes>`;
  senders no longer need `Rc` wrapping and `with_sink` closures are
  infallible

No public API changes.