### PR TITLE
fix(hydro_lang)!: require top-level locations for `.atomic()` on live collections

### DIFF
--- a/docs/docs/hydro/learn/quickstart/partitioned-counter.mdx
+++ b/docs/docs/hydro/learn/quickstart/partitioned-counter.mdx
@@ -27,7 +27,7 @@ Before partitioning the counter, you need to make the `keyed_counter_service` fu
 <CodeBlock language="rust" title={
   <Link href="https://github.com/hydro-project/hydro/tree/main/hydro_test/src/tutorials/keyed_counter.rs">src/keyed_counter.rs</Link>
 } showLineNumbers={7}>{getLines(keyedCounterSrc, 7, 13, `
-pub fn keyed_counter_service<'a, L: Location<'a>>(
+pub fn keyed_counter_service<'a, L: TopLevel<'a>>(
     increment_requests: KeyedStream<u32, String, L, Unbounded>,
     get_requests: KeyedStream<u32, String, L, Unbounded>,
 ) -> (

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -28,7 +28,7 @@ use crate::live_collections::stream::{Ordering, Retries};
 #[cfg(stageleft_runtime)]
 use crate::location::dynamic::{DynLocation, LocationId};
 use crate::location::tick::DeferTick;
-use crate::location::{Atomic, Location, Tick, check_matching_location};
+use crate::location::{Atomic, Location, Tick, TopLevel, check_matching_location};
 use crate::manual_expr::ManualExpr;
 use crate::nondet::{NonDet, nondet};
 use crate::properties::manual_proof;
@@ -1656,7 +1656,10 @@ where
     ///
     /// This is useful to enforce local consistency constraints, such as ensuring that a write is
     /// processed before an acknowledgement is emitted.
-    pub fn atomic(self) -> KeyedSingleton<K, V, Atomic<L>, B> {
+    pub fn atomic(self) -> KeyedSingleton<K, V, Atomic<L>, B>
+    where
+        L: TopLevel<'a>,
+    {
         let id = self.location.flow_state().borrow_mut().next_clock_id();
         let out_location = Atomic {
             tick: Tick {

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -1660,12 +1660,8 @@ where
     where
         L: TopLevel<'a>,
     {
-        let id = self.location.flow_state().borrow_mut().next_clock_id();
         let out_location = Atomic {
-            tick: Tick {
-                id,
-                l: self.location.clone(),
-            },
+            tick: self.location.tick(),
         };
         KeyedSingleton::new(
             out_location.clone(),

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -31,7 +31,7 @@ use crate::live_collections::stream::{
 #[cfg(stageleft_runtime)]
 use crate::location::dynamic::{DynLocation, LocationId};
 use crate::location::tick::DeferTick;
-use crate::location::{Atomic, Location, Tick, check_matching_location};
+use crate::location::{Atomic, Location, Tick, TopLevel, check_matching_location};
 use crate::manual_expr::ManualExpr;
 use crate::nondet::{NonDet, nondet};
 use crate::properties::{
@@ -2666,7 +2666,10 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     ///
     /// This is useful to enforce local consistency constraints, such as ensuring that a write is
     /// processed before an acknowledgement is emitted.
-    pub fn atomic(self) -> KeyedStream<K, V, Atomic<L>, B, O, R> {
+    pub fn atomic(self) -> KeyedStream<K, V, Atomic<L>, B, O, R>
+    where
+        L: TopLevel<'a>,
+    {
         let id = self.location.flow_state().borrow_mut().next_clock_id();
         let out_location = Atomic {
             tick: Tick {

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2670,12 +2670,8 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
     where
         L: TopLevel<'a>,
     {
-        let id = self.location.flow_state().borrow_mut().next_clock_id();
         let out_location = Atomic {
-            tick: Tick {
-                id,
-                l: self.location.clone(),
-            },
+            tick: self.location.tick(),
         };
         KeyedStream::new(
             out_location.clone(),

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -2128,12 +2128,8 @@ where
     where
         L: TopLevel<'a>,
     {
-        let id = self.location.flow_state().borrow_mut().next_clock_id();
         let out_location = Atomic {
-            tick: Tick {
-                id,
-                l: self.location.clone(),
-            },
+            tick: self.location.tick(),
         };
         Stream::new(
             out_location.clone(),

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -2124,7 +2124,10 @@ where
     ///
     /// This is useful to enforce local consistency constraints, such as ensuring that a write is
     /// processed before an acknowledgement is emitted.
-    pub fn atomic(self) -> Stream<T, Atomic<L>, B, O, R> {
+    pub fn atomic(self) -> Stream<T, Atomic<L>, B, O, R>
+    where
+        L: TopLevel<'a>,
+    {
         let id = self.location.flow_state().borrow_mut().next_clock_id();
         let out_location = Atomic {
             tick: Tick {

--- a/hydro_lang/tests/compile-fail/atomic_on_atomic_location.rs
+++ b/hydro_lang/tests/compile-fail/atomic_on_atomic_location.rs
@@ -1,0 +1,13 @@
+#![allow(unexpected_cfgs)]
+
+use hydro_lang::prelude::*;
+
+struct P1 {}
+
+fn test<'a>(p1: &Process<'a, P1>) {
+    // `.atomic()` on an already-atomic stream would create a redundant
+    // `Atomic<Atomic<Process>>` location.
+    let _ = p1.source_iter(q!(0..10)).atomic().atomic();
+}
+
+fn main() {}

--- a/hydro_lang/tests/compile-fail/atomic_on_tick_location.rs
+++ b/hydro_lang/tests/compile-fail/atomic_on_tick_location.rs
@@ -1,0 +1,18 @@
+#![allow(unexpected_cfgs)]
+
+use hydro_lang::prelude::*;
+
+struct P1 {}
+
+fn test<'a>(p1: &Process<'a, P1>) {
+    let tick = p1.tick();
+    let batched = p1
+        .source_iter(q!(0..10))
+        .batch(&tick, nondet!(/** test */));
+
+    // `.atomic()` on a tick-located stream would create an invalid nested
+    // `Tick<Tick<Process>>` location.
+    let _ = batched.atomic();
+}
+
+fn main() {}

--- a/hydro_lang/tests/compile-fail/nightly/atomic_on_atomic_location.stderr
+++ b/hydro_lang/tests/compile-fail/nightly/atomic_on_atomic_location.stderr
@@ -1,0 +1,24 @@
+error[E0277]: the trait bound `hydro_lang::location::Atomic<hydro_lang::prelude::Process<'a, P1>>: TopLevel<'_>` is not satisfied
+  --> tests/compile-fail/nightly/atomic_on_atomic_location.rs:10:48
+   |
+10 |     let _ = p1.source_iter(q!(0..10)).atomic().atomic();
+   |                                                ^^^^^^ the trait `TopLevel<'_>` is not implemented for `hydro_lang::location::Atomic<hydro_lang::prelude::Process<'a, P1>>`
+   |
+help: the following other types implement trait `TopLevel<'a>`
+  --> src/location/process.rs
+   |
+   | impl<'a, P> TopLevel<'a> for Process<'a, P> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `hydro_lang::prelude::Process<'a, P>`
+   |
+  ::: src/location/cluster.rs
+   |
+   | impl<'a, C, Con: Consistency> TopLevel<'a> for Cluster<'a, C, Con> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `hydro_lang::prelude::Cluster<'a, C, Con>`
+note: required by a bound in `hydro_lang::prelude::Stream::<T, L, B, O, R>::atomic`
+  --> src/live_collections/stream/mod.rs
+   |
+   |     pub fn atomic(self) -> Stream<T, Atomic<L>, B, O, R>
+   |            ------ required by a bound in this associated function
+   |     where
+   |         L: TopLevel<'a>,
+   |            ^^^^^^^^^^^^ required by this bound in `Stream::<T, L, B, O, R>::atomic`

--- a/hydro_lang/tests/compile-fail/nightly/atomic_on_tick_location.stderr
+++ b/hydro_lang/tests/compile-fail/nightly/atomic_on_tick_location.stderr
@@ -1,0 +1,24 @@
+error[E0277]: the trait bound `hydro_lang::prelude::Tick<hydro_lang::prelude::Process<'a, P1>>: TopLevel<'_>` is not satisfied
+  --> tests/compile-fail/nightly/atomic_on_tick_location.rs:15:21
+   |
+15 |     let _ = batched.atomic();
+   |                     ^^^^^^ the trait `TopLevel<'_>` is not implemented for `hydro_lang::prelude::Tick<hydro_lang::prelude::Process<'a, P1>>`
+   |
+help: the following other types implement trait `TopLevel<'a>`
+  --> src/location/process.rs
+   |
+   | impl<'a, P> TopLevel<'a> for Process<'a, P> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `hydro_lang::prelude::Process<'a, P>`
+   |
+  ::: src/location/cluster.rs
+   |
+   | impl<'a, C, Con: Consistency> TopLevel<'a> for Cluster<'a, C, Con> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `hydro_lang::prelude::Cluster<'a, C, Con>`
+note: required by a bound in `hydro_lang::prelude::Stream::<T, L, B, O, R>::atomic`
+  --> src/live_collections/stream/mod.rs
+   |
+   |     pub fn atomic(self) -> Stream<T, Atomic<L>, B, O, R>
+   |            ------ required by a bound in this associated function
+   |     where
+   |         L: TopLevel<'a>,
+   |            ^^^^^^^^^^^^ required by this bound in `Stream::<T, L, B, O, R>::atomic`

--- a/hydro_lang/tests/compile-fail/nightly/singleton_by_mut_unbounded_for_each.stderr
+++ b/hydro_lang/tests/compile-fail/nightly/singleton_by_mut_unbounded_for_each.stderr
@@ -1,0 +1,41 @@
+error[E0308]: mismatched types
+  --> tests/compile-fail/nightly/singleton_by_mut_unbounded_for_each.rs:18:24
+   |
+18 |       unbounded.for_each(q!(|x| {
+   |  ________________________^
+19 | |         *count_mut += x;
+20 | |     }));
+   | |      ^
+   | |      |
+   | |______expected `hydro_lang::prelude::Bounded`, found `hydro_lang::prelude::Unbounded`
+   |        arguments to this function are incorrect
+   |
+   = note: expected reference `&OperatorContext<Process<'a, P1>, hydro_lang::prelude::Bounded>`
+              found reference `&OperatorContext<Process<'a, P1>, hydro_lang::prelude::Unbounded>`
+note: method defined here
+  --> $CARGO/stageleft-$VERSION/src/runtime_support.rs
+   |
+   |     fn uninitialized(
+   |        ^^^^^^^^^^^^^
+   = note: this error originates in the macro `q` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/compile-fail/nightly/singleton_by_mut_unbounded_for_each.rs:18:24
+   |
+18 |       unbounded.for_each(q!(|x| {
+   |  ________________________^
+19 | |         *count_mut += x;
+20 | |     }));
+   | |      ^
+   | |      |
+   | |______expected `hydro_lang::prelude::Bounded`, found `hydro_lang::prelude::Unbounded`
+   |        arguments to this function are incorrect
+   |
+   = note: expected reference `&OperatorContext<Process<'a, P1>, hydro_lang::prelude::Bounded>`
+              found reference `&OperatorContext<Process<'a, P1>, hydro_lang::prelude::Unbounded>`
+note: method defined here
+  --> $CARGO/stageleft-$VERSION/src/runtime_support.rs
+   |
+   |     fn to_tokens(self, ctx: &Ctx) -> QuoteTokens
+   |        ^^^^^^^^^
+   = note: this error originates in the macro `q` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/hydro_lang/tests/compile-fail/nightly/singleton_by_ref_unbounded_filter.stderr
+++ b/hydro_lang/tests/compile-fail/nightly/singleton_by_ref_unbounded_filter.stderr
@@ -1,0 +1,35 @@
+error[E0308]: mismatched types
+  --> tests/compile-fail/nightly/singleton_by_ref_unbounded_filter.rs:18:30
+   |
+18 |     let _ = unbounded.filter(q!(|&x| x > *threshold_ref));
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              |
+   |                              expected `hydro_lang::prelude::Bounded`, found `hydro_lang::prelude::Unbounded`
+   |                              arguments to this function are incorrect
+   |
+   = note: expected reference `&OperatorContext<Process<'a, P1>, hydro_lang::prelude::Bounded>`
+              found reference `&OperatorContext<Process<'a, P1>, hydro_lang::prelude::Unbounded>`
+note: method defined here
+  --> $CARGO/stageleft-$VERSION/src/runtime_support.rs
+   |
+   |     fn uninitialized(
+   |        ^^^^^^^^^^^^^
+   = note: this error originates in the macro `q` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/compile-fail/nightly/singleton_by_ref_unbounded_filter.rs:18:30
+   |
+18 |     let _ = unbounded.filter(q!(|&x| x > *threshold_ref));
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              |
+   |                              expected `hydro_lang::prelude::Bounded`, found `hydro_lang::prelude::Unbounded`
+   |                              arguments to this function are incorrect
+   |
+   = note: expected reference `&OperatorContext<Process<'a, P1>, hydro_lang::prelude::Bounded>`
+              found reference `&OperatorContext<Process<'a, P1>, hydro_lang::prelude::Unbounded>`
+note: method defined here
+  --> $CARGO/stageleft-$VERSION/src/runtime_support.rs
+   |
+   |     fn to_tokens(self, ctx: &Ctx) -> QuoteTokens
+   |        ^^^^^^^^^
+   = note: this error originates in the macro `q` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/hydro_lang/tests/compile-fail/nightly/singleton_by_ref_unbounded_map.stderr
+++ b/hydro_lang/tests/compile-fail/nightly/singleton_by_ref_unbounded_map.stderr
@@ -1,0 +1,35 @@
+error[E0308]: mismatched types
+  --> tests/compile-fail/nightly/singleton_by_ref_unbounded_map.rs:18:27
+   |
+18 |     let _ = unbounded.map(q!(|x| x + *count_ref));
+   |                           ^^^^^^^^^^^^^^^^^^^^^^
+   |                           |
+   |                           expected `hydro_lang::prelude::Bounded`, found `hydro_lang::prelude::Unbounded`
+   |                           arguments to this function are incorrect
+   |
+   = note: expected reference `&OperatorContext<Process<'a, P1>, hydro_lang::prelude::Bounded>`
+              found reference `&OperatorContext<Process<'a, P1>, hydro_lang::prelude::Unbounded>`
+note: method defined here
+  --> $CARGO/stageleft-$VERSION/src/runtime_support.rs
+   |
+   |     fn uninitialized(
+   |        ^^^^^^^^^^^^^
+   = note: this error originates in the macro `q` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/compile-fail/nightly/singleton_by_ref_unbounded_map.rs:18:27
+   |
+18 |     let _ = unbounded.map(q!(|x| x + *count_ref));
+   |                           ^^^^^^^^^^^^^^^^^^^^^^
+   |                           |
+   |                           expected `hydro_lang::prelude::Bounded`, found `hydro_lang::prelude::Unbounded`
+   |                           arguments to this function are incorrect
+   |
+   = note: expected reference `&OperatorContext<Process<'a, P1>, hydro_lang::prelude::Bounded>`
+              found reference `&OperatorContext<Process<'a, P1>, hydro_lang::prelude::Unbounded>`
+note: method defined here
+  --> $CARGO/stageleft-$VERSION/src/runtime_support.rs
+   |
+   |     fn to_tokens(self, ctx: &Ctx) -> QuoteTokens
+   |        ^^^^^^^^^
+   = note: this error originates in the macro `q` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/hydro_lang/tests/compile-fail/nightly/sliced_missing_arg.stderr
+++ b/hydro_lang/tests/compile-fail/nightly/sliced_missing_arg.stderr
@@ -10,6 +10,31 @@ error[E0425]: cannot find value `fake` in this scope
 14 |         let f = use::atomic(fake, nondet!(/** test */));
    |                             ^^^^ not found in this scope
 
+warning: use of deprecated function `hydro_lang::live_collections::sliced::style::default`: use `use::batch(...)` for stream-like collections or `use::snapshot(...)` for singleton-like collections instead
+ --> tests/compile-fail/nightly/sliced_missing_arg.rs:9:21
+  |
+9 |         let a = use(input);
+  |                     ^^^^^
+  |
+  = note: `#[warn(deprecated)]` on by default
+  = note: this warning originates in the macro `$crate::__sliced_parse_uses__` which comes from the expansion of the macro `sliced` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: use of deprecated function `hydro_lang::live_collections::sliced::style::default`: use `use::batch(...)` for stream-like collections or `use::snapshot(...)` for singleton-like collections instead
+  --> tests/compile-fail/nightly/sliced_missing_arg.rs:11:21
+   |
+11 |         let c = use(input, 123);
+   |                     ^^^^^^^^^^
+   |
+   = note: this warning originates in the macro `$crate::__sliced_parse_uses__` which comes from the expansion of the macro `sliced` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: use of deprecated function `hydro_lang::live_collections::sliced::style::default`: use `use::batch(...)` for stream-like collections or `use::snapshot(...)` for singleton-like collections instead
+  --> tests/compile-fail/nightly/sliced_missing_arg.rs:13:21
+   |
+13 |         let e = use(fake, nondet!(/** test */));
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this warning originates in the macro `$crate::__sliced_parse_uses__` which comes from the expansion of the macro `sliced` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> tests/compile-fail/nightly/sliced_missing_arg.rs:9:21
    |

--- a/hydro_lang/tests/compile-fail/nightly/stream_by_ref_unbounded.stderr
+++ b/hydro_lang/tests/compile-fail/nightly/stream_by_ref_unbounded.stderr
@@ -9,7 +9,7 @@ error[E0277]: The input collection must be bounded (`Bounded`), but has bound `h
 note: required by a bound in `hydro_lang::prelude::Stream::<T, L, B, O, R>::by_ref`
  --> src/live_collections/stream/mod.rs
   |
-  |     pub fn by_ref(&self) -> crate::handoff_ref::StreamRef<'a, '_, T, L>
+  |     pub fn by_ref(&self) -> crate::handoff_ref::StreamRef<'a, '_, T, L, B>
   |            ------ required by a bound in this associated function
   |     where
   |         B: IsBounded,

--- a/hydro_lang/tests/compile-fail/stable/atomic_on_atomic_location.stderr
+++ b/hydro_lang/tests/compile-fail/stable/atomic_on_atomic_location.stderr
@@ -1,0 +1,24 @@
+error[E0277]: the trait bound `hydro_lang::location::Atomic<hydro_lang::prelude::Process<'a, P1>>: TopLevel<'_>` is not satisfied
+  --> tests/compile-fail/stable/atomic_on_atomic_location.rs:10:48
+   |
+10 |     let _ = p1.source_iter(q!(0..10)).atomic().atomic();
+   |                                                ^^^^^^ the trait `TopLevel<'_>` is not implemented for `hydro_lang::location::Atomic<hydro_lang::prelude::Process<'a, P1>>`
+   |
+help: the following other types implement trait `TopLevel<'a>`
+  --> src/location/process.rs
+   |
+   | impl<'a, P> TopLevel<'a> for Process<'a, P> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `hydro_lang::prelude::Process<'a, P>`
+   |
+  ::: src/location/cluster.rs
+   |
+   | impl<'a, C, Con: Consistency> TopLevel<'a> for Cluster<'a, C, Con> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `hydro_lang::prelude::Cluster<'a, C, Con>`
+note: required by a bound in `hydro_lang::prelude::Stream::<T, L, B, O, R>::atomic`
+  --> src/live_collections/stream/mod.rs
+   |
+   |     pub fn atomic(self) -> Stream<T, Atomic<L>, B, O, R>
+   |            ------ required by a bound in this associated function
+   |     where
+   |         L: TopLevel<'a>,
+   |            ^^^^^^^^^^^^ required by this bound in `Stream::<T, L, B, O, R>::atomic`

--- a/hydro_lang/tests/compile-fail/stable/atomic_on_tick_location.stderr
+++ b/hydro_lang/tests/compile-fail/stable/atomic_on_tick_location.stderr
@@ -1,0 +1,24 @@
+error[E0277]: the trait bound `hydro_lang::prelude::Tick<hydro_lang::prelude::Process<'a, P1>>: TopLevel<'_>` is not satisfied
+  --> tests/compile-fail/stable/atomic_on_tick_location.rs:15:21
+   |
+15 |     let _ = batched.atomic();
+   |                     ^^^^^^ the trait `TopLevel<'_>` is not implemented for `hydro_lang::prelude::Tick<hydro_lang::prelude::Process<'a, P1>>`
+   |
+help: the following other types implement trait `TopLevel<'a>`
+  --> src/location/process.rs
+   |
+   | impl<'a, P> TopLevel<'a> for Process<'a, P> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `hydro_lang::prelude::Process<'a, P>`
+   |
+  ::: src/location/cluster.rs
+   |
+   | impl<'a, C, Con: Consistency> TopLevel<'a> for Cluster<'a, C, Con> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `hydro_lang::prelude::Cluster<'a, C, Con>`
+note: required by a bound in `hydro_lang::prelude::Stream::<T, L, B, O, R>::atomic`
+  --> src/live_collections/stream/mod.rs
+   |
+   |     pub fn atomic(self) -> Stream<T, Atomic<L>, B, O, R>
+   |            ------ required by a bound in this associated function
+   |     where
+   |         L: TopLevel<'a>,
+   |            ^^^^^^^^^^^^ required by this bound in `Stream::<T, L, B, O, R>::atomic`

--- a/hydro_test/src/tutorials/keyed_counter.rs
+++ b/hydro_test/src/tutorials/keyed_counter.rs
@@ -1,10 +1,10 @@
 use hydro_lang::live_collections::stream::NoOrder;
-use hydro_lang::location::Location;
+use hydro_lang::location::TopLevel;
 use hydro_lang::prelude::*;
 
 pub struct CounterServer;
 
-pub fn keyed_counter_service<'a, L: Location<'a>>(
+pub fn keyed_counter_service<'a, L: TopLevel<'a>>(
     increment_requests: KeyedStream<u32, String, L, Unbounded>,
     get_requests: KeyedStream<u32, String, L, Unbounded>,
 ) -> (

--- a/template/hydro/.prompts/challenge-keyed-counter.md
+++ b/template/hydro/.prompts/challenge-keyed-counter.md
@@ -34,12 +34,12 @@ You are helping the developer build a keyed counter service where a single serve
 
 ```rust
 use hydro_lang::live_collections::stream::NoOrder;
-use hydro_lang::location::Location;
+use hydro_lang::location::TopLevel;
 use hydro_lang::prelude::*;
 
 pub struct CounterServer;
 
-pub fn keyed_counter_service<'a, L: Location<'a>>(
+pub fn keyed_counter_service<'a, L: TopLevel<'a>>(
     increment_requests: KeyedStream<u32, String, L, Unbounded>,
     get_requests: KeyedStream<u32, String, L, Unbounded>,
 ) -> (


### PR DESCRIPTION
Previously, `Stream::atomic`, `KeyedStream::atomic`, and `KeyedSingleton::atomic`
were available for any `L: Location<'a>`, allowing them to be called on
collections already located in a `Tick` or `Atomic` context. This could
construct invalid locations:

- `.atomic()` on a `Tick<L>`-located collection minted a fresh clock wrapping
  the existing tick, producing `Atomic<Tick<L>>` — i.e. an invalid directly
  nested `Tick(Tick(..))` location.
- `.atomic()` on an `Atomic<L>`-located collection produced a redundant
  `Atomic<Atomic<L>>`.

The sim backend caught both cases only at flow-compile time, with internal
compiler panics (`assertion failed: in_location.is_top_level()` in
`begin_atomic`, and `todo!("atomic yield to a different tick is not yet
supported")` in `yield_from_tick`). The deploy backend was worse: it silently
compiled such programs, erasing the atomic boundary entirely (begin/end atomic
are identity ops in DFIR codegen, and the fresh clock ID was never unified
with the surrounding tick by `unify_atomic_ticks`), so the atomicity guarantee
was silently dropped.

Fix: add a `L: TopLevel<'a>` bound to all three `.atomic()` methods, making
both invalid constructions compile errors. Intentionally valid nestings like
`Tick(Atomic(Tick(L)))` remain constructible through their intended paths
(`all_ticks_atomic`, `latest_atomic`, ticks created on atomic locations),
which reuse the existing clock rather than minting a nested one.

Also:
- Tighten `keyed_counter_service` in `hydro_test/src/tutorials/keyed_counter.rs`
  from `L: Location<'a>` to `L: TopLevel<'a>`, since it calls `.atomic()` on
  its generic location.
- Add two trybuild compile-fail tests (`atomic_on_tick_location.rs`,
  `atomic_on_atomic_location.rs`) with stable and nightly stderr snapshots.

Verified: full workspace `cargo check --all-targets` passes, existing
atomic/sliced sim tests and the keyed_counter tutorial tests pass, and the
compile-fail suite passes on both stable and nightly.

BREAKING CHANGE: `Stream::atomic`, `KeyedStream::atomic`, and
`KeyedSingleton::atomic` now require the collection's location to implement
`TopLevel` (i.e. `Process` or `Cluster`). Code generic over `L: Location<'a>`
that calls `.atomic()` must tighten its bound to `L: TopLevel<'a>`; calls on
`Tick`- or `Atomic`-located collections (previously invalid or redundant, and
miscompiled by the deploy backend) no longer compile.