### PR TITLE
refactor(hydro_lang)!: surface DFIR partition failures instead of panicking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,6 +1761,7 @@ dependencies = [
  "documented",
  "hydro_build_utils",
  "itertools 0.14.0",
+ "nameof",
  "prettyplease",
  "proc-macro2",
  "quote",

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -18,7 +18,7 @@ criterion = { version = "0.5.0", features = [ "async_tokio", "html_reports" ] }
 dfir_rs = { path = "../dfir_rs", features = [ "debugging" ] }
 differential-dataflow = { package = "differential-dataflow-master", version = "0.13.0-dev.1" } # git = "https://github.com/TimelyDataflow/differential-dataflow.git", rev = "7bc5338a977fe1d95b96a9ba84ba8cd460e0cdd7" } # "0.12"
 futures = "0.3"
-nameof = "1.0.0"
+nameof = "1.3"
 rand = "0.10"
 rand_distr = "0.6"
 seq-macro = "0.2.0"

--- a/dfir_lang/Cargo.toml
+++ b/dfir_lang/Cargo.toml
@@ -40,6 +40,7 @@ clap = { version = "4.5.4", features = [ "derive" ], optional = true }
 data-encoding = { version = "2.0.0", optional = true }
 documented = { version = "0.9.1", optional = true }
 itertools = { version = "0.14.0", optional = true }
+nameof = "1.3.0"
 prettyplease = { version = "0.2.0", features = [ "verbatim" ], optional = true }
 proc-macro2 = { version = "1.0.95", features = [ "span-locations" ], optional = true }
 quote = { version = "1.0.35", optional = true }

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -511,7 +511,6 @@ fn mark_tick_boundary_handoffs(
 ///
 /// This hands back the original **flat graph** alongside the diagnostic, so callers can visualize
 /// the graph to diagnose the cycle that prevented partitioning.
-#[derive(Debug)]
 pub struct PartitionError {
     /// The pristine, un-partitioned flat graph (returned so it can still be rendered).
     ///
@@ -526,6 +525,14 @@ pub struct PartitionError {
 impl std::fmt::Display for PartitionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.diagnostic, f)
+    }
+}
+
+impl std::fmt::Debug for PartitionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(nameof::name_of_type!(PartitionError))
+            .field(nameof::name_of!(diagnostic in Self), &self.diagnostic)
+            .finish_non_exhaustive() // Hide the large `DfirGraph` debug output.
     }
 }
 

--- a/dfir_lang/src/graph/flat_to_partitioned.rs
+++ b/dfir_lang/src/graph/flat_to_partitioned.rs
@@ -507,21 +507,52 @@ fn mark_tick_boundary_handoffs(
     }
 }
 
+/// The error returned by [`partition_graph`] when partitioning fails.
+///
+/// This hands back the original **flat graph** alongside the diagnostic, so callers can visualize
+/// the graph to diagnose the cycle that prevented partitioning.
+#[derive(Debug)]
+pub struct PartitionError {
+    /// The pristine, un-partitioned flat graph (returned so it can still be rendered).
+    ///
+    /// Boxed because a [`DfirGraph`] is large (hundreds of bytes) and this keeps the
+    /// `Err` variant of [`partition_graph`]'s result small; the allocation only happens
+    /// on the (cold) failure path.
+    pub flat_graph: Box<DfirGraph>,
+    /// The diagnostic explaining why partitioning failed (names the offending cycle).
+    pub diagnostic: Diagnostic,
+}
+
+impl std::fmt::Display for PartitionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.diagnostic, f)
+    }
+}
+
 /// Main method for this module. Partitions a flat [`DfirGraph`] into one with subgraphs.
 ///
