### PR TITLE
feat(hydro_lang)!: add sound `collect_n_sorted_only` / `next_only` for unordered sim receivers

### DIFF
--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -1359,19 +1359,24 @@ impl<F1: Future<Output = ()>, F2: Future<Output = ()>> Future for ChainedFuture<
 }
 
 impl<T: Serialize + DeserializeOwned> SimReceiver<T, NoOrder, ExactlyOnce> {
-    /// Receives the next `n` messages, sorted, waiting (and letting the scheduler run any
-    /// pending simulation work) until they are available. If the simulation becomes quiescent
-    /// before `n` messages arrive, the test fails.
+    /// Receives the next `n` messages, sorted, and then asserts that the stream ends (like
+    /// [`SimReceiver::assert_no_more`], forking the search in exhaustive mode). If the
+    /// simulation becomes quiescent before `n` messages arrive, the test fails.
     ///
-    /// Like [`SimReceiver::next`], this is safe to use in the middle of a test.
-    pub fn collect_n_sorted<C: Default + Extend<T> + AsMut<[T]>>(
-        &self,
-        n: usize,
-    ) -> impl use<'_, T, C> + Future<Output = C>
+    /// Unlike [`collect_n`](SimReceiver::collect_n) on ordered streams, there is no variant
+    /// of this API that skips the end-of-stream check. On an unordered stream, the set of
+    /// messages that arrives *first* is not well-defined, so observing a strict prefix of
+    /// the output would be sensitive to arrival orders that the simulator does not explore
+    /// (delivery into the port is FIFO, with no ordering hook); sorting normalizes the
+    /// permutation of the received messages, but not the choice of *subset*. The quiescence
+    /// check makes the observation sound: it proves the `n` messages are *all* the messages
+    /// the program can produce from the input so far, a set which does not depend on
+    /// arrival order.
+    pub async fn collect_n_sorted_only<C: Default + Extend<T> + AsMut<[T]>>(self, n: usize) -> C
     where
-        T: Ord,
+        T: Debug + Ord,
     {
-        FutureTrackingCaller {
+        let out = FutureTrackingCaller {
             future: async move {
                 let mut out = C::default();
                 for i in 0..n {
@@ -1390,6 +1395,26 @@ impl<T: Serialize + DeserializeOwned> SimReceiver<T, NoOrder, ExactlyOnce> {
                 Ok(out)
             },
         }
+        .await;
+        self.assert_no_more().await;
+        out
+    }
+
+    /// Receives the next message, and then asserts that the stream ends (like
+    /// [`SimReceiver::assert_no_more`], forking the search in exhaustive mode). If the
+    /// simulation becomes quiescent without producing a message, the test fails.
+    ///
+    /// This is a shortcut for [`Self::collect_n_sorted_only`] with `n = 1`. Unlike
+    /// [`next`](SimReceiver::next) on ordered streams, there is no variant that skips the
+    /// end-of-stream check, because on an unordered stream *which* message arrives first is
+    /// not well-defined; the check proves the message is the *only* one the program can
+    /// produce from the input so far.
+    pub async fn next_only(self) -> T
+    where
+        T: Debug + Ord,
+    {
+        let mut out: Vec<T> = self.collect_n_sorted_only(1).await;
+        out.remove(0)
     }
 
     /// Collects all remaining messages from the external bincode stream into a collection,
@@ -1553,6 +1578,32 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterReceive
             .await
             .map(|bytes| bincode::deserialize(&bytes).unwrap())
     }
+
+    /// Asserts that the stream from a specific cluster member has ended and no more messages
+    /// can possibly arrive.
+    ///
+    /// If the check cannot be answered without running pending nondeterministic work (such
+    /// as ticks with buffered inputs):
+    /// - Under [`CompiledSim::exhaustive`], the search forks: one instance performs the
+    ///   check and ends there, while sibling instances skip the check and continue.
+    /// - In other modes, the pending work runs; afterwards, sending more input and then
+    ///   attempting to receive output will panic.
+    pub fn assert_no_more(self, member_id: u32) -> impl Future<Output = ()>
+    where
+        T: Debug,
+    {
+        QuiescenceCheckFuture::new(FutureTrackingCaller {
+            future: async move {
+                if let Some(next) = self.try_next_impl(member_id).await {
+                    return Err(format!(
+                        "Stream yielded unexpected message: {:?}, expected termination",
+                        next
+                    ));
+                }
+                Ok(())
+            },
+        })
+    }
 }
 
 impl<T: Serialize + DeserializeOwned> SimClusterReceiver<T, TotalOrder, ExactlyOnce> {
@@ -1600,20 +1651,23 @@ impl<T: Serialize + DeserializeOwned> SimClusterReceiver<T, TotalOrder, ExactlyO
 }
 
 impl<T: Serialize + DeserializeOwned> SimClusterReceiver<T, NoOrder, ExactlyOnce> {
-    /// Receives the next `n` values from a specific cluster member, sorted, waiting (and
-    /// letting the scheduler run any pending simulation work) until they are available. If
-    /// the simulation becomes quiescent before `n` values arrive, the test fails.
+    /// Receives the next `n` values from a specific cluster member, sorted, and then
+    /// asserts that the stream ends (like [`Self::assert_no_more`], forking the search in
+    /// exhaustive mode). If the simulation becomes quiescent before `n` values arrive, the
+    /// test fails.
     ///
-    /// Like [`SimReceiver::next`], this is safe to use in the middle of a test.
-    pub fn collect_n_sorted<C: Default + Extend<T> + AsMut<[T]>>(
-        &self,
+    /// There is no variant of this API that skips the end-of-stream check; see
+    /// [`SimReceiver::collect_n_sorted_only`] for why observing a strict prefix of an
+    /// unordered stream would be unsound.
+    pub async fn collect_n_sorted_only<C: Default + Extend<T> + AsMut<[T]>>(
+        self,
         member_id: u32,
         n: usize,
-    ) -> impl use<'_, T, C> + Future<Output = C>
+    ) -> C
     where
-        T: Ord,
+        T: Debug + Ord,
     {
-        FutureTrackingCaller {
+        let out = FutureTrackingCaller {
             future: async move {
                 let mut out = C::default();
                 for i in 0..n {
@@ -1633,6 +1687,24 @@ impl<T: Serialize + DeserializeOwned> SimClusterReceiver<T, NoOrder, ExactlyOnce
                 Ok(out)
             },
         }
+        .await;
+        self.assert_no_more(member_id).await;
+        out
+    }
+
+    /// Receives the next value from a specific cluster member, and then asserts that the
+    /// stream ends (like [`Self::assert_no_more`], forking the search in exhaustive mode).
+    /// If the simulation becomes quiescent without producing a value, the test fails.
+    ///
+    /// This is a shortcut for [`Self::collect_n_sorted_only`] with `n = 1`; see
+    /// [`SimReceiver::next_only`] for why there is no variant that skips the end-of-stream
+    /// check.
+    pub async fn next_only(self, member_id: u32) -> T
+    where
+        T: Debug + Ord,
+    {
+        let mut out: Vec<T> = self.collect_n_sorted_only(member_id, 1).await;
+        out.remove(0)
     }
 
     /// Collects all remaining values from a specific cluster member, sorted, waiting until no

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -1359,19 +1359,27 @@ impl<F1: Future<Output = ()>, F2: Future<Output = ()>> Future for ChainedFuture<
 }
 
 impl<T: Serialize + DeserializeOwned> SimReceiver<T, NoOrder, ExactlyOnce> {
-    /// Receives the next `n` messages, sorted, waiting (and letting the scheduler run any
-    /// pending simulation work) until they are available. If the simulation becomes quiescent
-    /// before `n` messages arrive, the test fails.
+    /// Receives the next `n` messages, sorted, and then asserts that the stream ends (like
+    /// [`SimReceiver::assert_no_more`], forking the search in exhaustive mode). If the
+    /// simulation becomes quiescent before `n` messages arrive, the test fails.
     ///
-    /// Like [`SimReceiver::next`], this is safe to use in the middle of a test.
-    pub fn collect_n_sorted<C: Default + Extend<T> + AsMut<[T]>>(
-        &self,
+    /// Unlike [`collect_n`](SimReceiver::collect_n) on ordered streams, there is no variant
+    /// of this API that skips the end-of-stream check. On an unordered stream, the set of
+    /// messages that arrives *first* is not well-defined, so observing a strict prefix of
+    /// the output would be sensitive to arrival orders that the simulator does not explore
+    /// (delivery into the port is FIFO, with no ordering hook); sorting normalizes the
+    /// permutation of the received messages, but not the choice of *subset*. The quiescence
+    /// check makes the observation sound: it proves the `n` messages are *all* the messages
+    /// the program can produce from the input so far, a set which does not depend on
+    /// arrival order.
+    pub async fn collect_n_sorted_only<C: Default + Extend<T> + AsMut<[T]>>(
+        self,
         n: usize,
-    ) -> impl use<'_, T, C> + Future<Output = C>
+    ) -> C
     where
-        T: Ord,
+        T: Debug + Ord,
     {
-        FutureTrackingCaller {
+        let out = FutureTrackingCaller {
             future: async move {
                 let mut out = C::default();
                 for i in 0..n {
@@ -1390,6 +1398,26 @@ impl<T: Serialize + DeserializeOwned> SimReceiver<T, NoOrder, ExactlyOnce> {
                 Ok(out)
             },
         }
+        .await;
+        self.assert_no_more().await;
+        out
+    }
+
+    /// Receives the next message, and then asserts that the stream ends (like
+    /// [`SimReceiver::assert_no_more`], forking the search in exhaustive mode). If the
+    /// simulation becomes quiescent without producing a message, the test fails.
+    ///
+    /// This is a shortcut for [`Self::collect_n_sorted_only`] with `n = 1`. Unlike
+    /// [`next`](SimReceiver::next) on ordered streams, there is no variant that skips the
+    /// end-of-stream check, because on an unordered stream *which* message arrives first is
+    /// not well-defined; the check proves the message is the *only* one the program can
+    /// produce from the input so far.
+    pub async fn next_only(self) -> T
+    where
+        T: Debug + Ord,
+    {
+        let mut out: Vec<T> = self.collect_n_sorted_only(1).await;
+        out.remove(0)
     }
 
     /// Collects all remaining messages from the external bincode stream into a collection,
@@ -1553,6 +1581,32 @@ impl<T: Serialize + DeserializeOwned, O: Ordering, R: Retries> SimClusterReceive
             .await
             .map(|bytes| bincode::deserialize(&bytes).unwrap())
     }
+
+    /// Asserts that the stream from a specific cluster member has ended and no more messages
+    /// can possibly arrive.
+    ///
+    /// If the check cannot be answered without running pending nondeterministic work (such
+    /// as ticks with buffered inputs):
+    /// - Under [`CompiledSim::exhaustive`], the search forks: one instance performs the
+    ///   check and ends there, while sibling instances skip the check and continue.
+    /// - In other modes, the pending work runs; afterwards, sending more input and then
+    ///   attempting to receive output will panic.
+    pub fn assert_no_more(self, member_id: u32) -> impl Future<Output = ()>
+    where
+        T: Debug,
+    {
+        QuiescenceCheckFuture::new(FutureTrackingCaller {
+            future: async move {
+                if let Some(next) = self.try_next_impl(member_id).await {
+                    return Err(format!(
+                        "Stream yielded unexpected message: {:?}, expected termination",
+                        next
+                    ));
+                }
+                Ok(())
+            },
+        })
+    }
 }
 
 impl<T: Serialize + DeserializeOwned> SimClusterReceiver<T, TotalOrder, ExactlyOnce> {
@@ -1600,20 +1654,23 @@ impl<T: Serialize + DeserializeOwned> SimClusterReceiver<T, TotalOrder, ExactlyO
 }
 
 impl<T: Serialize + DeserializeOwned> SimClusterReceiver<T, NoOrder, ExactlyOnce> {
-    /// Receives the next `n` values from a specific cluster member, sorted, waiting (and
-    /// letting the scheduler run any pending simulation work) until they are available. If
-    /// the simulation becomes quiescent before `n` values arrive, the test fails.
+    /// Receives the next `n` values from a specific cluster member, sorted, and then
+    /// asserts that the stream ends (like [`Self::assert_no_more`], forking the search in
+    /// exhaustive mode). If the simulation becomes quiescent before `n` values arrive, the
+    /// test fails.
     ///
-    /// Like [`SimReceiver::next`], this is safe to use in the middle of a test.
-    pub fn collect_n_sorted<C: Default + Extend<T> + AsMut<[T]>>(
-        &self,
+    /// There is no variant of this API that skips the end-of-stream check; see
+    /// [`SimReceiver::collect_n_sorted_only`] for why observing a strict prefix of an
+    /// unordered stream would be unsound.
+    pub async fn collect_n_sorted_only<C: Default + Extend<T> + AsMut<[T]>>(
+        self,
         member_id: u32,
         n: usize,
-    ) -> impl use<'_, T, C> + Future<Output = C>
+    ) -> C
     where
-        T: Ord,
+        T: Debug + Ord,
     {
-        FutureTrackingCaller {
+        let out = FutureTrackingCaller {
             future: async move {
                 let mut out = C::default();
                 for i in 0..n {
@@ -1633,6 +1690,24 @@ impl<T: Serialize + DeserializeOwned> SimClusterReceiver<T, NoOrder, ExactlyOnce
                 Ok(out)
             },
         }
+        .await;
+        self.assert_no_more(member_id).await;
+        out
+    }
+
+    /// Receives the next value from a specific cluster member, and then asserts that the
+    /// stream ends (like [`Self::assert_no_more`], forking the search in exhaustive mode).
+    /// If the simulation becomes quiescent without producing a value, the test fails.
+    ///
+    /// This is a shortcut for [`Self::collect_n_sorted_only`] with `n = 1`; see
+    /// [`SimReceiver::next_only`] for why there is no variant that skips the end-of-stream
+    /// check.
+    pub async fn next_only(self, member_id: u32) -> T
+    where
+        T: Debug + Ord,
+    {
+        let mut out: Vec<T> = self.collect_n_sorted_only(member_id, 1).await;
+        out.remove(0)
     }
 
     /// Collects all remaining values from a specific cluster member, sorted, waiting until no

--- a/hydro_test/src/distributed/versioning.rs
+++ b/hydro_test/src/distributed/versioning.rs
@@ -238,9 +238,8 @@ mod tests {
 
                 inputter.send(0, Request::Write { value: 42 });
 
-                let r1 = output.collect_n_sorted::<Vec<_>>(0, 1).await;
-                match r1.as_slice() {
-                    [Response { value: 42 }] => {
+                match output.next_only(0).await {
+                    Response { value: 42 } => {
                         write_confirmed = true;
                     }
                     other => panic!("unexpected write response: {other:?}"),
@@ -311,10 +310,8 @@ mod tests {
 
                 inputter.send(0, Request::Write { value: 42 });
 
-                let r1 = output.collect_n_sorted::<Vec<_>>(0, 1).await;
-                match r1.as_slice() {
-                    [] => return,
-                    [Response { value: 42 }] => {
+                match output.next_only(0).await {
+                    Response { value: 42 } => {
                         write_confirmed = true;
                     }
                     other => panic!("unexpected write response: {other:?}"),
@@ -384,9 +381,8 @@ mod tests {
 
                 inputter.send(0, Request::Write { value: 42 });
 
-                let r1 = output.collect_n_sorted::<Vec<_>>(0, 1).await;
-                match r1.as_slice() {
-                    [Response { value: 42 }] => {
+                match output.next_only(0).await {
+                    Response { value: 42 } => {
                         write_confirmed = true;
                     }
                     other => panic!("unexpected write response: {other:?}"),
@@ -471,9 +467,8 @@ mod tests {
 
                 inputter.send(0, Request::Write { value: 42 });
 
-                let r1 = output.collect_n_sorted::<Vec<_>>(0, 1).await;
-                match r1.as_slice() {
-                    [Response { value: 42 }] => {
+                match output.next_only(0).await {
+                    Response { value: 42 } => {
                         write_confirmed = true;
                     }
                     other => panic!("unexpected write response: {other:?}"),


### PR DESCRIPTION
## API changes

- **`SimReceiver<T, NoOrder, ExactlyOnce>`**
  - Added `collect_n_sorted_only(n)`: receives the next `n` messages, sorts them, then asserts the stream ends (like `assert_no_more`, forking the search in exhaustive mode).
  - Added `next_only()`: shortcut for `collect_n_sorted_only` with `n = 1` that returns the single message directly.
  - Removed the public `collect_n_sorted(n)` (inlined into `collect_n_sorted_only`).
- **`SimClusterReceiver<T, O, R>`**
  - Added `assert_no_more(member_id)`, mirroring `SimReceiver::assert_no_more` (was missing entirely).
  - Added `collect_n_sorted_only(member_id, n)` and `next_only(member_id)` on the `NoOrder` impl; removed the public `collect_n_sorted(member_id, n)`.

## Why the bare `collect_n_sorted` was unsound

On an unordered stream, "the first `n` messages" is not a well-defined observation: when more than `n` messages can eventually arrive, *which* `n` land in the external port first depends on arrival order. Delivery into external ports is compiled as a plain FIFO `for_each -> try_send` with no ordering hook (hooks are only inserted at observation points like `batch` / `assume_ordering`), so the simulator does not fork over the alternative prefix subsets — sorting normalizes the permutation of the received messages but not the choice of *subset*. A test could therefore pass exhaustively while a real execution delivers a different first-`n`.

The trailing quiescence check fixes this: it proves the `n` messages are *all* the messages the program can produce from the input so far — a set that does not depend on arrival order. Accordingly, only the `_only` variants are exposed, and their docs explain why no check-skipping variant exists (unlike `collect_n` on ordered streams).

## Call-site updates

- `hydro_test/src/distributed/versioning.rs`: the four gossip tests now use `output.next_only(0)` instead of `collect_n_sorted::<Vec<_>>(0, 1)`, matching on the response directly (a dead `[] => return` arm, unreachable since quiescence already failed the test, was dropped). All 8 versioning tests pass, including the `should_panic` multi-version linearizability test.

BREAKING CHANGE: `SimReceiver::collect_n_sorted` and `SimClusterReceiver::collect_n_sorted` have been removed; use `collect_n_sorted_only` (or `next_only` for a single message), which additionally asserts that the stream ends. The bare variants were unsound: they observed an order-dependent subset of an unordered stream that the simulator does not exhaustively explore.