### PR TITLE
fix(hydro_lang): set TCP_NODELAY on containerized channel connections

### DIFF
--- a/hydro_lang/src/deploy/deploy_runtime_containerized.rs
+++ b/hydro_lang/src/deploy/deploy_runtime_containerized.rs
@@ -128,6 +128,8 @@ impl ChannelMux {
 
             let mux = self.clone();
             tokio::spawn(async move {
+                // Accepted streams are read-only; if a write path is ever added,
+                // set TCP_NODELAY first (see connect_channel).
                 let (rx, _tx) = stream.into_split();
                 let mut source = FramedRead::new(rx, LengthDelimitedCodec::new());
 
@@ -254,6 +256,17 @@ pub async fn send_handshake(
     Ok(())
 }
 
+/// Connects to a channel endpoint, enabling `TCP_NODELAY` so Nagle's
+/// algorithm (combined with delayed ACKs) doesn't stall small writes.
+/// Failure to set the option is non-fatal, so we just log a warning.
+pub async fn connect_channel(target: &str) -> Result<TcpStream, std::io::Error> {
+    let stream = TcpStream::connect(target).await?;
+    if let Err(e) = stream.set_nodelay(true) {
+        warn!(name: "set_nodelay_failed", %target, error = %e);
+    }
+    Ok(stream)
+}
+
 pub fn deploy_containerized_o2o(target: &str, channel_name: &str) -> (syn::Expr, syn::Expr) {
     (
         q!(LazySink::<_, _, _, bytes::Bytes>::new(move || Box::pin(
@@ -262,7 +275,7 @@ pub fn deploy_containerized_o2o(target: &str, channel_name: &str) -> (syn::Expr,
                 let target = format!("{}:{}", target, self::CHANNEL_MUX_PORT);
                 debug!(name: "connecting", %target, %channel_name);
 
-                let stream = TcpStream::connect(&target).await?;
+                let stream = self::connect_channel(&target).await?;
                 let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
 
                 self::send_handshake(&mut sink, channel_name, None).await?;
@@ -301,7 +314,7 @@ pub fn deploy_containerized_o2m(channel_name: &str) -> (syn::Expr, syn::Expr) {
                             format!("{}:{}", key.get_container_name(), self::CHANNEL_MUX_PORT);
                         debug!(name: "connecting", %target, channel_name = %channel_name);
 
-                        let stream = TcpStream::connect(&target).await?;
+                        let stream = self::connect_channel(&target).await?;
                         let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
 
                         self::send_handshake(&mut sink, &channel_name, None).await?;
@@ -337,7 +350,7 @@ pub fn deploy_containerized_m2o(target_host: &str, channel_name: &str) -> (syn::
                 let target = format!("{}:{}", target_host, self::CHANNEL_MUX_PORT);
                 debug!(name: "connecting", %target, %channel_name);
 
-                let stream = TcpStream::connect(&target).await?;
+                let stream = self::connect_channel(&target).await?;
                 let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
 
                 let container_name = std::env::var("CONTAINER_NAME").unwrap();
@@ -388,7 +401,7 @@ pub fn deploy_containerized_m2m(channel_name: &str) -> (syn::Expr, syn::Expr) {
                             format!("{}:{}", key.get_container_name(), self::CHANNEL_MUX_PORT);
                         debug!(name: "connecting", %target, channel_name = %channel_name);
 
-                        let stream = TcpStream::connect(&target).await?;
+                        let stream = self::connect_channel(&target).await?;
                         let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
 
                         let container_name = std::env::var("CONTAINER_NAME").unwrap();

--- a/hydro_lang/src/deploy/deploy_runtime_containerized_ecs.rs
+++ b/hydro_lang/src/deploy/deploy_runtime_containerized_ecs.rs
@@ -17,8 +17,8 @@ use tracing::{Instrument, debug, instrument, span, trace, trace_span};
 
 pub use super::deploy_runtime_containerized::{
     CHANNEL_MAGIC, CHANNEL_MUX_PORT, CHANNEL_PROTOCOL_VERSION, ChannelHandshake, ChannelMagic,
-    ChannelMux, ChannelProtocolVersion, SocketIdent, cluster_ids, get_or_init_channel_mux,
-    send_handshake,
+    ChannelMux, ChannelProtocolVersion, SocketIdent, cluster_ids, connect_channel,
+    get_or_init_channel_mux, send_handshake,
 };
 use crate::location::dynamic::LocationId;
 use crate::location::member_id::TaglessMemberId;
@@ -38,7 +38,7 @@ pub fn deploy_containerized_o2o(
                 let target = format!("{}:{}", ip, self::CHANNEL_MUX_PORT);
                 debug!(name: "connecting", %target, %target_task_family, %task_id, %channel_name);
 
-                let stream = TcpStream::connect(&target).await?;
+                let stream = self::connect_channel(&target).await?;
                 let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
 
                 self::send_handshake(&mut sink, channel_name, None).await?;
@@ -78,7 +78,7 @@ pub fn deploy_containerized_o2m(channel_name: &str) -> (syn::Expr, syn::Expr) {
                         let target = format!("{}:{}", ip, self::CHANNEL_MUX_PORT);
                         debug!(name: "connecting", %target, %task_id, channel_name = %channel_name);
 
-                        let stream = TcpStream::connect(&target).await?;
+                        let stream = self::connect_channel(&target).await?;
                         let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
 
                         self::send_handshake(&mut sink, &channel_name, None).await?;
@@ -120,7 +120,7 @@ pub fn deploy_containerized_m2o(
                 let target = format!("{}:{}", ip, self::CHANNEL_MUX_PORT);
                 debug!(name: "connecting", %target, %target_task_family, %target_task_id, %channel_name);
 
-                let stream = TcpStream::connect(&target).await?;
+                let stream = self::connect_channel(&target).await?;
                 let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
 
                 let self_task_id = self::get_self_task_id();
@@ -173,7 +173,7 @@ pub fn deploy_containerized_m2m(channel_name: &str) -> (syn::Expr, syn::Expr) {
                         let target = format!("{}:{}", ip, self::CHANNEL_MUX_PORT);
                         debug!(name: "connecting", %target, %task_id, channel_name = %channel_name);
 
-                        let stream = TcpStream::connect(&target).await?;
+                        let stream = self::connect_channel(&target).await?;
                         let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
 
                         let self_task_id = self::get_self_task_id();


### PR DESCRIPTION
## Problem

The containerized and ECS runtimes never set TCP_NODELAY on channel connections (the non-containerized path already does). Without it, Nagle's algorithm delays each small write until the previous one is ACKed, and the peer's delayed-ACK timer holds that ACK for 40–200 ms on Linux ([TCP_DELACK_MIN/TCP_DELACK_MAX](https://github.com/torvalds/linux/blob/master/include/net/tcp.h)). Hydro's channels are unidirectional, so ACKs never piggyback on response data, meaning every burst of small messages pays this delay.

## Why TCP_NODELAY unconditionally

- This is necessary to build latency-sensitive distributed systems (see also Marc Brooker, ["It's always TCP_NODELAY"](https://brooker.co.za/blog/2024/05/09/nagle.html)). Hydro should follow this for channel sockets inside the generated code, where users have no control. 
- The cost is acceptable: hydro batches each tick's messages into one write, so all Nagle could further merge is consecutive small ticks. Disabling it costs at most one extra small packet per tick, cheap on modern networks, versus stalls of tens of milliseconds.
- It's the established default: Go [enables it on every TCP connection](https://pkg.go.dev/net#TCPConn.SetNoDelay), as do gRPC and Redis.

## Not covered

External-port paths are left as-is pending their deprecation in favor of sidecars.