### PR TITLE
feat(dfir_lang): add `batch_eager()` loop-ingress operator, always fires the loop

### DIFF
--- a/dfir_lang/src/graph/flat_graph_builder.rs
+++ b/dfir_lang/src/graph/flat_graph_builder.rs
@@ -1132,6 +1132,33 @@ impl FlatGraphBuilder {
                         ));
                     }
                 }
+                Some(FloType::WindowingEager) => {
+                    if !is_input {
+                        self.diagnostics.push(Diagnostic::spanned(
+                            span,
+                            Level::Error,
+                            format!(
+                                "Windowing operator `{}(...)` must be the first input operator into a `loop {{ ... }}` context.",
+                                op_inst.op_constraints.name
+                            )
+                        ));
+                    } else if loop_id
+                        .and_then(|lid| self.flat_graph.loop_parent(lid))
+                        .is_some()
+                    {
+                        // An eager windowing operator forces the loop to always fire. In a nested
+                        // loop this would prevent the fixpoint iteration from ever terminating, so
+                        // it is only allowed at the entry of a root-level loop.
+                        self.diagnostics.push(Diagnostic::spanned(
+                            span,
+                            Level::Error,
+                            format!(
+                                "Eager windowing operator `{}(...)` is only allowed at the entry of a root-level `loop {{ ... }}` context, not a nested loop.",
+                                op_inst.op_constraints.name
+                            )
+                        ));
+                    }
+                }
                 Some(FloType::Unwindowing) => {
                     if !is_output {
                         self.diagnostics.push(Diagnostic::spanned(

--- a/dfir_lang/src/graph/meta_graph.rs
+++ b/dfir_lang/src/graph/meta_graph.rs
@@ -1101,7 +1101,24 @@ impl DfirGraph {
             }
         }
 
-        if gate_checks.is_empty() {
+        // An eager windowing operator (`batch_eager()`) forces the loop to fire unconditionally,
+        // even when its windowed input is empty. It is only valid at the entry of a root-level
+        // loop (disallowed in nested loops during validation, since forcing a nested loop to
+        // always fire would prevent its fixpoint iteration from terminating).
+        let has_eager = entry_handoffs.iter().any(|&hoff_id| {
+            self.node_successors(hoff_id)
+                .next()
+                .and_then(|(_, succ)| self.node_op_inst(succ))
+                .is_some_and(|op_inst| {
+                    op_inst.op_constraints.flo_type == Some(FloType::WindowingEager)
+                })
+        });
+
+        if has_eager && is_root_loop {
+            // Eager entry: always run the loop body (gate forced true).
+            output.extend(child_body);
+            output.extend(quote! { #( #swap_code )* });
+        } else if gate_checks.is_empty() {
             // No entry handoffs — always run.
             output.extend(child_body);
             output.extend(quote! { #( #swap_code )* });

--- a/dfir_lang/src/graph/ops/batch_eager.rs
+++ b/dfir_lang/src/graph/ops/batch_eager.rs
@@ -5,16 +5,21 @@ use super::{
 
 /// Given an _unbounded_ input stream, emits values arbitrarily split into batches over multiple iterations in the same order.
 ///
-/// Will cause additional loop iterations as long as new values arrive.
-///
-/// `batch()` is one of three loop-ingress ("windowing") operators, which differ only in whether
-/// they cause the surrounding `loop { ... }` to fire:
+/// `batch_eager()` is one of three loop-ingress ("windowing") operators, which differ only in
+/// whether they cause the surrounding `loop { ... }` to fire:
 /// - `batch()` triggers the loop only when its windowed input is non-empty.
 /// - `batch_lazy()` never triggers the loop on its own; its data is only observed if the loop
 ///   fires for some other reason (otherwise dropped at tick end).
-/// - `batch_eager()` always triggers the loop, even when the windowed input is empty.
-pub const BATCH: OperatorConstraints = OperatorConstraints {
-    name: "batch",
+/// - `batch_eager()` **always** triggers the loop, even when the windowed input is empty.
+///
+/// Because it forces the loop body to run, `batch_eager()` is only valid at the entry of a
+/// root-level loop. It is disallowed inside nested loops, where forcing the loop to always fire
+/// would prevent the fixpoint iteration from terminating.
+///
+/// Note that `batch_eager()` only forces the loop body to run when a tick executes; it does not
+/// schedule additional ticks on its own (unlike `spin()`).
+pub const BATCH_EAGER: OperatorConstraints = OperatorConstraints {
+    name: "batch_eager",
     categories: &[OperatorCategory::Windowing],
     hard_range_inn: RANGE_1,
     soft_range_inn: RANGE_1,
@@ -24,12 +29,12 @@ pub const BATCH: OperatorConstraints = OperatorConstraints {
     persistence_args: RANGE_0,
     type_args: RANGE_0,
     is_external_input: false,
-    flo_type: Some(FloType::Windowing),
+    flo_type: Some(FloType::WindowingEager),
     ports_inn: None,
     ports_out: None,
     input_delaytype_fn: |_| None,
-    // Scheduler automatically handles the batching of values as this is a `OperatorCategory::Windowing` operator.
-    // In inline codegen, batch() is identity — the loop boundary handoff provides the buffering/gating.
+    // Same as batch() — identity in inline codegen. The loop-gate logic (see `emit_loop_gate`)
+    // uses the `WindowingEager` flo type to force the loop to fire unconditionally.
     write_fn: |wc @ &WriteContextArgs { .. }, _diagnostics| {
         let write_iterator = identity_write_iterator_fn(wc);
         Ok(OperatorWriteOutput {

--- a/dfir_lang/src/graph/ops/batch_lazy.rs
+++ b/dfir_lang/src/graph/ops/batch_lazy.rs
@@ -9,6 +9,13 @@ use super::{
 /// does not fire for another reason (e.g., a non-lazy `batch` or `defer_tick`
 /// has data), the lazy-batched data is available. If the loop never fires that
 /// tick, the data is simply dropped (reclaimed by the bump allocator at tick end).
+///
+/// `batch_lazy()` is one of three loop-ingress ("windowing") operators, which differ only in
+/// whether they cause the surrounding `loop { ... }` to fire:
+/// - `batch()` triggers the loop only when its windowed input is non-empty.
+/// - `batch_lazy()` never triggers the loop on its own; its data is only observed if the loop
+///   fires for some other reason (otherwise dropped at tick end).
+/// - `batch_eager()` always triggers the loop, even when the windowed input is empty.
 pub const BATCH_LAZY: OperatorConstraints = OperatorConstraints {
     name: "batch_lazy",
     categories: &[OperatorCategory::Windowing],

--- a/dfir_lang/src/graph/ops/mod.rs
+++ b/dfir_lang/src/graph/ops/mod.rs
@@ -276,6 +276,7 @@ declare_ops![
     assert::ASSERT,
     assert_eq::ASSERT_EQ,
     batch::BATCH,
+    batch_eager::BATCH_EAGER,
     batch_lazy::BATCH_LAZY,
     chain::CHAIN,
     chain_first_n::CHAIN_FIRST_N,
@@ -615,6 +616,10 @@ pub enum FloType {
     /// A lazy windowing operator — moves data into a loop context but does not trigger the loop.
     /// Data is dropped if the loop does not fire that tick.
     WindowingLazy,
+    /// An eager windowing operator — moves data into a loop context and always triggers the loop,
+    /// even when the windowed input is empty. Only valid at the entry of a root-level loop (it is
+    /// disallowed in nested loops, where it would prevent the fixpoint iteration from terminating).
+    WindowingEager,
     /// An un-windowing operator, for moving data out of a loop context.
     Unwindowing,
 }

--- a/dfir_rs/tests/compile-fail/nightly/surface_loop_eager_nested.stderr
+++ b/dfir_rs/tests/compile-fail/nightly/surface_loop_eager_nested.stderr
@@ -1,0 +1,5 @@
+error: Eager windowing operator `batch_eager(...)` is only allowed at the entry of a root-level `loop { ... }` context, not a nested loop.
+ --> tests/compile-fail/nightly/surface_loop_eager_nested.rs:8:22
+  |
+8 |                 b -> batch_eager() -> null();
+  |                      ^^^^^^^^^^^^^

--- a/dfir_rs/tests/compile-fail/stable/surface_loop_eager_nested.stderr
+++ b/dfir_rs/tests/compile-fail/stable/surface_loop_eager_nested.stderr
@@ -1,0 +1,5 @@
+error: Eager windowing operator `batch_eager(...)` is only allowed at the entry of a root-level `loop { ... }` context, not a nested loop.
+ --> tests/compile-fail/stable/surface_loop_eager_nested.rs:8:22
+  |
+8 |                 b -> batch_eager() -> null();
+  |                      ^^^^^^^^^^^

--- a/dfir_rs/tests/compile-fail/surface_loop_eager_nested.rs
+++ b/dfir_rs/tests/compile-fail/surface_loop_eager_nested.rs
@@ -1,0 +1,13 @@
+fn main() {
+    let mut df = dfir_rs::dfir_syntax! {
+        a = source_iter(0..10);
+        loop {
+            a -> batch() -> b;
+            b = identity();
+            loop {
+                b -> batch_eager() -> null();
+            };
+        };
+    };
+    df.run_available_sync();
+}

--- a/dfir_rs/tests/surface_loop.rs
+++ b/dfir_rs/tests/surface_loop.rs
@@ -239,6 +239,80 @@ pub fn test_batch_lazy() {
     assert_eq!(out, Vec::<i32>::new());
 }
 
+/// Test batch_eager: the loop fires every tick, even when the eager input is empty.
+/// A `fold` inside the loop should emit output on every tick regardless of input.
+#[multiplatform_test(test, wasm, env_tracing)]
+pub fn test_batch_eager() {
+    let (eager_send, eager_recv) = dfir_rs::util::unbounded_channel::<i32>();
+    let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<usize>();
+
+    let mut df = dfir_syntax! {
+        eager_inp = source_stream(eager_recv);
+        loop {
+            // Count the batch each tick. With `batch_eager()` the loop fires even when
+            // the batch is empty, so we should observe a count on every tick.
+            eager_inp -> batch_eager() -> fold(|| 0usize, |acc, _| *acc += 1)
+                -> for_each(|c| out_send.send(c).unwrap());
+        };
+    };
+
+    // Tick 1: no data — loop should STILL fire (count 0).
+    df.run_tick_sync();
+    let out: Vec<usize> = dfir_rs::util::collect_ready(&mut out_recv);
+    assert_eq!(out, vec![0]);
+
+    // Tick 2: two elements — loop fires, count 2.
+    eager_send.send(1).unwrap();
+    eager_send.send(2).unwrap();
+    df.run_tick_sync();
+    let out: Vec<usize> = dfir_rs::util::collect_ready(&mut out_recv);
+    assert_eq!(out, vec![2]);
+
+    // Tick 3: no data again — loop still fires (count 0).
+    df.run_tick_sync();
+    let out: Vec<usize> = dfir_rs::util::collect_ready(&mut out_recv);
+    assert_eq!(out, vec![0]);
+}
+
+/// Test batch_eager combined with batch_lazy: the eager input always fires the loop,
+/// making the lazy data visible on every tick it is present.
+#[multiplatform_test(test, wasm, env_tracing)]
+pub fn test_batch_eager_with_lazy() {
+    let (eager_send, eager_recv) = dfir_rs::util::unbounded_channel::<i32>();
+    let (lazy_send, lazy_recv) = dfir_rs::util::unbounded_channel::<i32>();
+    let (out_send, mut out_recv) = dfir_rs::util::unbounded_channel::<i32>();
+
+    let mut df = dfir_syntax! {
+        eager_inp = source_stream(eager_recv);
+        lazy_inp = source_stream(lazy_recv);
+        loop {
+            merged = union();
+            eager_inp -> batch_eager() -> merged;
+            lazy_inp -> batch_lazy() -> merged;
+            merged -> for_each(|x| out_send.send(x).unwrap());
+        };
+    };
+
+    // Tick 1: only lazy data — loop fires anyway (eager), so lazy data is visible.
+    lazy_send.send(100).unwrap();
+    df.run_tick_sync();
+    let out: Vec<i32> = dfir_rs::util::collect_ready(&mut out_recv);
+    assert_eq!(out, vec![100]);
+
+    // Tick 2: no data at all — loop still fires (eager), but there is nothing to emit.
+    df.run_tick_sync();
+    let out: Vec<i32> = dfir_rs::util::collect_ready(&mut out_recv);
+    assert_eq!(out, Vec::<i32>::new());
+
+    // Tick 3: both eager and lazy data.
+    eager_send.send(1).unwrap();
+    lazy_send.send(200).unwrap();
+    df.run_tick_sync();
+    let mut out: Vec<i32> = dfir_rs::util::collect_ready(&mut out_recv);
+    out.sort();
+    assert_eq!(out, vec![1, 200]);
+}
+
 /// Test all_iterations: collects output from all loop iterations and emits
 /// it outside the loop after the loop completes.
 /// Note: defer_tick only works in nested loops, so we use a nested structure.


### PR DESCRIPTION
Adds a third DFIR loop-ingress ("windowing") operator alongside the existing
`batch()` (fires when input non-empty) and `batch_lazy()` (never fires on its
own). `batch_eager()` always fires the surrounding loop, even when its windowed
input is empty. Naming follows the existing minimal `lazy`/`eager` convention;
no renames of existing operators.

Semantics (as requested):
- Gate-only: `batch_eager()` forces the root-level loop body to run whenever a
  tick executes, but does not schedule additional ticks on its own (unlike
  `spin()`).
- Disallowed in nested loops: since nested loops iterate to fixpoint via a
  `while <gate>` construct, forcing the gate true would never terminate. Using
  `batch_eager()` at a nested-loop entry is a compile error.

Changes:
- dfir_lang/src/graph/ops/mod.rs: new `FloType::WindowingEager` variant;
  register `batch_eager::BATCH_EAGER` in `OPERATORS`.
- dfir_lang/src/graph/ops/batch_eager.rs: new operator (identity codegen, like
  batch/batch_lazy), with docs explaining the three-way distinction.
- dfir_lang/src/graph/ops/batch.rs, batch_lazy.rs: expanded doc comments to
  describe all three loop-ingress operators (auto-propagated to the generated
  operator reference docs).
- dfir_lang/src/graph/meta_graph.rs (`emit_loop_gate`): detect an eager entry
  handoff and, for root-level loops, emit the loop body unconditionally.
- dfir_lang/src/graph/flat_graph_builder.rs: accept `WindowingEager` at loop
  entry edges and emit an error when it is used at a nested-loop entry.
- dfir_rs/tests/surface_loop.rs: `test_batch_eager` (loop fires every tick incl.
  empty) and `test_batch_eager_with_lazy`.
- dfir_rs/tests/compile-fail/surface_loop_eager_nested.rs (+ stable/nightly
  stderr): verifies the nested-loop rejection.

The operator reference docs (docs/docgen/*.md, surface_ops_gen.md) are generated
from the doc comments at build time and are not version-controlled.