### PR TITLE
fix(hydro_lang): make each top-level sim hook its own observation

### DIFF
--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -3823,7 +3823,7 @@ mod tests {
         });
 
         assert!(saw, "did not see an instance with (1, 1) before (1, 2)");
-        assert_eq!(instance_count, 78);
+        assert_eq!(instance_count, 28);
     }
 
     /// Tests that `merge_ordered` on a keyed stream explores every valid
@@ -3883,7 +3883,7 @@ mod tests {
         assert!(saw_first, "did not observe [a, b, c]");
         assert!(saw_interleaved, "did not observe [a, c, b]");
         assert!(saw_second_first, "did not observe [c, a, b]");
-        assert_eq!(instances, 33);
+        assert_eq!(instances, 15);
     }
 
     /// Tests that `merge_ordered` on a keyed stream interleaves each group
@@ -3947,6 +3947,6 @@ mod tests {
             saw_independent,
             "did not observe per-key-independent interleaving"
         );
-        assert_eq!(instances, 2944);
+        assert_eq!(instances, 1120);
     }
 }

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -4080,7 +4080,7 @@ mod tests {
         });
 
         assert!(saw, "did not see an instance with 0, 3, 1 in order");
-        assert_eq!(instance_count, 24);
+        assert_eq!(instance_count, 15);
     }
 
     #[cfg(feature = "sim")]

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -1013,10 +1013,17 @@ impl<'a> CompiledSimInstance<'a> {
 
         let not_ready_observations = async_dfirs
             .iter()
-            .map(|(lid, cluster_id, _)| SimObservation {
-                location: serde_json::from_str(lid).unwrap(),
-                cluster_id: *cluster_id,
-                hooks: hooks.remove(&(*lid, *cluster_id)).unwrap_or_default(),
+            .flat_map(|(lid, cluster_id, _)| {
+                let location: LocationId = serde_json::from_str(lid).unwrap();
+                hooks
+                    .remove(&(*lid, *cluster_id))
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(move |hook| SimObservation {
+                        location: location.clone(),
+                        cluster_id: *cluster_id,
+                        hook,
+                    })
             })
             .collect();
 
@@ -1825,23 +1832,34 @@ impl SimTick {
     }
 }
 
-/// A top-level location whose hooks (e.g. from `assume_ordering` on a non-tick stream)
-/// need scheduling decisions, but which has no tick DFIR to execute. The scheduler just
-/// resolves the hooks.
+/// A single top-level hook (e.g. from `assume_ordering` on a non-tick stream) that needs
+/// scheduling decisions, but has no tick DFIR to execute. The scheduler just resolves the
+/// hook.
+///
+/// Each top-level hook is its own observation ("its own virtual tick"), even when several
+/// hooks live at the same location: unlike a tick's hooks, which one atomic tick
+/// execution consumes together, co-located top-level hooks are causally independent
+/// operators, so resolving them jointly would only couple their decisions. Grouping them
+/// would both add redundant schedules (releasing jointly is equivalent to releasing in
+/// consecutive steps, which is explored anyway) and *lose* schedules for hook kinds whose
+/// decisions always release when resolved (a fold could never stay silent while a
+/// co-located sibling acts). With one hook per observation, "act" and "stay silent" are
+/// expressed purely by the scheduler picking or not picking the observation, and a picked
+/// observation always makes a nontrivial decision.
 struct SimObservation {
     /// The top-level location, used to match this observation against the async DFIR that
     /// produces its input data.
     location: LocationId,
     /// The cluster member ID, if the location is a cluster.
     cluster_id: Option<u32>,
-    /// Hooks resolved when the scheduler selects this observation.
-    hooks: Vec<Box<dyn SimHook>>,
+    /// The hook resolved when the scheduler selects this observation.
+    hook: Box<dyn SimHook>,
 }
 
 impl SimObservation {
-    /// Whether the scheduler can resolve any of this observation's hooks right now.
+    /// Whether the scheduler can resolve this observation's hook right now.
     fn can_run(&self) -> bool {
-        self.hooks.iter().any(|hook| hook_can_release(&**hook))
+        hook_can_release(&*self.hook)
     }
 }
 
@@ -2033,7 +2051,7 @@ impl<W: std::io::Write> LaunchedSim<W> {
                 let log_writer = (!matches!(self.log, LogKind::Null)).then_some(&mut self.log);
                 run_hooks(
                     log_writer,
-                    &mut self.possibly_ready_observations[next_obs].hooks,
+                    std::slice::from_mut(&mut self.possibly_ready_observations[next_obs].hook),
                 );
             }
         }

--- a/hydro_lang/src/sim/tests/mod.rs
+++ b/hydro_lang/src/sim/tests/mod.rs
@@ -721,6 +721,79 @@ fn sim_fold_sample_eager_state_count() {
     assert_eq!(count, 108, "Exhaustive states explored");
 }
 
+/// A top-level fold co-located with another observation hook must be able to *withhold*
+/// its buffered input while the sibling releases. The witness is the accumulator version
+/// `[11]`: it exists only in executions where the fold held back its direct input `5`
+/// while the sibling released `10` (which cycles in as `11`) *and* the fold then released
+/// `11` alone — so observing it proves the withholding interleaving is explored.
+///
+/// This reproduces a coverage gap when all top-level hooks at one location are resolved
+/// together as a single observation: a fold's autonomous decision always releases a
+/// non-empty subset whenever it runs, so the fold can never stay silent while the
+/// co-located sibling acts — its first release is always exactly `[5]`, and version
+/// `[11]` can never exist.
+#[test]
+fn sim_colocated_fold_can_withhold_while_sibling_observation_releases() {
+    use crate::live_collections::stream::NoOrder;
+    use crate::properties::manual_proof;
+
+    let mut flow = FlowBuilder::new();
+    let node = flow.process::<()>();
+
+    let (direct_send, direct_in) = node.sim_input::<u32, NoOrder, ExactlyOnce>();
+    let (u_send, u_in) = node.sim_input::<u32, NoOrder, ExactlyOnce>();
+
+    // The sibling: an unscripted top-level ordering whose releases feed the fold.
+    let cycled = u_in
+        .assume_ordering::<TotalOrder>(nondet!(/** fuzzed */))
+        .map(q!(|v| v + 1))
+        .weaken_ordering::<NoOrder>();
+
+    let folded = direct_in.merge_unordered(cycled).fold(
+        q!(|| Vec::new()),
+        q!(
+            |acc, v| {
+                acc.push(v);
+                acc.sort();
+            },
+            commutative = manual_proof!(
+                /// a sorted vector accumulates a multiset, so insertion order is invisible
+            )
+        ),
+    );
+
+    let out = sliced! {
+        let state = use::snapshot(folded, nondet!(/** fuzzed */));
+        state.into_stream()
+    }
+    .sim_output();
+
+    let mut saw_fold_alone_first = false;
+    let mut saw_fold_withholding = false;
+
+    flow.sim().exhaustive(async || {
+        direct_send.send_many_unordered([5u32]);
+        u_send.send_many_unordered([10u32]);
+
+        let versions: Vec<Vec<u32>> = out.collect().await;
+        if versions.iter().any(|v| v.as_slice() == [5]) {
+            saw_fold_alone_first = true;
+        }
+        if versions.iter().any(|v| v.as_slice() == [11]) {
+            saw_fold_withholding = true;
+        }
+    });
+
+    assert!(
+        saw_fold_alone_first,
+        "never explored the fold releasing its direct input first"
+    );
+    assert!(
+        saw_fold_withholding,
+        "the fold never withheld its buffered input while the co-located hook released"
+    );
+}
+
 #[test]
 fn sim_fold_commutative_explores_all_subset_sums() {
     use std::collections::HashSet;

--- a/hydro_lang/tests/snapshots/sim_fuzzer__fuzz_with_cargo_sim_continue_if.snap
+++ b/hydro_lang/tests/snapshots/sim_fuzzer__fuzz_with_cargo_sim_continue_if.snap
@@ -3,6 +3,6 @@ source: hydro_lang/tests/sim_fuzzer.rs
 expression: "lines[block_start..block_start + 4].join(\"\\n\")"
 ---
 Condition failed (discarding simulation instance):
---> hydro_lang/src/sim/tests/mod.rs:1249:9
+--> hydro_lang/src/sim/tests/mod.rs:1322:9
  |        crate::sim::continue_if!(
  |        ^ first batch was a singleton


### PR DESCRIPTION
All top-level hooks at one location were grouped into a single
`SimObservation` and resolved together whenever the scheduler selected
that location. This both bloated and pruned the explored schedule space:

- **Redundant schedules**: co-located hooks releasing jointly in one step
  is state-equivalent to releasing in consecutive steps (releases only
  append to disjoint downstream buffers, and propagation happens after
  the step), so the joint combinations added `a*b` redundant branches on
  top of the `a+b` sequential ones.
- **Lost schedules**: hook kinds whose autonomous decision always releases
  when resolved (e.g. the top-level fold hook, which always selects a
  non-empty subset) could never stay silent while a co-located sibling
  acted, so interleavings where the sibling's output cycles into the hook
  before its first release were silently never explored.

Unlike a tick, whose hooks one atomic execution consumes together, a
top-level location has no joint consumer: co-located observation hooks
are causally independent operators. So each hook is now its own
`SimObservation` ("its own virtual tick"): the scheduler picks a single
hook, and a picked hook always makes a nontrivial decision — staying
silent is expressed by picking a different candidate, not by a trivial
decision drawn from entropy.

Adds `sim_colocated_fold_can_withhold_while_sibling_observation_releases`,
which fails before this change (the witness accumulator version `[11]`,
the fold withholding its direct input while the sibling's release cycles
in, is never explored) and passes after.

Exhaustive instance counts in four existing tests shrink accordingly
(their semantic coverage assertions are unchanged and still pass):
`sim_top_level_assume_ordering_multiple` 24→15,
`sim_entries_partially_ordered_cycle_back` 78→28,
`sim_keyed_merge_ordered` 33→15,
`sim_keyed_merge_ordered_independent_keys` 2944→1120.

Full hydro_lang lib suite passes; clippy clean.