### PR TITLE
docs: add Related API sections to live collection guide pages

### DIFF
--- a/docs/docs/hydro/reference/state-management/keyed-state.md
+++ b/docs/docs/hydro/reference/state-management/keyed-state.md
@@ -88,3 +88,8 @@ Since keys are unordered across groups, streams produced by flattening have `NoO
 
 ## Rekeying and Transformation
 Keyed singletons support per-key transformations like `map`, `filter`, and `filter_map` (operating on each value), and `map_with_key` when the transformation also needs the key. To change the *grouping key* of state (e.g., from client ID to resource name), regroup the underlying keyed stream **before** aggregating: flatten with `entries()`, remap the tuples, and regroup with `into_keyed()`, as shown in the [keyed counter tutorial](../../learn/quickstart/keyed-counter.mdx).
+
+## Related API
+
+- [`KeyedSingleton`](rust:hydro_lang::live_collections::KeyedSingleton)
+- Keyed singleton bounds: [`BoundedValue`](rust:hydro_lang::live_collections::keyed_singleton::BoundedValue), [`MonotonicValue`](rust:hydro_lang::live_collections::keyed_singleton::MonotonicValue), and [`MonotonicKeys`](rust:hydro_lang::live_collections::keyed_singleton::MonotonicKeys)

--- a/docs/docs/hydro/reference/state-management/singletons-optionals.md
+++ b/docs/docs/hydro/reference/state-management/singletons-optionals.md
@@ -132,3 +132,9 @@ let get_response = sliced! {
 ```
 
 Snapshots are asynchronous: each snapshot is at least as recent as the previous one, but may lag behind acknowledged writes. See [Slice Blocks](./slices.mdx) for the semantics of slicing, [References and Mutations](./references-mutations.md) for `by_ref()` and `by_mut()`, and [Atomic Collections](../atomic-collections.mdx) for establishing read-after-write consistency.
+
+## Related API
+
+- [`Singleton`](rust:hydro_lang::live_collections::Singleton)
+- [`Optional`](rust:hydro_lang::live_collections::Optional)
+- [`Monotonic`](rust:hydro_lang::live_collections::singleton::Monotonic)

--- a/docs/docs/hydro/reference/streaming-data/keyed-singletons.mdx
+++ b/docs/docs/hydro/reference/streaming-data/keyed-singletons.mdx
@@ -182,3 +182,8 @@ Inside a slice, batched keyed singletons also unlock relational APIs like `get`,
 The batch-of-new-entries semantics applies to `BoundedValue` keyed singletons. Slicing an `Unbounded` keyed singleton (mutable per-key state) instead reveals a **snapshot** of the current mapping; see [Keyed State](../state-management/keyed-state.md).
 
 :::
+
+## Related API
+
+- [`KeyedSingleton`](rust:hydro_lang::live_collections::KeyedSingleton)
+- Keyed singleton bounds: [`BoundedValue`](rust:hydro_lang::live_collections::keyed_singleton::BoundedValue), [`MonotonicValue`](rust:hydro_lang::live_collections::keyed_singleton::MonotonicValue), and [`MonotonicKeys`](rust:hydro_lang::live_collections::keyed_singleton::MonotonicKeys)

--- a/docs/docs/hydro/reference/streaming-data/keyed-streams.mdx
+++ b/docs/docs/hydro/reference/streaming-data/keyed-streams.mdx
@@ -194,3 +194,9 @@ This makes keyed streams particularly well-suited for distributed aggregations w
 
 ## Collapsing to One Value Per Key
 Keyed streams model *many* events per key. When each key should instead resolve to a *single* value — such as one response per request — you can collapse a keyed stream into a [Keyed Singleton](./keyed-singletons.mdx) using APIs like `first()` (take the first value for each key) or `fold_early_stop` (aggregate each key's values until the aggregation declares itself complete). See [Keyed Singletons](./keyed-singletons.mdx) for details.
+
+## Related API
+
+- [`KeyedStream`](rust:hydro_lang::live_collections::KeyedStream)
+- Ordering markers: [`TotalOrder`](rust:hydro_lang::live_collections::stream::TotalOrder) and [`NoOrder`](rust:hydro_lang::live_collections::stream::NoOrder)
+- Retry markers: [`ExactlyOnce`](rust:hydro_lang::live_collections::stream::ExactlyOnce) and [`AtLeastOnce`](rust:hydro_lang::live_collections::stream::AtLeastOnce)

--- a/docs/docs/hydro/reference/streaming-data/streams.md
+++ b/docs/docs/hydro/reference/streaming-data/streams.md
@@ -155,3 +155,9 @@ Use `assume_ordering` sparingly. Once you cast a stream to `TotalOrder`, the typ
 
 ## Bounded and Unbounded Streams
 Like all live collections, streams have a type parameter that tracks whether their contents are final (`Bounded`) or may continue to grow asynchronously (`Unbounded`). A stream created from a fixed in-memory collection with `source_iter` is bounded, while streams of network requests are unbounded. Several APIs — such as those that need to observe the _end_ of the stream — are only available on bounded streams. See [Bounded and Unbounded Types](../correctness/bounded-unbounded.md) for how boundedness is tracked and converted.
+
+## Related API
+
+- [`Stream`](rust:hydro_lang::live_collections::Stream)
+- Ordering markers: [`TotalOrder`](rust:hydro_lang::live_collections::stream::TotalOrder) and [`NoOrder`](rust:hydro_lang::live_collections::stream::NoOrder)
+- Retry markers: [`ExactlyOnce`](rust:hydro_lang::live_collections::stream::ExactlyOnce) and [`AtLeastOnce`](rust:hydro_lang::live_collections::stream::AtLeastOnce)


### PR DESCRIPTION
## Summary

Adds a terminal **Related API** section to the five live-collection guide pages, linking directly to the corresponding rustdoc items and guarantee marker types:

- `streaming-data/streams.md`: `Stream`, ordering markers, retry markers
- `streaming-data/keyed-streams.mdx`: `KeyedStream`, ordering markers, retry markers
- `streaming-data/keyed-singletons.mdx`: `KeyedSingleton`, keyed singleton bounds
- `state-management/singletons-optionals.md`: `Singleton`, `Optional`, `Monotonic`
- `state-management/keyed-state.md`: `KeyedSingleton`, keyed singleton bounds

All links use the `rust:` pseudo-link syntax, so they are resolved and validated against generated rustdoc at build time.

Split out of #3118 per review, so the Quick References reorganization and these guide-page additions can be reviewed independently.

## Testing

- Full production docs build passes (`npm run build` from `docs/`, includes rustdoc link validation)
