### PR TITLE
test(hydro_lang): fix re-entrant tick in `across_ticks` doctests

### DIFF
--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -3002,12 +3002,16 @@ where
     /// #   .into_keyed()
     /// #   .batch(&tick, nondet!(/** test */))
     /// #   .defer_tick(); // appears on the second tick
-    /// let input = batch_first_tick.chain(batch_second_tick).all_ticks();
+    /// let input = batch_first_tick.chain(batch_second_tick);
     ///
-    /// input.batch(&tick, nondet!(/** test */))
-    ///     .across_ticks(|s| s.reduce(q!(|sum, new| {
-    ///         *sum += new;
-    ///     }))).entries().all_ticks()
+    /// input
+    ///     .across_ticks(|s| {
+    ///         s.reduce(q!(|sum, new| {
+    ///             *sum += new;
+    ///         }))
+    ///     })
+    ///     .entries()
+    ///     .all_ticks()
     /// # }, |mut stream| async move {
     /// // First tick: [(0, 1), (1, 2), (2, 3), (3, 4)]
     /// # let mut results = Vec::new();

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -3289,10 +3289,9 @@ where
     /// #   .batch(&tick, nondet!(/** test */))
     /// #   .defer_tick(); // appears on the second tick
     /// let input = // [1, 2, 3, 4 (first batch), 5, 6, 7 (second batch)]
-    /// # batch_first_tick.chain(batch_second_tick).all_ticks();
+    /// # batch_first_tick.chain(batch_second_tick);
     ///
-    /// input.batch(&tick, nondet!(/** test */))
-    ///     .across_ticks(|s| s.count()).all_ticks()
+    /// input.across_ticks(|s| s.count()).all_ticks()
     /// # }, |mut stream| async move {
     /// // [4, 7]
     /// assert_eq!(stream.next().await.unwrap(), 4);


### PR DESCRIPTION
The `Stream::across_ticks` and `KeyedStream::across_ticks` doctests built their
input as `batch_first_tick.chain(batch_second_tick).all_ticks()` and then fed it
back into the *same* tick via `.batch(&tick)`. Under the new gated DFIR
`loop { ... }` codegen, that round-trip — `chain` (inside the tick's loop) →
`all_iterations()` (exit the loop) → `batch()` (re-enter the same loop) — is a
re-entrant tick, which can't be represented as a single loop context and was
reported by the partitioner as the cycle `["batch()", "chain()", "all_iterations()"]`.

Removed the redundant round-trip: `across_ticks` already accepts a
`Stream<T, Tick<L>, Bounded>` (resp. `KeyedStream<...>`), and
`batch_first_tick.chain(batch_second_tick)` already has exactly that type, so
`.all_ticks().batch(&tick)` was a no-op that only introduced the re-entrancy.

- `stream/mod.rs`: `let input = ... .chain(...);` (drop `.all_ticks()`) and call
  `input.across_ticks(|s| s.count()).all_ticks()` directly (drop `input.batch(&tick)`).
- `keyed_stream/mod.rs`: same change for the `reduce`-based example.

Keeping the data in a single tick preserves the deterministic per-tick alignment
(a separate tick would make the `[4, 7]` / accumulated-reduce outputs
nondeterministic, since cross-tick batching is `nondet`). Expected outputs are
unchanged; both doctests now pass.