### PR TITLE
fix(hydro_concurrent_cargo, hydro_lang, hydro_deploy): support cargo's new build-dir layout for concurrent builds [ci-full]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -179,7 +179,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1360,7 +1360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1369,7 +1369,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1894,7 +1894,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2081,7 +2081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3186,7 +3186,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3620,7 +3620,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4904,7 +4904,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4917,7 +4917,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5241,9 +5241,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.3"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -5677,7 +5677,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5959,17 +5959,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.8"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
  "indexmap 2.12.1",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.3",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.14",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5983,6 +5983,15 @@ name = "toml_datetime"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -6024,11 +6033,11 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 0.7.14",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6039,9 +6048,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.4"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -6182,9 +6191,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.115"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f614c21bd3a61bad9501d75cbb7686f00386c806d7f456778432c25cf86948a"
+checksum = "1e605bf6b39357663d8ba4e984f8be8da8df6bb32e81031d6889024ea8fd68e4"
 dependencies = [
  "glob",
  "serde",
@@ -6197,9 +6206,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild-internals-api"
-version = "1.0.114"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c823ac353d4ef60d9ed955b3294f0dafb0e05180175bc170a4c555f7e0a3333f"
+checksum = "dac016ca7fb5616d7cc25d57c3b610241020807813ff9a6b6e125d16a35ba128"
 dependencies = [
  "glob",
  "serde",
@@ -6608,7 +6617,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6935,6 +6944,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "winsafe"

--- a/hydro_concurrent_cargo/build.rs
+++ b/hydro_concurrent_cargo/build.rs
@@ -1,0 +1,36 @@
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(new_build_dir_layout)");
+
+    // Detect which build-dir layout the cargo building this crate uses, by
+    // inspecting the shape of our own OUT_DIR:
+    //
+    // - legacy layout: `<target>/debug/build/<pkg>-<16 hex>/out`
+    // - new layout (`-Zbuild-dir-new-layout`, default on current nightly):
+    //   `<build-dir>/debug/build/<pkg>/<16 hex>/out`
+    //
+    // i.e. under the new layout the parent of `out/` is a bare hex hash, while
+    // under the legacy layout it is always `<pkg>-<hash>` (which contains a
+    // `-`). This observes the actual layout rather than a channel/version
+    // proxy, so it stays correct when the new layout reaches stable or when it
+    // is toggled explicitly.
+    //
+    // The runtime cargo invocations coordinated by this crate use the same
+    // toolchain that compiled it (rustup pins the toolchain for the whole
+    // process tree), so a compile-time verdict is sound; switching toolchains
+    // recompiles this crate and re-runs this detection.
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let out_dir = std::path::Path::new(&out_dir);
+    let is_new_layout = out_dir
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .is_some_and(|name| {
+            name.len() == 16
+                && name
+                    .bytes()
+                    .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+        });
+    if is_new_layout {
+        println!("cargo::rustc-cfg=new_build_dir_layout");
+    }
+}

--- a/hydro_concurrent_cargo/src/lib.rs
+++ b/hydro_concurrent_cargo/src/lib.rs
@@ -11,6 +11,37 @@ use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
 use std::time::SystemTime;
 
+/// The filesystem layout cargo uses for intermediate build artifacts.
+///
+/// Detected at compile time by this crate's build script, which inspects the
+/// shape of its own `OUT_DIR` (see `build.rs`). Use [`build_dir_layout`] to
+/// query it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildDirLayout {
+    /// The stable layout: `debug/{.fingerprint,deps,build,...}`, with final
+    /// artifacts uplifted into `debug/` and dependency dylibs in `debug/deps/`.
+    Legacy,
+    /// The layout behind `-Zbuild-dir-new-layout` (default on current nightly):
+    /// all intermediates (fingerprints, rlibs, build script outputs) live under
+    /// `debug/build/<pkg>/<hash>/{fingerprint,out,run}/`, and final artifacts
+    /// — including dependency dylibs — are uplifted into `debug/`.
+    New,
+}
+
+/// The [`BuildDirLayout`] used by the toolchain that compiled this crate.
+///
+/// The runtime cargo invocations coordinated by this crate use the same
+/// toolchain (rustup pins the toolchain for the whole process tree), so the
+/// compile-time verdict matches the layout of the builds we coordinate;
+/// switching toolchains recompiles this crate and re-runs the detection.
+pub fn build_dir_layout() -> BuildDirLayout {
+    if cfg!(new_build_dir_layout) {
+        BuildDirLayout::New
+    } else {
+        BuildDirLayout::Legacy
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Logging
 // ---------------------------------------------------------------------------
@@ -196,6 +227,12 @@ impl PrebuildGuard {
 /// Set up a job directory with symlinked .fingerprint and deps subdirs.
 /// Does NOT set up build/ — use `populate_job_build_dir` for final builds
 /// or manually symlink for prebuild.
+///
+/// The `.fingerprint` and `deps` symlinks are what shares prebuilt state under
+/// the [`BuildDirLayout::Legacy`] layout. Under [`BuildDirLayout::New`] cargo
+/// ignores both directories (everything lives under `build/`), so the symlinks
+/// are harmless; they are created unconditionally because the layout is not
+/// yet known when job dirs are set up (detection happens during the prebuild).
 pub fn setup_job_dir(jobs_dir: &Path, name: &str, shared_debug: &Path) -> PathBuf {
     let job = jobs_dir.join(name);
     let _lock = get_job_dir_lock(&job);
@@ -249,7 +286,9 @@ pub struct JobBuildGuard {
 
 /// Populate the per-job build/ directory from the shared build/ directory.
 /// Returns a guard that holds the job lock — keep alive for the entire final build.
-/// This prevents races from cargo's `link_or_copy` on build script binaries.
+/// This prevents races between processes building the same job concurrently
+/// (and, under the legacy layout, races from cargo's `link_or_copy` on build
+/// script binaries).
 pub fn populate_job_build_dir(job_debug: &Path, shared_debug: &Path) -> JobBuildGuard {
     let shared_build = shared_debug.join("build");
     let job_build = job_debug.join("build");
@@ -269,29 +308,65 @@ pub fn populate_job_build_dir(job_debug: &Path, shared_debug: &Path) -> JobBuild
         .unwrap();
     job_lock_file.lock().unwrap();
 
-    let _ = fs::remove_dir_all(&job_build);
-    fs::create_dir_all(&job_build).unwrap();
-    if shared_build.exists() {
-        for entry in fs::read_dir(&shared_build).unwrap() {
-            let entry = entry.unwrap();
-            if !entry.file_type().unwrap().is_dir() {
-                continue;
-            }
-            let dest = job_build.join(entry.file_name());
-            // Create dir and symlink each child individually so cargo can
-            // safely remove+relink build-script-build without racing other jobs.
-            fs::create_dir_all(&dest).unwrap();
-            for file in fs::read_dir(entry.path()).unwrap() {
-                let file = file.unwrap();
-                let file_dest = dest.join(file.file_name());
+    match build_dir_layout() {
+        BuildDirLayout::New => {
+            // Under the new layout, build/ holds *all* intermediate state
+            // (fingerprints, dependency artifacts, build script outputs), and
+            // cargo no longer re-links build script binaries on fresh builds,
+            // so the whole directory can be shared with a single symlink —
+            // exactly like `symlink_prebuild_build_dir`. Each job only writes
+            // its own unique `build/<pkg>/<hash>/` units for the generated
+            // example, and its uplifted artifacts land in the job-local
+            // `debug/`.
+            fs::create_dir_all(&shared_build).unwrap();
+            let is_correct_symlink =
+                fs::read_link(&job_build).is_ok_and(|target| target == shared_build);
+            if !is_correct_symlink {
+                // The job dir may hold a stale real directory (e.g. populated
+                // by an earlier legacy-layout run) or a stale symlink.
+                if job_build.symlink_metadata().is_ok_and(|m| m.is_symlink()) {
+                    let _ = fs::remove_file(&job_build);
+                } else {
+                    let _ = fs::remove_dir_all(&job_build);
+                }
                 #[cfg(unix)]
-                std::os::unix::fs::symlink(file.path(), &file_dest).unwrap();
+                std::os::unix::fs::symlink(&shared_build, &job_build).unwrap();
                 #[cfg(windows)]
-                {
-                    if file.file_type().unwrap().is_dir() {
-                        std::os::windows::fs::symlink_dir(file.path(), &file_dest).unwrap();
-                    } else {
-                        std::os::windows::fs::symlink_file(file.path(), &file_dest).unwrap();
+                std::os::windows::fs::symlink_dir(&shared_build, &job_build).unwrap();
+            }
+        }
+        BuildDirLayout::Legacy => {
+            // A stale symlink may be left over from an earlier new-layout run.
+            if job_build.symlink_metadata().is_ok_and(|m| m.is_symlink()) {
+                let _ = fs::remove_file(&job_build);
+            } else {
+                let _ = fs::remove_dir_all(&job_build);
+            }
+            fs::create_dir_all(&job_build).unwrap();
+            if shared_build.exists() {
+                for entry in fs::read_dir(&shared_build).unwrap() {
+                    let entry = entry.unwrap();
+                    if !entry.file_type().unwrap().is_dir() {
+                        continue;
+                    }
+                    let dest = job_build.join(entry.file_name());
+                    // Create dir and symlink each child individually so cargo can
+                    // safely remove+relink build-script-build without racing other jobs.
+                    fs::create_dir_all(&dest).unwrap();
+                    for file in fs::read_dir(entry.path()).unwrap() {
+                        let file = file.unwrap();
+                        let file_dest = dest.join(file.file_name());
+                        #[cfg(unix)]
+                        std::os::unix::fs::symlink(file.path(), &file_dest).unwrap();
+                        #[cfg(windows)]
+                        {
+                            if file.file_type().unwrap().is_dir() {
+                                std::os::windows::fs::symlink_dir(file.path(), &file_dest).unwrap();
+                            } else {
+                                std::os::windows::fs::symlink_file(file.path(), &file_dest)
+                                    .unwrap();
+                            }
+                        }
                     }
                 }
             }
@@ -353,6 +428,9 @@ pub fn run_prebuild(
         .max()
         .unwrap_or(SystemTime::UNIX_EPOCH);
 
+    // The stamp's freshness also covers the build-dir layout: layout changes
+    // require a toolchain change, which also changes the mtime of
+    // `current_exe`, which callers include in `staged_paths`.
     let prebuild_is_fresh = |path: &Path, expected_hash: &str| -> bool {
         fs::read_to_string(path)
             .ok()

--- a/hydro_deploy/core/src/rust_crate/build.rs
+++ b/hydro_deploy/core/src/rust_crate/build.rs
@@ -340,7 +340,19 @@ pub async fn build_crate_memoized(params: BuildParams) -> Result<&'static BuildO
                                         bin_data: data,
                                         bin_path: path_buf,
                                         shared_library_path: if params.is_dylib {
-                                            Some(per_job_target_dir.join("debug").join("deps"))
+                                            // Where cargo places the dependency dylib: under the
+                                            // legacy layout debug/deps/ has all variants
+                                            // (including hash-suffixed ones); under the new
+                                            // build-dir layout deps/ no longer exists and the
+                                            // dylib is uplifted into debug/.
+                                            Some(match hydro_concurrent_cargo::build_dir_layout() {
+                                                hydro_concurrent_cargo::BuildDirLayout::Legacy => {
+                                                    per_job_target_dir.join("debug").join("deps")
+                                                }
+                                                hydro_concurrent_cargo::BuildDirLayout::New => {
+                                                    per_job_target_dir.join("debug")
+                                                }
+                                            })
                                         } else {
                                             None
                                         },

--- a/hydro_lang/Cargo.toml
+++ b/hydro_lang/Cargo.toml
@@ -156,10 +156,10 @@ tokio-stream = { version = "0.1.3", default-features = false, features = [
     "time",
 ], optional = true }
 tokio-util = { version = "0.7.5", features = ["codec"], optional = true }
-toml = { version = "0.9", optional = true }
+toml = { version = "1", optional = true }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
-trybuild-internals-api = { version = "=1.0.114", optional = true }
+trybuild-internals-api = { version = "=1.0.120", optional = true }
 
 # Optional dependencies for graph rendering (now behind viz feature)
 auto_impl = { version = "1.2.0", optional = true }

--- a/hydro_lang/src/compile/trybuild/generate.rs
+++ b/hydro_lang/src/compile/trybuild/generate.rs
@@ -11,6 +11,7 @@ use sha2::{Digest, Sha256};
 use stageleft::internal::quote;
 use trybuild_internals_api::cargo::{self, Metadata};
 use trybuild_internals_api::env::Update;
+use trybuild_internals_api::normalize::Normalization;
 use trybuild_internals_api::run::{PathDependency, Project};
 use trybuild_internals_api::{Runner, dependencies, features, path};
 
@@ -546,8 +547,12 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
         };
 
         // The built example links the trybuild dylib dynamically. Bake rpath entries for
-        // where cargo places it (debug/ and debug/deps/) and for the toolchain's shared
-        // libstd, so the artifact can be loaded/run without LD_LIBRARY_PATH.
+        // where cargo places it and for the toolchain's shared libstd, so the artifact can
+        // be loaded/run without LD_LIBRARY_PATH. Cargo uplifts the dylib into debug/ and,
+        // under the legacy build-dir layout, also places it in debug/deps/ (the only
+        // location of hash-suffixed variants); under the new layout (nightly's
+        // `-Zbuild-dir-new-layout`) debug/deps/ no longer exists. Bake both so the same
+        // binary works regardless of layout.
         let mut rpaths = vec![debug_path.clone(), path!(debug_path / "deps")];
         if let Some(libdir) = rustc_target_libdir() {
             rpaths.push(PathBuf::from(libdir));
@@ -836,6 +841,7 @@ pub fn create_trybuild()
                 Some(PathDependency {
                     name: name.clone(),
                     normalized_path: path.canonicalize().ok()?,
+                    normalization: Normalization::PathDependencies,
                 })
             }
         })


### PR DESCRIPTION
Fixes #3148. On nightly, cargo now defaults to the new build-dir layout
(`-Zbuild-dir-new-layout`): `debug/.fingerprint/` and `debug/deps/` no longer
exist — all intermediate state (fingerprints, dependency artifacts, build
script outputs) lives under `debug/build/<pkg>/<hash>/{fingerprint,out,run}/`,
and final artifacts (including dependency dylibs) are uplifted into `debug/`.
This broke the concurrent cargo machinery; fixed while keeping stable behavior
unchanged.