### PR TITLE
test(hydro_lang): fix tests re-entering a tick #3126

### DIFF
--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -3186,6 +3186,10 @@ mod tests {
         let node_tick = node.tick();
         let watermark = node_tick.singleton(q!(2));
 
+        // The reduce produces a top-level value driven by `node_tick`'s watermark. Snapshot it
+        // in a *distinct* tick so we don't re-enter `node_tick` (which supplied an input to the
+        // reduce), which is not representable as a DFIR loop.
+        let snapshot_tick = node.tick();
         let sum = node
             .source_stream(q!(tokio_stream::iter([
                 (0, 100),
@@ -3200,7 +3204,7 @@ mod tests {
                     *acc += v;
                 }),
             )
-            .snapshot(&node_tick, nondet!(/** test */))
+            .snapshot(&snapshot_tick, nondet!(/** test */))
             .entries()
             .all_ticks()
             .send_bincode_external(&external);
@@ -3286,6 +3290,11 @@ mod tests {
             )
             .all_ticks();
 
+        // Snapshot the top-level reduce output in a *distinct* tick from `node_tick` (which
+        // supplies the watermark and tick-triggered inputs to the reduce), so we don't re-enter
+        // `node_tick` — a value that already exited that tick coming back into it is not
+        // representable as a DFIR loop.
+        let snapshot_tick = node.tick();
         let sum = node
             .source_stream(q!(tokio_stream::iter([
                 (0, 100),
@@ -3304,7 +3313,7 @@ mod tests {
                     commutative = manual_proof!(/** integer addition is commutative */)
                 ),
             )
-            .snapshot(&node_tick, nondet!(/** test */))
+            .snapshot(&snapshot_tick, nondet!(/** test */))
             .entries()
             .all_ticks()
             .send_bincode_external(&external);

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -1648,17 +1648,21 @@ mod tests {
         let node = flow.process::<()>();
         let external = flow.external::<()>();
 
-        let node_tick = node.tick();
-        let top_level_none = node_tick.singleton(q!(123)).latest().filter(q!(|_| false));
+        let top_level_none = node
+            .tick()
+            .singleton(q!(123))
+            .latest()
+            .filter(q!(|_| false));
         let into_singleton = top_level_none.into_singleton();
 
         let tick_driver = node.spin();
 
+        let tick_later = node.tick();
         let counts = into_singleton
-            .snapshot(&node_tick, nondet!(/** test */))
+            .snapshot(&tick_later, nondet!(/** test */))
             .into_stream()
             .count()
-            .zip(tick_driver.batch(&node_tick, nondet!(/** test */)).count())
+            .zip(tick_driver.batch(&tick_later, nondet!(/** test */)).count())
             .map(q!(|(c, _)| c))
             .all_ticks()
             .send_bincode_external(&external);

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -109,6 +109,7 @@ pub enum NetworkHint {
     TcpPort(Option<u16>),
 }
 
+#[track_caller]
 pub(crate) fn check_matching_location<'a, L: Location<'a>>(l1: &L, l2: &L) {
     assert_eq!(Location::id(l1), Location::id(l2), "locations do not match");
 }


### PR DESCRIPTION
- `into_singleton_unbounded_top_level_none_cardinality`: snapshot/batch into a new
   `consume_tick` instead of the `node_tick` that produced the value via `.latest()`.
- `reduce_watermark_filter` / `reduce_watermark_garbage_collect`: snapshot into a new
   `snapshot_tick` instead of the `node_tick` that supplies the reduce's watermark.

Also adds `#[track_caller]` to `check_matching_location`