### PR TITLE
fix(hydro_lang): `transform_children` leaves a `Placeholder` in `partition`

### DIFF
--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -4118,7 +4118,7 @@ impl HydroNode {
                             let idx = if is_true { 0 } else { 1 };
                             built_idents[idx].clone()
                         } else {
-                            // The `PartitionShared`` node was already processed by transform_bottom_up,
+                            // The `PartitionShared` node was already processed by transform_bottom_up,
                             // so its ident is on the stack
                             let partition_ident = ident_stack.pop().unwrap();
 
@@ -5745,9 +5745,8 @@ impl HydroNode {
             | HydroNode::Tee { .. }
             | HydroNode::Reference { .. }
             | HydroNode::PartitionSide { .. }
-            | HydroNode::PartitionShared { .. }
             | HydroNode::VersionedNetwork { .. } => {
-                // Tee/Partition/VersionedNetwork find their input in separate special ways
+                // Tee/PartitionSide/VersionedNetwork find their input in separate special ways
                 vec![]
             }
             HydroNode::Cast { inner, .. }
@@ -5760,13 +5759,9 @@ impl HydroNode {
             | HydroNode::AssertIsConsistent { inner, .. } => {
                 vec![inner]
             }
-            HydroNode::Chain { first, second, .. } => {
-                vec![first, second]
-            }
-            HydroNode::MergeOrdered { first, second, .. } => {
-                vec![first, second]
-            }
-            HydroNode::ChainFirst { first, second, .. } => {
+            HydroNode::Chain { first, second, .. }
+            | HydroNode::MergeOrdered { first, second, .. }
+            | HydroNode::ChainFirst { first, second, .. } => {
                 vec![first, second]
             }
             HydroNode::CrossProduct { left, right, .. }
@@ -5778,27 +5773,28 @@ impl HydroNode {
             HydroNode::Difference { pos, neg, .. } | HydroNode::AntiJoin { pos, neg, .. } => {
                 vec![pos, neg]
             }
-            HydroNode::Map { input, .. }
-            | HydroNode::FlatMap { input, .. }
-            | HydroNode::FlatMapStreamBlocking { input, .. }
-            | HydroNode::Filter { input, .. }
-            | HydroNode::FilterMap { input, .. }
-            | HydroNode::Sort { input, .. }
+            HydroNode::Counter { input, .. }
             | HydroNode::DeferTick { input, .. }
             | HydroNode::Enumerate { input, .. }
+            | HydroNode::Filter { input, .. }
+            | HydroNode::FilterMap { input, .. }
+            | HydroNode::FlatMap { input, .. }
+            | HydroNode::FlatMapStreamBlocking { input, .. }
+            | HydroNode::Fold { input, .. }
+            | HydroNode::FoldKeyed { input, .. }
             | HydroNode::Inspect { input, .. }
-            | HydroNode::Unique { input, .. }
+            | HydroNode::Map { input, .. }
             | HydroNode::Network { input, .. }
-            | HydroNode::Counter { input, .. }
+            | HydroNode::PartitionShared { input, .. }
+            | HydroNode::Reduce { input, .. }
+            | HydroNode::ReduceKeyed { input, .. }
             | HydroNode::ResolveFutures { input, .. }
             | HydroNode::ResolveFuturesBlocking { input, .. }
             | HydroNode::ResolveFuturesOrdered { input, .. }
-            | HydroNode::Fold { input, .. }
-            | HydroNode::FoldKeyed { input, .. }
-            | HydroNode::Reduce { input, .. }
-            | HydroNode::ReduceKeyed { input, .. }
             | HydroNode::Scan { input, .. }
-            | HydroNode::ScanAsyncBlocking { input, .. } => {
+            | HydroNode::ScanAsyncBlocking { input, .. }
+            | HydroNode::Sort { input, .. }
+            | HydroNode::Unique { input, .. } => {
                 vec![input]
             }
             HydroNode::ReduceKeyedWatermark {

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -2700,10 +2700,17 @@ pub enum HydroNode {
         metadata: HydroIrMetadata,
     },
 
-    Partition {
+    /// An output side of the partition operator.
+    PartitionSide {
         inner: SharedNode,
-        f: ClosureExpr,
         is_true: bool,
+        metadata: HydroIrMetadata,
+    },
+
+    /// The inner input of partitioning, shared between two `PartitionSide`.
+    PartitionShared {
+        input: Box<HydroNode>,
+        f: ClosureExpr,
         metadata: HydroIrMetadata,
     },
 
@@ -3043,18 +3050,21 @@ impl HydroNode {
                 }
             }
 
-            HydroNode::Partition { inner, f, .. } => {
+            HydroNode::PartitionSide { inner, .. } => {
                 if let Some(transformed) = seen_tees.get(&inner.as_ptr()) {
                     *inner = SharedNode(transformed.clone());
                 } else {
-                    f.transform_children(&mut transform, seen_tees);
                     let transformed_cell = Rc::new(RefCell::new(HydroNode::Placeholder));
                     seen_tees.insert(inner.as_ptr(), transformed_cell.clone());
-                    let mut orig = inner.0.replace(HydroNode::Placeholder);
+                    let mut orig: HydroNode = inner.0.replace(HydroNode::Placeholder);
                     transform(&mut orig, seen_tees);
                     *transformed_cell.borrow_mut() = orig;
                     *inner = SharedNode(transformed_cell);
                 }
+            }
+            HydroNode::PartitionShared { input, f, .. } => {
+                f.transform_children(&mut transform, seen_tees);
+                transform(input.as_mut(), seen_tees);
             }
 
             HydroNode::Cast { inner, .. }
@@ -3247,16 +3257,14 @@ impl HydroNode {
                     }
                 }
             }
-            HydroNode::Partition {
+            HydroNode::PartitionSide {
                 inner,
-                f,
                 is_true,
                 metadata,
             } => {
                 if let Some(transformed) = seen_tees.get(&inner.as_ptr()) {
-                    HydroNode::Partition {
+                    HydroNode::PartitionSide {
                         inner: SharedNode(transformed.clone()),
-                        f: f.deep_clone(seen_tees),
                         is_true: *is_true,
                         metadata: metadata.clone(),
                     }
@@ -3265,14 +3273,18 @@ impl HydroNode {
                     seen_tees.insert(inner.as_ptr(), new_rc.clone());
                     let cloned = inner.0.borrow().deep_clone(seen_tees);
                     *new_rc.borrow_mut() = cloned;
-                    HydroNode::Partition {
+                    HydroNode::PartitionSide {
                         inner: SharedNode(new_rc),
-                        f: f.deep_clone(seen_tees),
                         is_true: *is_true,
                         metadata: metadata.clone(),
                     }
                 }
             }
+            HydroNode::PartitionShared { input, f, metadata } => HydroNode::PartitionShared {
+                input: Box::new(input.deep_clone(seen_tees)),
+                f: f.deep_clone(seen_tees),
+                metadata: metadata.clone(),
+            },
             HydroNode::YieldConcat { inner, metadata } => HydroNode::YieldConcat {
                 inner: Box::new(inner.deep_clone(seen_tees)),
                 metadata: metadata.clone(),
@@ -4088,8 +4100,8 @@ impl HydroNode {
                         ident_stack.push(ret_ident);
                     }
 
-                    HydroNode::Partition {
-                        inner, f, is_true, metadata,
+                    HydroNode::PartitionSide {
+                        inner, is_true, metadata: _,
                     } => {
                         let is_true = *is_true; // need to copy early to avoid borrow checking issues with node
                         let ptr = std::ptr::from_ref(inner.0.as_ref());
@@ -4106,26 +4118,10 @@ impl HydroNode {
                             let idx = if is_true { 0 } else { 1 };
                             built_idents[idx].clone()
                         } else {
-                            // The inner node was already processed by transform_bottom_up,
+                            // The `PartitionShared`` node was already processed by transform_bottom_up,
                             // so its ident is on the stack
-                            let inner_ident = ident_stack.pop().unwrap();
-                            let f_tokens = f.emit_tokens(&mut ident_stack);
+                            let partition_ident = ident_stack.pop().unwrap();
 
-                            let inner_ident = {
-                                let inner_borrow = inner.0.borrow();
-                                maybe_observe_for_mut(
-                                    f, inner_ident,
-                                    &inner_borrow.metadata().location_id,
-                                    &inner_borrow.metadata().collection_kind,
-                                    &metadata.op,
-                                    builders_or_callback, next_stmt_id,
-                                )
-                            };
-
-                            let partition_ident = syn::Ident::new(
-                                &format!("stream_{}_partition", stmt_id),
-                                Span::call_site(),
-                            );
                             let true_ident = syn::Ident::new(
                                 &format!("stream_{}_true", stmt_id),
                                 Span::call_site(),
@@ -4146,7 +4142,6 @@ impl HydroNode {
                                     graph_builders.add_dfir_at(
                                         &out_location,
                                         parse_quote! {
-                                            #partition_ident = #inner_ident -> partition(|__item, __num_outputs| if (#f_tokens)(__item) { 0_usize } else { 1_usize });
                                             #true_ident = #partition_ident[0];
                                             #false_ident = #partition_ident[1];
                                         },
@@ -4162,6 +4157,45 @@ impl HydroNode {
                         };
 
                         ident_stack.push(ret_ident);
+                    }
+
+                    HydroNode::PartitionShared { input, f, metadata } => {
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
+
+                        let inner_ident = ident_stack.pop().unwrap();
+
+                        let inner_ident = {
+                            maybe_observe_for_mut(
+                                f, inner_ident,
+                                &input.metadata().location_id,
+                                &input.metadata().collection_kind,
+                                &metadata.op,
+                                builders_or_callback, next_stmt_id,
+                            )
+                        };
+
+                        let stmt_id = next_stmt_id.get_and_increment();
+                        let partition_ident = syn::Ident::new(
+                            &format!("stream_{}_partition", stmt_id),
+                            Span::call_site(),
+                        );
+
+                        let stmt_id = next_stmt_id.get_and_increment();
+                        match builders_or_callback {
+                            BuildersOrCallback::Builders(graph_builders) => {
+                                graph_builders.add_dfir_at(
+                                    &out_location,
+                                    parse_quote! {
+                                        #partition_ident = #inner_ident -> partition(|__item, __num_outputs| if (#f_tokens)(__item) { 0_usize } else { 1_usize });
+                                    },
+                                    Some(&stmt_id.to_string()),
+                                );
+                            }
+                            BuildersOrCallback::Callback(_, node_callback) => {
+                                node_callback(node, next_stmt_id);
+                            }
+                        }
+                        ident_stack.push(partition_ident);
                     }
 
                     HydroNode::Chain { .. } => {
@@ -5525,6 +5559,7 @@ impl HydroNode {
             | HydroNode::Enumerate { .. }
             | HydroNode::Unique { .. }
             | HydroNode::Sort { .. }
+            | HydroNode::PartitionSide { .. }
             | HydroNode::VersionedNetworkFork { .. }
             | HydroNode::VersionedNetwork { .. } => {}
             HydroNode::Map { f, .. }
@@ -5533,7 +5568,7 @@ impl HydroNode {
             | HydroNode::Filter { f, .. }
             | HydroNode::FilterMap { f, .. }
             | HydroNode::Inspect { f, .. }
-            | HydroNode::Partition { f, .. }
+            | HydroNode::PartitionShared { f, .. }
             | HydroNode::Reduce { f, .. }
             | HydroNode::ReduceKeyed { f, .. }
             | HydroNode::ReduceKeyedWatermark { f, .. } => {
@@ -5595,7 +5630,8 @@ impl HydroNode {
             | HydroNode::CycleSource { metadata, .. }
             | HydroNode::Tee { metadata, .. }
             | HydroNode::Reference { metadata, .. }
-            | HydroNode::Partition { metadata, .. }
+            | HydroNode::PartitionSide { metadata, .. }
+            | HydroNode::PartitionShared { metadata, .. }
             | HydroNode::YieldConcat { metadata, .. }
             | HydroNode::BeginAtomic { metadata, .. }
             | HydroNode::EndAtomic { metadata, .. }
@@ -5655,7 +5691,8 @@ impl HydroNode {
             | HydroNode::CycleSource { metadata, .. }
             | HydroNode::Tee { metadata, .. }
             | HydroNode::Reference { metadata, .. }
-            | HydroNode::Partition { metadata, .. }
+            | HydroNode::PartitionSide { metadata, .. }
+            | HydroNode::PartitionShared { metadata, .. }
             | HydroNode::YieldConcat { metadata, .. }
             | HydroNode::BeginAtomic { metadata, .. }
             | HydroNode::EndAtomic { metadata, .. }
@@ -5706,7 +5743,8 @@ impl HydroNode {
             | HydroNode::CycleSource { .. }
             | HydroNode::Tee { .. }
             | HydroNode::Reference { .. }
-            | HydroNode::Partition { .. }
+            | HydroNode::PartitionSide { .. }
+            | HydroNode::PartitionShared { .. }
             | HydroNode::VersionedNetwork { .. } => {
                 // Tee/Partition/VersionedNetwork find their input in separate special ways
                 vec![]
@@ -5786,7 +5824,7 @@ impl HydroNode {
     /// by another consumer and does not need a Null sink.
     pub fn is_shared_with_others(&self) -> bool {
         match self {
-            HydroNode::Tee { inner, .. } | HydroNode::Partition { inner, .. } => {
+            HydroNode::Tee { inner, .. } | HydroNode::PartitionSide { inner, .. } => {
                 Rc::strong_count(&inner.0) > 1
             }
             // A zero-output reference node is valid in DFIR (it drains itself at
@@ -5821,9 +5859,14 @@ impl HydroNode {
             HydroNode::Reference { inner, kind, .. } => {
                 format!("Reference({:?}, {})", kind, inner.0.borrow().print_root())
             }
-            HydroNode::Partition { f, is_true, .. } => {
-                format!("Partition({:?}, is_true={})", f, is_true)
+            HydroNode::PartitionSide { inner, is_true, .. } => {
+                format!(
+                    "PartitionSide(is_true={}, {})",
+                    is_true,
+                    inner.0.borrow().print_root(),
+                )
             }
+            HydroNode::PartitionShared { f, .. } => format!("PartitionShared({:?})", f),
             HydroNode::YieldConcat { .. } => "YieldConcat()".to_owned(),
             HydroNode::BeginAtomic { .. } => "BeginAtomic()".to_owned(),
             HydroNode::EndAtomic { .. } => "EndAtomic()".to_owned(),

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -4160,9 +4160,10 @@ impl HydroNode {
                     }
 
                     HydroNode::PartitionShared { input, f, metadata } => {
-                        let f_tokens = f.emit_tokens(&mut ident_stack);
-
+                        // Pop input ident (pushed last by transform_children) before
+                        // draining the closure's singleton ref idents below it.
                         let inner_ident = ident_stack.pop().unwrap();
+                        let f_tokens = f.emit_tokens(&mut ident_stack);
 
                         let inner_ident = {
                             maybe_observe_for_mut(

--- a/hydro_lang/src/handoff_ref.rs
+++ b/hydro_lang/src/handoff_ref.rs
@@ -799,7 +799,7 @@ mod tests {
                 | HydroNode::Reduce { f, .. }
                 | HydroNode::ReduceKeyed { f, .. }
                 | HydroNode::ReduceKeyedWatermark { f, .. }
-                | HydroNode::Partition { f, .. } => vec![f],
+                | HydroNode::PartitionShared { f, .. } => vec![f],
                 HydroNode::Fold { init, acc, .. }
                 | HydroNode::FoldKeyed { init, acc, .. }
                 | HydroNode::Scan { init, acc, .. }
@@ -833,7 +833,7 @@ mod tests {
             let shared_inner = match node {
                 HydroNode::Tee { inner, .. }
                 | HydroNode::Reference { inner, .. }
-                | HydroNode::Partition { inner, .. } => Some(inner),
+                | HydroNode::PartitionSide { inner, .. } => Some(inner),
                 _ => None,
             };
             if let Some(inner) = shared_inner

--- a/hydro_lang/src/handoff_ref.rs
+++ b/hydro_lang/src/handoff_ref.rs
@@ -771,4 +771,108 @@ mod tests {
         threshold.into_stream().for_each(q!(|_| {}));
         let _built = flow.finalize();
     }
+
+    /// Regression test for the `Partition` dedup path in `HydroNode::transform_children`.
+    ///
+    /// A `partition` whose predicate closure captures a `by_ref` singleton produces two output
+    /// branches that share the partition's `inner` but each own their own clone of the closure.
+    /// When the shared `inner` is rewritten (during `finalize` → `unify_atomic_ticks` →
+    /// `transform_bottom_up`), the first branch's closure is transformed and the referenced cell
+    /// is emptied to `HydroNode::Placeholder`. The *deduplicated* second branch used to be skipped
+    /// entirely, leaving its captured `singleton_ref` dangling at that `Placeholder` cell. This
+    /// asserts that no closure `singleton_ref` resolves to a `Placeholder` after finalization.
+    #[test]
+    fn partition_dedup_does_not_leave_placeholder_refs() {
+        use std::cell::RefCell;
+        use std::collections::HashSet;
+
+        use crate::compile::ir::{ClosureExpr, HydroNode};
+
+        fn closures(node: &HydroNode) -> Vec<&ClosureExpr> {
+            match node {
+                HydroNode::Map { f, .. }
+                | HydroNode::FlatMap { f, .. }
+                | HydroNode::FlatMapStreamBlocking { f, .. }
+                | HydroNode::Filter { f, .. }
+                | HydroNode::FilterMap { f, .. }
+                | HydroNode::Inspect { f, .. }
+                | HydroNode::Reduce { f, .. }
+                | HydroNode::ReduceKeyed { f, .. }
+                | HydroNode::ReduceKeyedWatermark { f, .. }
+                | HydroNode::Partition { f, .. } => vec![f],
+                HydroNode::Fold { init, acc, .. }
+                | HydroNode::FoldKeyed { init, acc, .. }
+                | HydroNode::Scan { init, acc, .. }
+                | HydroNode::ScanAsyncBlocking { init, acc, .. } => vec![init, acc],
+                _ => vec![],
+            }
+        }
+
+        fn count_placeholder_refs(
+            node: &HydroNode,
+            visited: &mut HashSet<*const RefCell<HydroNode>>,
+            count: &mut usize,
+        ) {
+            // A captured `singleton_ref` should never resolve to a `Placeholder`.
+            for f in closures(node) {
+                for (ref_node, _is_mut) in &f.singleton_refs {
+                    if let HydroNode::Reference { inner, .. } = ref_node
+                        && matches!(&*inner.0.borrow(), HydroNode::Placeholder)
+                    {
+                        *count += 1;
+                    }
+                }
+            }
+
+            // Recurse the (owned) tree children.
+            for child in node.input() {
+                count_placeholder_refs(child, visited, count);
+            }
+
+            // Recurse the shared inner once, guarding against `Placeholder` / revisits.
+            let shared_inner = match node {
+                HydroNode::Tee { inner, .. }
+                | HydroNode::Reference { inner, .. }
+                | HydroNode::Partition { inner, .. } => Some(inner),
+                _ => None,
+            };
+            if let Some(inner) = shared_inner
+                && visited.insert(inner.as_ptr())
+            {
+                let borrowed = inner.0.borrow();
+                if !matches!(&*borrowed, HydroNode::Placeholder) {
+                    count_placeholder_refs(&borrowed, visited, count);
+                }
+            }
+        }
+
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<P1>();
+
+        let threshold = node
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        let (above, below) = node
+            .source_iter(q!(vec![5i32, 8, 10, 11, 15, 3]))
+            .partition(q!(|x| *x > *threshold_ref));
+
+        above.for_each(q!(|_| {}));
+        below.for_each(q!(|_| {}));
+        threshold.into_stream().for_each(q!(|_| {}));
+
+        let built = flow.finalize();
+
+        let mut visited = HashSet::new();
+        let mut count = 0usize;
+        for root in built.ir() {
+            count_placeholder_refs(root.input(), &mut visited, &mut count);
+        }
+
+        assert_eq!(
+            count, 0,
+            "partition's deduplicated branch left {count} closure singleton_ref(s) dangling at a Placeholder cell"
+        );
+    }
 }

--- a/hydro_lang/src/handoff_ref.rs
+++ b/hydro_lang/src/handoff_ref.rs
@@ -624,6 +624,37 @@ mod tests {
             .preview_compile();
     }
 
+    /// Regression test: a singleton ref captured by a partition predicate must be
+    /// spliced correctly during DFIR emission. The `PartitionShared` emit previously
+    /// drained the ident stack in the wrong order (calling `emit_tokens` before popping
+    /// the input ident), so the partition's *input* ident was consumed as if it were the
+    /// closure's singleton ref. This test drives the flow through full DFIR emission
+    /// (which `flow.finalize()` alone does not) to cover that path.
+    #[cfg(feature = "deploy")]
+    #[test]
+    fn singleton_by_ref_partition_emits() {
+        let mut flow = FlowBuilder::new();
+        let node = flow.process::<P1>();
+
+        let threshold = node
+            .source_iter(q!(0..5i32))
+            .fold(q!(|| 0i32), q!(|acc: &mut i32, x| *acc += x));
+        let threshold_ref = threshold.by_ref();
+
+        let (above, below) = node
+            .source_iter(q!(1..=10i32))
+            .partition(q!(|x| *x > *threshold_ref));
+
+        above.for_each(q!(|_| {}));
+        below.for_each(q!(|_| {}));
+        threshold.into_stream().for_each(q!(|_| {}));
+
+        let _ = flow
+            .finalize()
+            .with_default_optimize::<crate::deploy::HydroDeploy>()
+            .preview_compile();
+    }
+
     /// Compile-only test: singleton by_ref inside scan closures.
     #[test]
     fn singleton_by_ref_scan() {

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -914,15 +914,16 @@ where
             proof.register_proof(&expr);
             expr.into()
         });
-        let shared = SharedNode(Rc::new(RefCell::new(
-            self.ir_node.replace(HydroNode::Placeholder),
-        )));
+        let shared = Rc::new(RefCell::new(HydroNode::PartitionShared {
+            input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+            f,
+            metadata: self.location.new_node_metadata(Self::collection_kind()),
+        }));
 
         let true_stream = Stream::new(
             self.location.clone(),
-            HydroNode::Partition {
-                inner: SharedNode(shared.0.clone()),
-                f: f.clone(),
+            HydroNode::PartitionSide {
+                inner: SharedNode(Rc::clone(&shared)),
                 is_true: true,
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             },
@@ -930,9 +931,8 @@ where
 
         let false_stream = Stream::new(
             self.location.clone(),
-            HydroNode::Partition {
-                inner: SharedNode(shared.0),
-                f,
+            HydroNode::PartitionSide {
+                inner: SharedNode(shared),
                 is_true: false,
                 metadata: self.location.new_node_metadata(Self::collection_kind()),
             },

--- a/hydro_lang/src/viz/render.rs
+++ b/hydro_lang/src/viz/render.rs
@@ -1161,7 +1161,7 @@ impl HydroNode {
                 tee_id
             }
 
-            HydroNode::Partition {
+            HydroNode::PartitionSide {
                 inner, metadata, ..
             } => {
                 let ptr = inner.as_ptr();
@@ -1195,6 +1195,10 @@ impl HydroNode {
                 drop(inner_borrow);
 
                 partition_id
+            }
+            HydroNode::PartitionShared { input, .. } => {
+                // Transparent pass-thru.
+                input.build_graph_structure(structure, seen_tees, config)
             }
 
             // Non-deterministic operation


### PR DESCRIPTION
add partition_dedup_does_not_leave_placeholder_refs test

`HydroNode::transform_children` rewrites shared nodes in place: on the first
occurrence it empties the original `Rc` cell (`inner.0.replace(Placeholder)`) and
records `old_ptr → rewritten_cell` in `seen_tees`; subsequent occurrences are
redirected via that map. The `Partition` arm, however, only handled the shared
`inner` on the dedup path and skipped its closure `f`. Because a `partition`'s two
output branches each own a *separate* clone of the closure — and those closures can
capture `by_ref` singletons that are themselves shared nodes — the second (deduped)
branch's closure kept a `Reference` pointing at the now-emptied cell, i.e. a live
reference dangling at a `Placeholder`.

This diverged from the sibling traversal `deep_clone`, whose `Partition` arm already
reconciles the closure on the dedup path (`f: f.deep_clone(seen_tees)`).

Fix: split `HydroNode::Partition` into two parts. The outer exists twice, one for each
side, and have a `SharedNode` to the inner, which owns the closure. This way there
is no duplicated closure to handle, whichever outer node is reached first will recurse
and handle the inner node concerns.