-/// Returns an error if an intra-tick cycle exists in the graph.
-pub fn partition_graph(flat_graph: DfirGraph) -> Result<DfirGraph, Diagnostic> {
+/// Returns [`PartitionError`] if an intra-tick cycle exists in the graph. On error the
+/// original (pristine, un-partitioned) flat graph is handed back inside the error so it
+/// can still be rendered for debugging — see [`PartitionError`].
+pub fn partition_graph(flat_graph: DfirGraph) -> Result<DfirGraph, PartitionError> {
     let (mut tick_edges, edge_barrier_pairs) = find_edge_barriers(&flat_graph);
     let access_group_pairs = find_access_group_ordering(&flat_graph);
     let mut partitioned_graph = flat_graph;
 
-    // Partition into subgraphs and insert handoffs.
-    make_subgraphs(
+    // Partition into subgraphs and insert handoffs. The only recoverable failure is an
+    // intra-tick cycle, which is detected before `partitioned_graph` is mutated, so on
+    // error it is still the pristine flat graph and safe to hand back.
+    if let Err(diagnostic) = make_subgraphs(
         &mut partitioned_graph,
         &mut tick_edges,
         &edge_barrier_pairs,
         &access_group_pairs,
-    )?;
+    ) {
+        return Err(PartitionError {
+            flat_graph: Box::new(partitioned_graph),
+            diagnostic,
+        });
+    }
 
     // Mark tick-boundary handoffs for double-buffering.
     mark_tick_boundary_handoffs(&mut partitioned_graph, &tick_edges);
@@ -595,7 +626,6 @@ mod tests {
         let FlatGraphBuilderOutput { flat_graph, .. } =
             builder.build().expect("should build without errors");
         let partitioned = partition_graph(flat_graph).expect("should partition without errors");
-
         // Verify: every forward (non-delay) handoff has its producer subgraph *before* its
         // consumer subgraph in the final `subgraph_toposort`.
         let order = partitioned.subgraph_toposort();
@@ -756,5 +786,60 @@ mod tests {
 
         // After rearrangement within outer: A, B, C, D — inner loop (B, C) contiguous.
         assert_eq!(result, vec![sg_a, sg_b, sg_c, sg_d]);
+    }
+
+    /// Demonstrates the mechanism behind the proposed fix for the "meta-graph
+    /// catch-22": when a flat graph contains an intra-tick cycle, [`partition_graph`]
+    /// fails, but the *flat* graph is still fully renderable to mermaid. That flat
+    /// rendering (plus the diagnostic, which names the offending cycle) is exactly
+    /// what a user needs to diagnose why partitioning failed.
+    ///
+    /// This is why [`partition_graph`] returns [`PartitionError`] (carrying the flat
+    /// graph) rather than discarding its input on failure: callers such as
+    /// `hydro_lang`'s `preview_compile` can then hand back a renderable meta graph to
+    /// debug the very error that prevents compilation. This test locks in that property.
+    #[test]
+    fn flat_mermaid_available_when_partition_fails() {
+        use crate::graph::{FlatGraphBuilder, FlatGraphBuilderOutput};
+
+        // An intra-tick cycle: `my_union` feeds a `map` that feeds back into
+        // `my_union` with no `defer_tick()` to break the cycle across ticks.
+        let mut builder = FlatGraphBuilder::new();
+        builder.add_dfir(
+            syn::parse_quote! {
+                source_iter(0..5) -> my_union;
+                my_union = union() -> map(|x| x + 1) -> my_union;
+            },
+            None,
+            None,
+        );
+
+        let FlatGraphBuilderOutput { flat_graph, .. } = builder
+            .build()
+            .expect("flat graph should build successfully");
+
+        // 1. The flat graph renders to mermaid just fine — the cyclic operators
+        //    (`union` and `map`) that make up the offending cycle are visible, so a
+        //    user could actually diagnose the problem from this rendering.
+        let flat_mermaid = flat_graph.mermaid_string_flat();
+        assert!(flat_mermaid.contains("flowchart"));
+        assert!(flat_mermaid.contains("union"));
+        assert!(flat_mermaid.contains("map"));
+
+        // 2. Partitioning fails, but hands back the pristine flat graph *and* a
+        //    diagnostic that names the cycle. Both pieces are exactly what a user
+        //    needs to debug the failure — and neither is discarded.
+        let err = partition_graph(flat_graph).expect_err("partitioning should fail on a cycle");
+        assert!(
+            format!("{}", err.diagnostic).contains("Cyclical dataflow within a tick"),
+            "unexpected diagnostic: {}",
+            err.diagnostic
+        );
+
+        // The returned flat graph is still fully renderable (this is the property the
+        // `hydro_lang` catch-22 fix relies on).
+        let recovered_mermaid = err.flat_graph.mermaid_string_flat();
+        assert!(recovered_mermaid.contains("union"));
+        assert!(recovered_mermaid.contains("map"));
     }
 }

--- a/dfir_lang/src/graph/mod.rs
+++ b/dfir_lang/src/graph/mod.rs
@@ -28,7 +28,7 @@ use std::fmt::Display;
 pub use di_mul_graph::DiMulGraph;
 pub use eliminate_extra_unions_tees::eliminate_extra_unions_tees;
 pub use flat_graph_builder::{FlatGraphBuilder, FlatGraphBuilderOutput};
-pub use flat_to_partitioned::partition_graph;
+pub use flat_to_partitioned::{PartitionError, partition_graph};
 pub use meta_graph::{DfirGraph, WriteConfig, WriteGraphType};
 
 pub use crate::graph_ids::{GraphEdgeId, GraphLoopId, GraphNodeId, GraphSubgraphId};
@@ -504,8 +504,8 @@ pub fn build_dfir_code(
 
     let partitioned_graph = match partition_graph(flat_graph) {
         Ok(partitioned_graph) => partitioned_graph,
-        Err(d) => {
-            diagnostics.push(d);
+        Err(err) => {
+            diagnostics.push(err.diagnostic);
             return Err(diagnostics);
         }
     };

--- a/dfir_macro/src/lib.rs
+++ b/dfir_macro/src/lib.rs
@@ -132,7 +132,7 @@ pub fn dfir_parser(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         let part_mermaid = partition_graph(flat_graph)
             .map(|part_graph| part_graph.to_mermaid(&Default::default()))
-            .unwrap_or_else(|err| format!("failed to partition: {err}"));
+            .unwrap_or_else(|err| format!("failed to partition: {}", err.diagnostic));
 
         let lit0 = Literal::string(&flat_mermaid);
         let lit1 = Literal::string(&part_mermaid);

--- a/hydro_deploy/core/Cargo.toml
+++ b/hydro_deploy/core/Cargo.toml
@@ -33,7 +33,7 @@ hydro_deploy_integration = { path = "../hydro_deploy_integration", version = "^0
 indicatif = "0.17.0"
 inferno = { version = "0.11.0", default-features = false, optional = true }
 memo-map = "0.3.0"
-nameof = "1.0.0"
+nameof = "1.3"
 nanoid = "0.5"
 nix = { version = "0.29.0", features = ["signal"] }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/hydro_lang/Cargo.toml
+++ b/hydro_lang/Cargo.toml
@@ -137,7 +137,7 @@ futures = "0.3.0"
 hydro_concurrent_cargo = { path = "../hydro_concurrent_cargo", version = "^0.1.0-alpha.0", optional = true }
 hydro_deploy = { path = "../hydro_deploy/core", version = "^0.17.0-alpha.3", optional = true }
 hydro_deploy_integration = { path = "../hydro_deploy/hydro_deploy_integration", version = "^0.17.0-alpha.2", optional = true }
-nameof = { version = "1.0.0", optional = true }
+nameof = { version = "1.3", optional = true }
 prettyplease = { version = "0.2.0", features = ["verbatim"], optional = true }
 proc-macro-crate = "3.3"
 proc-macro2 = "1.0.95"

--- a/hydro_lang/src/compile/built.rs
+++ b/hydro_lang/src/compile/built.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use dfir_lang::graph::{
-    DfirGraph, FlatGraphBuilderOutput, eliminate_extra_unions_tees, partition_graph,
+    DfirGraph, FlatGraphBuilderOutput, PartitionError, eliminate_extra_unions_tees, partition_graph,
 };
 use slotmap::{SecondaryMap, SlotMap};
 
@@ -42,16 +42,26 @@ pub struct BuiltFlow<'a> {
     pub(super) _phantom: Invariant<'a>,
 }
 
-pub(crate) fn build_inner(ir: &mut Vec<HydroRoot>) -> SecondaryMap<LocationKey, DfirGraph> {
+/// Builds the DFIR graph for each location.
+///
+/// Each location's graph is partitioned into subgraphs. Partitioning can fail (e.g. an
+/// intra-tick cycle), so the result is stored per-location as a [`Result`]:
+/// - `Ok(partitioned_graph)` on success.
+/// - `Err(PartitionError)` on failure, which still carries the (renderable) flat graph
+///   plus the diagnostic. This lets callers such as [`preview_compile`] obtain a meta
+///   graph to *diagnose* the failure instead of panicking with the information discarded.
+///
+/// [`preview_compile`]: super::deploy::DeployFlow::preview_compile
+pub(crate) fn build_inner(
+    ir: &mut Vec<HydroRoot>,
+) -> SecondaryMap<LocationKey, Result<DfirGraph, PartitionError>> {
     emit(ir)
         .into_iter()
         .map(|(k, v)| {
             let FlatGraphBuilderOutput { mut flat_graph, .. } =
                 v.build().expect("Failed to build DFIR flat graph.");
             eliminate_extra_unions_tees(&mut flat_graph);
-            let partitioned_graph =
-                partition_graph(flat_graph).expect("Failed to partition (cycle detected).");
-            (k, partitioned_graph)
+            (k, partition_graph(flat_graph))
         })
         .collect()
 }

--- a/hydro_lang/src/compile/compiled.rs
+++ b/hydro_lang/src/compile/compiled.rs
@@ -1,4 +1,4 @@
-use dfir_lang::graph::DfirGraph;
+use dfir_lang::graph::{DfirGraph, PartitionError};
 use slotmap::{SecondaryMap, SparseSecondaryMap};
 use syn::Stmt;
 
@@ -7,7 +7,12 @@ use crate::staging_util::Invariant;
 
 pub struct CompiledFlow<'a> {
     /// The DFIR graph for each location.
-    pub(super) dfir: SecondaryMap<LocationKey, DfirGraph>,
+    ///
+    /// Each entry is `Ok(partitioned_graph)` on success, or `Err(PartitionError)` if
+    /// partitioning failed (e.g. an intra-tick cycle). The error still carries the
+    /// renderable flat graph and the diagnostic, so a failed location can be visualized
+    /// and diagnosed rather than aborting the whole compile.
+    pub(super) dfir: SecondaryMap<LocationKey, Result<DfirGraph, PartitionError>>,
 
     /// Extra statements to be added above the DFIR graph code, for each location.
     pub(super) extra_stmts: SparseSecondaryMap<LocationKey, Vec<Stmt>>,
@@ -19,11 +24,28 @@ pub struct CompiledFlow<'a> {
 }
 
 impl<'a> CompiledFlow<'a> {
-    pub fn dfir_for(&self, location: &impl Location<'a>) -> &DfirGraph {
-        self.dfir.get(Location::id(location).key()).unwrap()
+    /// Returns the DFIR graph for the given location.
+    ///
+    /// - `Ok(&partitioned_graph)` if partitioning succeeded.
+    /// - `Err(&PartitionError)` if partitioning failed. The error still exposes the
+    ///   (renderable) flat graph via [`PartitionError::flat_graph`] and the reason via
+    ///   [`PartitionError::diagnostic`], so the graph can be visualized to diagnose the
+    ///   failure — e.g.
+    ///   ```ignore
+    ///   let mermaid = match compiled.dfir_for(&process) {
+    ///       Ok(graph) => graph.to_mermaid(&Default::default()),
+    ///       Err(err) => err.flat_graph.to_mermaid(&Default::default()),
+    ///   };
+    ///   ```
+    pub fn dfir_for(&self, location: &impl Location<'a>) -> Result<&DfirGraph, &PartitionError> {
+        self.dfir
+            .get(Location::id(location).key())
+            .unwrap()
+            .as_ref()
     }
 
-    pub fn all_dfir(&self) -> &SecondaryMap<LocationKey, DfirGraph> {
+    /// Returns the DFIR graph (or [`PartitionError`]) for every location.
+    pub fn all_dfir(&self) -> &SecondaryMap<LocationKey, Result<DfirGraph, PartitionError>> {
         &self.dfir
     }
 }

--- a/hydro_lang/src/compile/compiled.rs
+++ b/hydro_lang/src/compile/compiled.rs
@@ -32,10 +32,10 @@ impl<'a> CompiledFlow<'a> {
     ///   [`PartitionError::diagnostic`], so the graph can be visualized to diagnose the
     ///   failure — e.g.
     ///   ```ignore
-    ///   let mermaid = match compiled.dfir_for(&process) {
-    ///       Ok(graph) => graph.to_mermaid(&Default::default()),
-    ///       Err(err) => err.flat_graph.to_mermaid(&Default::default()),
-    ///   };
+///   let mermaid = match compiled.dfir_for(&process) {
+///       Ok(graph) => graph.to_mermaid(&Default::default()),
+///       Err(err) => err.flat_graph.mermaid_string_flat(),
+///   };
     ///   ```
     pub fn dfir_for(&self, location: &impl Location<'a>) -> Result<&DfirGraph, &PartitionError> {
         self.dfir

--- a/hydro_lang/src/compile/compiled.rs
+++ b/hydro_lang/src/compile/compiled.rs
@@ -32,10 +32,10 @@ impl<'a> CompiledFlow<'a> {
     ///   [`PartitionError::diagnostic`], so the graph can be visualized to diagnose the
     ///   failure — e.g.
     ///   ```ignore
-///   let mermaid = match compiled.dfir_for(&process) {
-///       Ok(graph) => graph.to_mermaid(&Default::default()),
-///       Err(err) => err.flat_graph.mermaid_string_flat(),
-///   };
+    ///   let mermaid = match compiled.dfir_for(&process) {
+    ///       Ok(graph) => graph.to_mermaid(&Default::default()),
+    ///       Err(err) => err.flat_graph.mermaid_string_flat(),
+    ///   };
     ///   ```
     pub fn dfir_for(&self, location: &impl Location<'a>) -> Result<&DfirGraph, &PartitionError> {
         self.dfir

--- a/hydro_lang/src/compile/deploy.rs
+++ b/hydro_lang/src/compile/deploy.rs
@@ -401,7 +401,10 @@ impl<'a, D: Deploy<'a>> DeployFlow<'a, D> {
                 .filter(|&(node_key, ref node)| {
                     if let Some(ir) = compiled.remove(node_key) {
                         let ir = ir.unwrap_or_else(|err| {
-                            panic!("Failed to partition DFIR graph: {}", err.diagnostic)
+                            panic!(
+                                "Failed to partition DFIR graph for location {node_key}: {}",
+                                err.diagnostic
+                            )
                         });
                         node.instantiate(
                             env,
@@ -421,7 +424,10 @@ impl<'a, D: Deploy<'a>> DeployFlow<'a, D> {
                 .filter(|&(cluster_key, ref cluster)| {
                     if let Some(ir) = compiled.remove(cluster_key) {
                         let ir = ir.unwrap_or_else(|err| {
-                            panic!("Failed to partition DFIR graph: {}", err.diagnostic)
+                            panic!(
+                                "Failed to partition DFIR graph for location {cluster_key}: {}",
+                                err.diagnostic
+                            )
                         });
                         cluster.instantiate(
                             env,

--- a/hydro_lang/src/compile/deploy.rs
+++ b/hydro_lang/src/compile/deploy.rs
@@ -400,6 +400,9 @@ impl<'a, D: Deploy<'a>> DeployFlow<'a, D> {
                 .into_iter()
                 .filter(|&(node_key, ref node)| {
                     if let Some(ir) = compiled.remove(node_key) {
+                        let ir = ir.unwrap_or_else(|err| {
+                            panic!("Failed to partition DFIR graph: {}", err.diagnostic)
+                        });
                         node.instantiate(
                             env,
                             &mut meta,
@@ -417,6 +420,9 @@ impl<'a, D: Deploy<'a>> DeployFlow<'a, D> {
                 .into_iter()
                 .filter(|&(cluster_key, ref cluster)| {
                     if let Some(ir) = compiled.remove(cluster_key) {
+                        let ir = ir.unwrap_or_else(|err| {
+                            panic!("Failed to partition DFIR graph: {}", err.diagnostic)
+                        });
                         cluster.instantiate(
                             env,
                             &mut meta,

--- a/hydro_lang/src/compile/embedded.rs
+++ b/hydro_lang/src/compile/embedded.rs
@@ -590,7 +590,12 @@ impl super::deploy::DeployFlow<'_, EmbeddedDeploy> {
         for location_key in location_keys {
             let graph = compiled.all_dfir()[location_key]
                 .as_ref()
-                .unwrap_or_else(|err| panic!("Failed to partition DFIR graph: {}", err.diagnostic));
+                .unwrap_or_else(|err| {
+                    panic!(
+                        "Failed to partition DFIR graph for location {location_key}: {}",
+                        err.diagnostic
+                    )
+                });
 
             // Get the user-provided function name from the node.
             let fn_name = fn_names[location_key];

--- a/hydro_lang/src/compile/embedded.rs
+++ b/hydro_lang/src/compile/embedded.rs
@@ -588,7 +588,9 @@ impl super::deploy::DeployFlow<'_, EmbeddedDeploy> {
             .collect();
 
         for location_key in location_keys {
-            let graph = &compiled.all_dfir()[location_key];
+            let graph = compiled.all_dfir()[location_key]
+                .as_ref()
+                .unwrap_or_else(|err| panic!("Failed to partition DFIR graph: {}", err.diagnostic));
 
             // Get the user-provided function name from the node.
             let fn_name = fn_names[location_key];

--- a/hydro_lang/src/sim/flow.rs
+++ b/hydro_lang/src/sim/flow.rs
@@ -203,10 +203,10 @@ impl<'a> SimFlow<'a> {
                     let FlatGraphBuilderOutput { mut flat_graph, .. } =
                         g.build().expect("Failed to build DFIR flat graph.");
                     eliminate_extra_unions_tees(&mut flat_graph);
-                    (
-                        l,
-                        partition_graph(flat_graph).expect("Failed to partition (cycle detected)."),
-                    )
+                    let partitioned = partition_graph(flat_graph).unwrap_or_else(|err| {
+                        panic!("Failed to partition DFIR graph: {}", err.diagnostic)
+                    });
+                    (l, partitioned)
                 })
                 .collect()
         }

--- a/hydro_lang/src/sim/flow.rs
+++ b/hydro_lang/src/sim/flow.rs
@@ -204,7 +204,10 @@ impl<'a> SimFlow<'a> {
                         g.build().expect("Failed to build DFIR flat graph.");
                     eliminate_extra_unions_tees(&mut flat_graph);
                     let partitioned = partition_graph(flat_graph).unwrap_or_else(|err| {
-                        panic!("Failed to partition DFIR graph: {}", err.diagnostic)
+                        panic!(
+                            "Failed to partition DFIR graph for location {l:?}: {}",
+                            err.diagnostic
+                        )
                     });
                     (l, partitioned)
                 })

--- a/hydro_test/src/cluster/compute_pi.rs
+++ b/hydro_test/src/cluster/compute_pi.rs
@@ -74,7 +74,7 @@ mod tests {
             hydro_build_utils::insta::with_settings!({
                 snapshot_suffix => format!("surface_graph_{location_key}"),
             }, {
-                hydro_build_utils::assert_snapshot!(ir.surface_syntax_string());
+                hydro_build_utils::assert_snapshot!(ir.as_ref().unwrap().surface_syntax_string());
             });
         }
     }

--- a/hydro_test/src/cluster/map_reduce.rs
+++ b/hydro_test/src/cluster/map_reduce.rs
@@ -63,7 +63,7 @@ mod tests {
             hydro_build_utils::insta::with_settings!({
                 snapshot_suffix => format!("surface_graph_{location_key}")
             }, {
-                hydro_build_utils::assert_snapshot!(ir.surface_syntax_string());
+                hydro_build_utils::assert_snapshot!(ir.as_ref().unwrap().surface_syntax_string());
             });
         }
     }

--- a/hydro_test/src/cluster/paxos_bench.rs
+++ b/hydro_test/src/cluster/paxos_bench.rs
@@ -216,7 +216,7 @@ mod tests {
             snapshot_suffix => "proposer_mermaid"
         }, {
             hydro_build_utils::assert_snapshot!(
-                preview.dfir_for(&proposers).to_mermaid(&WriteConfig {
+                preview.dfir_for(&proposers).unwrap().to_mermaid(&WriteConfig {
                     no_subgraphs: true,
                     no_pull_push: true,
                     no_handoffs: true,
@@ -229,7 +229,7 @@ mod tests {
             snapshot_suffix => "acceptor_mermaid"
         }, {
             hydro_build_utils::assert_snapshot!(
-                preview.dfir_for(&acceptors).to_mermaid(&WriteConfig {
+                preview.dfir_for(&acceptors).unwrap().to_mermaid(&WriteConfig {
                     no_subgraphs: true,
                     no_pull_push: true,
                     no_handoffs: true,

--- a/hydro_test/src/cluster/raft.rs
+++ b/hydro_test/src/cluster/raft.rs
@@ -2643,7 +2643,7 @@ mod tests {
             snapshot_suffix => "replica_mermaid"
         }, {
             hydro_build_utils::assert_snapshot!(
-                preview.dfir_for(&replicas).to_mermaid(&WriteConfig {
+                preview.dfir_for(&replicas).unwrap().to_mermaid(&WriteConfig {
                     no_subgraphs: true,
                     no_pull_push: true,
                     no_handoffs: true,

--- a/hydro_test/src/cluster/two_pc_bench.rs
+++ b/hydro_test/src/cluster/two_pc_bench.rs
@@ -115,7 +115,7 @@ mod tests {
             snapshot_suffix => "coordinator_mermaid"
         }, {
             hydro_build_utils::assert_snapshot!(
-                preview.dfir_for(&coordinator).to_mermaid(&WriteConfig {
+                preview.dfir_for(&coordinator).unwrap().to_mermaid(&WriteConfig {
                     no_subgraphs: true,
                     no_pull_push: true,
                     no_handoffs: true,
@@ -130,7 +130,7 @@ mod tests {
             snapshot_suffix => "participants_mermaid"
         }, {
             hydro_build_utils::assert_snapshot!(
-                preview.dfir_for(&participants).to_mermaid(&WriteConfig {
+                preview.dfir_for(&participants).unwrap().to_mermaid(&WriteConfig {
                     no_subgraphs: true,
                     no_pull_push: true,
                     no_handoffs: true,

--- a/hydro_test/src/local/chat_app.rs
+++ b/hydro_test/src/local/chat_app.rs
@@ -62,6 +62,7 @@ mod tests {
             built
                 .preview_compile()
                 .dfir_for(&p1)
+                .unwrap()
                 .to_mermaid(&Default::default())
         );
 
@@ -135,6 +136,7 @@ mod tests {
             built
                 .preview_compile()
                 .dfir_for(&p1)
+                .unwrap()
                 .to_mermaid(&Default::default())
         );
 

--- a/hydro_test/src/local/graph_reachability.rs
+++ b/hydro_test/src/local/graph_reachability.rs
@@ -52,6 +52,7 @@ mod tests {
             built
                 .preview_compile()
                 .dfir_for(&p1)
+                .unwrap()
                 .surface_syntax_string()
         );
 


### PR DESCRIPTION
Resolve the DFIR meta-graph "catch-22": previously, if a location's DFIR failed
to partition (e.g. an intra-tick cycle), `build_inner` called
`partition_graph(..).expect("Failed to partition (cycle detected).")`, which
panicked *and* discarded both the flat graph and the diagnostic — so there was
no way to obtain a meta graph to diagnose the very failure that blocked
compilation.

## `dfir_lang`

- `partition_graph` now returns `Result<DfirGraph, PartitionError>` instead of
  `Result<DfirGraph, Diagnostic>`. The new `PartitionError` carries both the
  `diagnostic` and the **pristine flat graph** (`flat_graph`). This is sound and
  free (no clone): the only recoverable failure is the intra-tick cycle, which
  is detected in `find_subgraph_unionfind` *before* the graph is mutated, so the
  graph handed back is the un-partitioned input and is fully renderable
  (`mermaid_string_flat` / `to_mermaid`). `PartitionError` implements `Display`
  (delegating to the diagnostic).
- Updated the internal `build_dfir_code` and `dfir_macro` call sites to read
  `err.diagnostic`.

## `hydro_lang`

- `build_inner` no longer panics; it stores `Result<DfirGraph, PartitionError>`
  per location on `CompiledFlow`.
- `CompiledFlow::dfir_for` now returns `Result<&DfirGraph, &PartitionError>`
  (Ok = partitioned, Err = flat graph + reason) and `all_dfir` returns the
  per-location `Result` map. No new methods, stages, or build variants were
  added: the existing `preview_compile()` simply stops being a landmine, and the
  strict deploy/codegen paths (`deploy`, `embedded`, `sim`) unwrap at the point a
  partitioned graph is actually required, panicking with the real cycle-naming
  diagnostic rather than a generic message.

## Tests

- `hydro_test` snapshot/IR call sites updated to acknowledge the `Result`
  (`.dfir_for(..).unwrap()`, `ir.as_ref().unwrap()`); snapshots are unchanged.
- Added `flat_mermaid_available_when_partition_fails` in `dfir_lang` locking in
  that a cyclic graph fails to partition but still yields a renderable flat graph
  plus a cycle-naming diagnostic via `PartitionError`.

BREAKING CHANGE: `dfir_lang::graph::partition_graph` now returns
`Result<DfirGraph, PartitionError>` instead of `Result<DfirGraph, Diagnostic>`,
and `hydro_lang`'s `CompiledFlow::dfir_for` / `all_dfir` now expose
`Result<_, PartitionError>` values.