### PR TITLE
fix(hydro_lang): black-hole failed containerized network channels

### DIFF
--- a/hydro_lang/src/deploy/deploy_runtime_containerized.rs
+++ b/hydro_lang/src/deploy/deploy_runtime_containerized.rs
@@ -17,6 +17,7 @@ use bytes::BytesMut;
 use futures::{FutureExt, Sink, SinkExt, Stream, StreamExt};
 use proc_macro2::Span;
 use sinktools::demux_map_lazy::LazyDemuxSink;
+use sinktools::fail_stop::FailStopSink;
 use sinktools::lazy::{LazySink, LazySource};
 use sinktools::lazy_sink_source::LazySinkSource;
 use stageleft::runtime_support::{
@@ -267,10 +268,27 @@ pub async fn connect_channel(target: &str) -> Result<TcpStream, std::io::Error> 
     Ok(stream)
 }
 
+/// Creates an `on_fail` callback for [`FailStopSink`] that logs a single warning
+/// identifying the failed channel and its destination.
+pub fn warn_on_fail(
+    channel_name: String,
+    target: String,
+) -> impl FnOnce(&'static str, &std::io::Error) + Unpin {
+    move |during, err| {
+        warn!(
+            %channel_name,
+            %target,
+            %during,
+            error = ?err,
+            "channel failed; dropping all further messages to this destination",
+        );
+    }
+}
+
 pub fn deploy_containerized_o2o(target: &str, channel_name: &str) -> (syn::Expr, syn::Expr) {
     (
-        q!(LazySink::<_, _, _, bytes::Bytes>::new(move || Box::pin(
-            async move {
+        q!(FailStopSink::new(
+            LazySink::<_, _, _, bytes::Bytes>::new(move || Box::pin(async move {
                 let channel_name = channel_name;
                 let target = format!("{}:{}", target, self::CHANNEL_MUX_PORT);
                 debug!(name: "connecting", %target, %channel_name);
@@ -281,8 +299,9 @@ pub fn deploy_containerized_o2o(target: &str, channel_name: &str) -> (syn::Expr,
                 self::send_handshake(&mut sink, channel_name, None).await?;
 
                 Result::<_, std::io::Error>::Ok(sink)
-            }
-        )))
+            })),
+            self::warn_on_fail(channel_name.to_owned(), target.to_owned()),
+        ))
         .splice_untyped_ctx(&()),
         q!(LazySource::new(move || Box::pin(async move {
             let channel_name = channel_name;
@@ -305,23 +324,30 @@ pub fn deploy_containerized_o2m(channel_name: &str) -> (syn::Expr, syn::Expr) {
     (
         q!(sinktools::demux_map_lazy::<_, _, _, _>(
             move |key: &TaglessMemberId| {
+                let on_fail = self::warn_on_fail(
+                    channel_name.to_owned(),
+                    key.get_container_name().to_owned(),
+                );
                 let key = key.clone();
                 let channel_name = channel_name.to_owned();
 
-                LazySink::<_, _, _, bytes::Bytes>::new(move || {
-                    Box::pin(async move {
-                        let target =
-                            format!("{}:{}", key.get_container_name(), self::CHANNEL_MUX_PORT);
-                        debug!(name: "connecting", %target, channel_name = %channel_name);
+                FailStopSink::new(
+                    LazySink::<_, _, _, bytes::Bytes>::new(move || {
+                        Box::pin(async move {
+                            let target =
+                                format!("{}:{}", key.get_container_name(), self::CHANNEL_MUX_PORT);
+                            debug!(name: "connecting", %target, channel_name = %channel_name);
 
-                        let stream = self::connect_channel(&target).await?;
-                        let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
+                            let stream = self::connect_channel(&target).await?;
+                            let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
 
-                        self::send_handshake(&mut sink, &channel_name, None).await?;
+                            self::send_handshake(&mut sink, &channel_name, None).await?;
 
-                        Result::<_, std::io::Error>::Ok(sink)
-                    })
-                })
+                            Result::<_, std::io::Error>::Ok(sink)
+                        })
+                    }),
+                    on_fail,
+                )
             }
         ))
         .splice_untyped_ctx(&()),
@@ -344,21 +370,24 @@ pub fn deploy_containerized_o2m(channel_name: &str) -> (syn::Expr, syn::Expr) {
 
 pub fn deploy_containerized_m2o(target_host: &str, channel_name: &str) -> (syn::Expr, syn::Expr) {
     (
-        q!(LazySink::<_, _, _, bytes::Bytes>::new(move || {
-            Box::pin(async move {
-                let channel_name = channel_name;
-                let target = format!("{}:{}", target_host, self::CHANNEL_MUX_PORT);
-                debug!(name: "connecting", %target, %channel_name);
+        q!(FailStopSink::new(
+            LazySink::<_, _, _, bytes::Bytes>::new(move || {
+                Box::pin(async move {
+                    let channel_name = channel_name;
+                    let target = format!("{}:{}", target_host, self::CHANNEL_MUX_PORT);
+                    debug!(name: "connecting", %target, %channel_name);
 
-                let stream = self::connect_channel(&target).await?;
-                let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
+                    let stream = self::connect_channel(&target).await?;
+                    let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
 
-                let container_name = std::env::var("CONTAINER_NAME").unwrap();
-                self::send_handshake(&mut sink, channel_name, Some(&container_name)).await?;
+                    let container_name = std::env::var("CONTAINER_NAME").unwrap();
+                    self::send_handshake(&mut sink, channel_name, Some(&container_name)).await?;
 
-                Result::<_, std::io::Error>::Ok(sink)
-            })
-        }))
+                    Result::<_, std::io::Error>::Ok(sink)
+                })
+            }),
+            self::warn_on_fail(channel_name.to_owned(), target_host.to_owned()),
+        ))
         .splice_untyped_ctx(&()),
         q!(LazySource::new(move || Box::pin(async move {
             let channel_name = channel_name;
@@ -392,25 +421,32 @@ pub fn deploy_containerized_m2m(channel_name: &str) -> (syn::Expr, syn::Expr) {
     (
         q!(sinktools::demux_map_lazy::<_, _, _, _>(
             move |key: &TaglessMemberId| {
+                let on_fail = self::warn_on_fail(
+                    channel_name.to_owned(),
+                    key.get_container_name().to_owned(),
+                );
                 let key = key.clone();
                 let channel_name = channel_name.to_owned();
 
-                LazySink::<_, _, _, bytes::Bytes>::new(move || {
-                    Box::pin(async move {
-                        let target =
-                            format!("{}:{}", key.get_container_name(), self::CHANNEL_MUX_PORT);
-                        debug!(name: "connecting", %target, channel_name = %channel_name);
+                FailStopSink::new(
+                    LazySink::<_, _, _, bytes::Bytes>::new(move || {
+                        Box::pin(async move {
+                            let target =
+                                format!("{}:{}", key.get_container_name(), self::CHANNEL_MUX_PORT);
+                            debug!(name: "connecting", %target, channel_name = %channel_name);
 
-                        let stream = self::connect_channel(&target).await?;
-                        let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
+                            let stream = self::connect_channel(&target).await?;
+                            let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
 
-                        let container_name = std::env::var("CONTAINER_NAME").unwrap();
-                        self::send_handshake(&mut sink, &channel_name, Some(&container_name))
-                            .await?;
+                            let container_name = std::env::var("CONTAINER_NAME").unwrap();
+                            self::send_handshake(&mut sink, &channel_name, Some(&container_name))
+                                .await?;
 
-                        Result::<_, std::io::Error>::Ok(sink)
-                    })
-                })
+                            Result::<_, std::io::Error>::Ok(sink)
+                        })
+                    }),
+                    on_fail,
+                )
             }
         ))
         .splice_untyped_ctx(&()),

--- a/hydro_lang/src/deploy/deploy_runtime_containerized_ecs.rs
+++ b/hydro_lang/src/deploy/deploy_runtime_containerized_ecs.rs
@@ -7,6 +7,7 @@
 use std::time::Duration;
 
 use futures::{SinkExt, Stream, StreamExt};
+use sinktools::fail_stop::FailStopSink;
 use sinktools::lazy::{LazySink, LazySource};
 use sinktools::lazy_sink_source::LazySinkSource;
 use stageleft::{QuotedWithContext, q};
@@ -18,7 +19,7 @@ use tracing::{Instrument, debug, instrument, span, trace, trace_span};
 pub use super::deploy_runtime_containerized::{
     CHANNEL_MAGIC, CHANNEL_MUX_PORT, CHANNEL_PROTOCOL_VERSION, ChannelHandshake, ChannelMagic,
     ChannelMux, ChannelProtocolVersion, SocketIdent, cluster_ids, connect_channel,
-    get_or_init_channel_mux, send_handshake,
+    get_or_init_channel_mux, send_handshake, warn_on_fail,
 };
 use crate::location::dynamic::LocationId;
 use crate::location::member_id::TaglessMemberId;
@@ -29,8 +30,8 @@ pub fn deploy_containerized_o2o(
     channel_name: &str,
 ) -> (syn::Expr, syn::Expr) {
     (
-        q!(LazySink::<_, _, _, bytes::Bytes>::new(move || Box::pin(
-            async move {
+        q!(FailStopSink::new(
+            LazySink::<_, _, _, bytes::Bytes>::new(move || Box::pin(async move {
                 let channel_name = channel_name;
                 let target_task_family = target_task_family;
                 let task_id = self::resolve_task_family_to_task_id(target_task_family).await;
@@ -44,8 +45,9 @@ pub fn deploy_containerized_o2o(
                 self::send_handshake(&mut sink, channel_name, None).await?;
 
                 Result::<_, std::io::Error>::Ok(sink)
-            }
-        )))
+            })),
+            self::warn_on_fail(channel_name.to_owned(), target_task_family.to_owned()),
+        ))
         .splice_untyped_ctx(&()),
         q!(LazySource::new(move || Box::pin(async move {
             let channel_name = channel_name;
@@ -68,24 +70,31 @@ pub fn deploy_containerized_o2m(channel_name: &str) -> (syn::Expr, syn::Expr) {
     (
         q!(sinktools::demux_map_lazy::<_, _, _, _>(
             move |key: &TaglessMemberId| {
+                let on_fail = self::warn_on_fail(
+                    channel_name.to_owned(),
+                    key.get_container_name().to_owned(),
+                );
                 let key = key.clone();
                 let channel_name = channel_name.to_owned();
 
-                LazySink::<_, _, _, bytes::Bytes>::new(move || {
-                    Box::pin(async move {
-                        let task_id = key.get_container_name();
-                        let ip = self::resolve_task_ip(task_id).await;
-                        let target = format!("{}:{}", ip, self::CHANNEL_MUX_PORT);
-                        debug!(name: "connecting", %target, %task_id, channel_name = %channel_name);
+                FailStopSink::new(
+                    LazySink::<_, _, _, bytes::Bytes>::new(move || {
+                        Box::pin(async move {
+                            let task_id = key.get_container_name();
+                            let ip = self::resolve_task_ip(task_id).await;
+                            let target = format!("{}:{}", ip, self::CHANNEL_MUX_PORT);
+                            debug!(name: "connecting", %target, %task_id, channel_name = %channel_name);
 
-                        let stream = self::connect_channel(&target).await?;
-                        let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
+                            let stream = self::connect_channel(&target).await?;
+                            let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
 
-                        self::send_handshake(&mut sink, &channel_name, None).await?;
+                            self::send_handshake(&mut sink, &channel_name, None).await?;
 
-                        Result::<_, std::io::Error>::Ok(sink)
-                    })
-                })
+                            Result::<_, std::io::Error>::Ok(sink)
+                        })
+                    }),
+                    on_fail,
+                )
             }
         ))
         .splice_untyped_ctx(&()),
@@ -111,24 +120,28 @@ pub fn deploy_containerized_m2o(
     channel_name: &str,
 ) -> (syn::Expr, syn::Expr) {
     (
-        q!(LazySink::<_, _, _, bytes::Bytes>::new(move || {
-            Box::pin(async move {
-                let channel_name = channel_name;
-                let target_task_family = target_task_family;
-                let target_task_id = self::resolve_task_family_to_task_id(target_task_family).await;
-                let ip = self::resolve_task_ip(&target_task_id).await;
-                let target = format!("{}:{}", ip, self::CHANNEL_MUX_PORT);
-                debug!(name: "connecting", %target, %target_task_family, %target_task_id, %channel_name);
+        q!(FailStopSink::new(
+            LazySink::<_, _, _, bytes::Bytes>::new(move || {
+                Box::pin(async move {
+                    let channel_name = channel_name;
+                    let target_task_family = target_task_family;
+                    let target_task_id =
+                        self::resolve_task_family_to_task_id(target_task_family).await;
+                    let ip = self::resolve_task_ip(&target_task_id).await;
+                    let target = format!("{}:{}", ip, self::CHANNEL_MUX_PORT);
+                    debug!(name: "connecting", %target, %target_task_family, %target_task_id, %channel_name);
 
-                let stream = self::connect_channel(&target).await?;
-                let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
+                    let stream = self::connect_channel(&target).await?;
+                    let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
 
-                let self_task_id = self::get_self_task_id();
-                self::send_handshake(&mut sink, channel_name, Some(&self_task_id)).await?;
+                    let self_task_id = self::get_self_task_id();
+                    self::send_handshake(&mut sink, channel_name, Some(&self_task_id)).await?;
 
-                Result::<_, std::io::Error>::Ok(sink)
-            })
-        }))
+                    Result::<_, std::io::Error>::Ok(sink)
+                })
+            }),
+            self::warn_on_fail(channel_name.to_owned(), target_task_family.to_owned()),
+        ))
         .splice_untyped_ctx(&()),
         q!(LazySource::new(move || Box::pin(async move {
             let channel_name = channel_name;
@@ -163,25 +176,33 @@ pub fn deploy_containerized_m2m(channel_name: &str) -> (syn::Expr, syn::Expr) {
     (
         q!(sinktools::demux_map_lazy::<_, _, _, _>(
             move |key: &TaglessMemberId| {
+                let on_fail = self::warn_on_fail(
+                    channel_name.to_owned(),
+                    key.get_container_name().to_owned(),
+                );
                 let key = key.clone();
                 let channel_name = channel_name.to_owned();
 
-                LazySink::<_, _, _, bytes::Bytes>::new(move || {
-                    Box::pin(async move {
-                        let task_id = key.get_container_name();
-                        let ip = self::resolve_task_ip(task_id).await;
-                        let target = format!("{}:{}", ip, self::CHANNEL_MUX_PORT);
-                        debug!(name: "connecting", %target, %task_id, channel_name = %channel_name);
+                FailStopSink::new(
+                    LazySink::<_, _, _, bytes::Bytes>::new(move || {
+                        Box::pin(async move {
+                            let task_id = key.get_container_name();
+                            let ip = self::resolve_task_ip(task_id).await;
+                            let target = format!("{}:{}", ip, self::CHANNEL_MUX_PORT);
+                            debug!(name: "connecting", %target, %task_id, channel_name = %channel_name);
 
-                        let stream = self::connect_channel(&target).await?;
-                        let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
+                            let stream = self::connect_channel(&target).await?;
+                            let mut sink = FramedWrite::new(stream, LengthDelimitedCodec::new());
 
-                        let self_task_id = self::get_self_task_id();
-                        self::send_handshake(&mut sink, &channel_name, Some(&self_task_id)).await?;
+                            let self_task_id = self::get_self_task_id();
+                            self::send_handshake(&mut sink, &channel_name, Some(&self_task_id))
+                                .await?;
 
-                        Result::<_, std::io::Error>::Ok(sink)
-                    })
-                })
+                            Result::<_, std::io::Error>::Ok(sink)
+                        })
+                    }),
+                    on_fail,
+                )
             }
         ))
         .splice_untyped_ctx(&()),

--- a/sinktools/src/fail_stop.rs
+++ b/sinktools/src/fail_stop.rs
@@ -1,0 +1,202 @@
+//! [`FailStopSink`] and related items.
+use core::pin::Pin;
+use core::task::{Context, Poll};
+
+use crate::Sink;
+
+/// A [`Sink`] wrapper implementing fail-stop semantics for network channels.
+///
+/// While the inner sink is healthy, all operations are forwarded to it unchanged. The first
+/// error returned by the inner sink permanently marks the channel as failed: the inner sink is
+/// dropped (disconnecting the underlying connection; there is no re-dial) and the `on_fail`
+/// callback is invoked exactly once (typically to log the failure). From then on the wrapper is
+/// a black hole: sends succeed immediately and items are silently discarded.
+///
+/// This matches the fail-stop failure model, where a failed connection stops all future
+/// deliveries to that recipient (modeling the recipient as having failed) without affecting the
+/// sender. Because the wrapper never returns an error, a dead peer cannot crash the sending
+/// process, and when used per-destination under a demux (e.g. [`crate::demux_map()`]) it cannot
+/// poison deliveries to healthy sibling destinations through the demux's shared error path.
+pub struct FailStopSink<Si, F> {
+    /// The inner sink. `None` once the channel has failed; dropping it disconnects.
+    sink: Option<Si>,
+    /// Failure callback. `None` once invoked (the channel fails at most once).
+    on_fail: Option<F>,
+}
+
+impl<Si, F> FailStopSink<Si, F> {
+    /// Wraps `sink`. On the first error, `on_fail` is invoked exactly once with the name of the
+    /// failing sink operation (`"poll_ready"`, `"start_send"`, `"poll_flush"`, or
+    /// `"poll_close"`) and the error.
+    pub fn new(sink: Si, on_fail: F) -> Self {
+        Self {
+            sink: Some(sink),
+            on_fail: Some(on_fail),
+        }
+    }
+
+    /// Returns `true` if the channel has failed and is now discarding all messages.
+    pub fn is_dead(&self) -> bool {
+        self.sink.is_none()
+    }
+
+    /// Marks the channel as failed, invoking `on_fail` and dropping the inner sink
+    /// (disconnect).
+    fn fail<E>(&mut self, during: &'static str, err: &E)
+    where
+        F: FnOnce(&'static str, &E),
+    {
+        if let Some(on_fail) = self.on_fail.take() {
+            (on_fail)(during, err);
+        }
+        self.sink = None;
+    }
+}
+
+impl<Si, Item, F> Sink<Item> for FailStopSink<Si, F>
+where
+    Si: Sink<Item> + Unpin,
+    F: FnOnce(&'static str, &Si::Error) + Unpin,
+{
+    /// Same type as the inner sink's error for drop-in compatibility, but never actually
+    /// returned: errors are converted into the fail-stop state instead.
+    type Error = Si::Error;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let this = self.get_mut();
+        let Some(sink) = this.sink.as_mut() else {
+            return Poll::Ready(Ok(()));
+        };
+        match Pin::new(sink).poll_ready(cx) {
+            Poll::Ready(Err(err)) => {
+                this.fail("poll_ready", &err);
+                Poll::Ready(Ok(()))
+            }
+            poll => poll,
+        }
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::Error> {
+        let this = self.get_mut();
+        let Some(sink) = this.sink.as_mut() else {
+            // Black hole: the item is silently discarded.
+            return Ok(());
+        };
+        if let Err(err) = Pin::new(sink).start_send(item) {
+            this.fail("start_send", &err);
+        }
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let this = self.get_mut();
+        let Some(sink) = this.sink.as_mut() else {
+            return Poll::Ready(Ok(()));
+        };
+        match Pin::new(sink).poll_flush(cx) {
+            Poll::Ready(Err(err)) => {
+                this.fail("poll_flush", &err);
+                Poll::Ready(Ok(()))
+            }
+            poll => poll,
+        }
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let this = self.get_mut();
+        let Some(sink) = this.sink.as_mut() else {
+            return Poll::Ready(Ok(()));
+        };
+        match Pin::new(sink).poll_close(cx) {
+            Poll::Ready(Err(err)) => {
+                this.fail("poll_close", &err);
+                Poll::Ready(Ok(()))
+            }
+            poll => poll,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::cell::Cell;
+    use core::pin::pin;
+
+    use futures_util::SinkExt;
+
+    use super::*;
+
+    /// Sink that accepts `ok_sends` items and then errors forever.
+    struct FlakySink {
+        ok_sends: usize,
+        received: Vec<u32>,
+    }
+    impl Sink<u32> for FlakySink {
+        type Error = &'static str;
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn start_send(self: Pin<&mut Self>, item: u32) -> Result<(), Self::Error> {
+            let this = self.get_mut();
+            if 0 < this.ok_sends {
+                this.ok_sends -= 1;
+                this.received.push(item);
+                Ok(())
+            } else {
+                Err("peer died")
+            }
+        }
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fail_stop_black_holes_after_error() {
+        let fail_count = Cell::new(0);
+        let observed = Cell::new(None::<(&'static str, &'static str)>);
+        let mut sink = pin!(FailStopSink::new(
+            FlakySink {
+                ok_sends: 2,
+                received: Vec::new(),
+            },
+            |during, err: &&'static str| {
+                fail_count.set(fail_count.get() + 1);
+                observed.set(Some((during, err)));
+            },
+        ));
+
+        // Healthy sends are forwarded; the callback has not fired.
+        sink.send(1).await.unwrap();
+        sink.send(2).await.unwrap();
+        assert!(!sink.is_dead());
+        assert_eq!(0, fail_count.get());
+
+        // First error kills the channel but is not surfaced; the callback fires once with the
+        // failing operation and the error.
+        sink.send(3).await.unwrap();
+        assert!(sink.is_dead());
+        assert_eq!(1, fail_count.get());
+        assert_eq!(Some(("start_send", "peer died")), observed.get());
+
+        // Subsequent operations silently discard, without re-invoking the callback.
+        sink.send(4).await.unwrap();
+        sink.send(5).await.unwrap();
+        sink.flush().await.unwrap();
+        sink.close().await.unwrap();
+        assert!(sink.is_dead());
+        assert_eq!(1, fail_count.get());
+    }
+}

--- a/sinktools/src/lib.rs
+++ b/sinktools/src/lib.rs
@@ -12,6 +12,7 @@ pub use futures_util::sink::Sink;
 #[cfg_attr(docsrs, doc(cfg(feature = "variadics")))]
 pub use variadics;
 
+pub mod fail_stop;
 pub mod filter;
 pub mod filter_map;
 pub mod flat_map;


### PR DESCRIPTION
Part of #3130.

A dead peer currently crashes senders: any sink error propagates into
`dest_sink`'s `sink_map_err(|e| panic!(...))` wrapper, and in demuxed
(to-many) channels a single failed destination poisons deliveries to
healthy siblings through the demux's shared error path.

This adds `sinktools::fail_stop::FailStopSink`, a sink wrapper
implementing fail-stop semantics: the first error from the inner sink
invokes an `on_fail` callback exactly once, disconnects (drops the
inner sink; no re-dial), and turns the wrapper into a permanent black
hole that silently discards all further messages.

The containerized (Docker + ECS) deploy runtimes wrap every channel
sink — o2o, o2m, m2o, m2m — and emit one warning per failed channel via
a shared `warn_on_fail` helper that identifies the channel and
destination. Logging is delegated to the callback, keeping sinktools
free of new dependencies and the module `no_std`-compatible.

Initial connect/handshake errors are black-holed the same way, by
design: a single dial attempt is made, and a peer that is dead at first
dial behaves the same as one that dies mid-run.

## Out of scope

- Localhost and external channels are intentionally not guarded.
- Reconnection/recovery semantics beyond fail-stop.