### PR TITLE
fix(hydro_lang): assert tick `parent_location()` matches in atomic batch/snapshot methods

### DIFF
--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -1778,7 +1778,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded> {
-        assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(&self.location)
+        );
         KeyedSingleton::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -1806,8 +1809,8 @@ where
         _nondet: NonDet,
     ) -> KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded> {
         assert_eq!(
-            Location::id(tick.outer()),
-            Location::id(self.location.tick.outer())
+            Location::id(tick.parent_location()),
+            Location::id(self.location.tick.parent_location())
         );
         KeyedSingleton::new(
             tick.drop_consistency(),
@@ -1970,7 +1973,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded> {
-        assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(&self.location)
+        );
         KeyedSingleton::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -2002,8 +2008,8 @@ where
     ) -> KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded> {
         let _ = nondet;
         assert_eq!(
-            Location::id(tick.outer()),
-            Location::id(self.location.tick.outer())
+            Location::id(tick.parent_location()),
+            Location::id(self.location.tick.parent_location())
         );
         KeyedSingleton::new(
             tick.drop_consistency(),

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -1805,6 +1805,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded> {
+        assert_eq!(
+            Location::id(tick.outer()),
+            Location::id(self.location.tick.outer())
+        );
         KeyedSingleton::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -1997,6 +2001,10 @@ where
         nondet: NonDet,
     ) -> KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded> {
         let _ = nondet;
+        assert_eq!(
+            Location::id(tick.outer()),
+            Location::id(self.location.tick.outer())
+        );
         KeyedSingleton::new(
             tick.drop_consistency(),
             HydroNode::Batch {

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2897,6 +2897,10 @@ where
         nondet: NonDet,
     ) -> KeyedStream<K, V, Tick<L::DropConsistency>, Bounded, O, R> {
         let _ = nondet;
+        assert_eq!(
+            Location::id(tick.outer()),
+            Location::id(self.location.tick.outer())
+        );
         KeyedStream::new(
             tick.drop_consistency(),
             HydroNode::Batch {

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2173,7 +2173,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         Idemp: ValidIdempotenceFor<R>,
     {
         let other: Optional<O2, Tick<L::Root>, Bounded> = other.into();
-        check_matching_location(&self.location.root(), other.location.outer());
+        check_matching_location(&self.location.root(), other.location.parent_location());
         let (f, proof) =
             comb.splice_fn2_borrow_mut_ctx_props(&OperatorContext::<L, B>::new(&self.location));
         proof.register_proof(&f);
@@ -2696,7 +2696,10 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         nondet: NonDet,
     ) -> KeyedStream<K, V, Tick<L::DropConsistency>, Bounded, O, R> {
         let _ = nondet;
-        assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(&self.location)
+        );
         KeyedStream::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -2898,8 +2901,8 @@ where
     ) -> KeyedStream<K, V, Tick<L::DropConsistency>, Bounded, O, R> {
         let _ = nondet;
         assert_eq!(
-            Location::id(tick.outer()),
-            Location::id(self.location.tick.outer())
+            Location::id(tick.parent_location()),
+            Location::id(self.location.tick.parent_location())
         );
         KeyedStream::new(
             tick.drop_consistency(),
@@ -2938,18 +2941,13 @@ where
     /// each key.
     pub fn all_ticks(self) -> KeyedStream<K, V, L, Unbounded, O, R> {
         KeyedStream::new(
-            self.location.outer().clone(),
+            self.location.parent_location().clone(),
             HydroNode::YieldConcat {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                metadata: self.location.outer().new_node_metadata(KeyedStream::<
-                    K,
-                    V,
-                    L,
-                    Unbounded,
-                    O,
-                    R,
-                >::collection_kind(
-                )),
+                metadata: self
+                    .location
+                    .parent_location()
+                    .new_node_metadata(KeyedStream::<K, V, L, Unbounded, O, R>::collection_kind()),
             },
         )
     }

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -1422,6 +1422,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> Optional<T, Tick<L::DropConsistency>, Bounded> {
+        assert_eq!(
+            Location::id(tick.outer()),
+            Location::id(self.location.tick.outer())
+        );
         Optional::new(
             tick.drop_consistency(),
             HydroNode::Batch {

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -1423,8 +1423,8 @@ where
         _nondet: NonDet,
     ) -> Optional<T, Tick<L::DropConsistency>, Bounded> {
         assert_eq!(
-            Location::id(tick.outer()),
-            Location::id(self.location.tick.outer())
+            Location::id(tick.parent_location()),
+            Location::id(self.location.tick.parent_location())
         );
         Optional::new(
             tick.drop_consistency(),
@@ -1454,7 +1454,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> Optional<T, Tick<L::DropConsistency>, Bounded> {
-        assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(&self.location)
+        );
         Optional::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -1602,12 +1605,12 @@ where
     /// ```
     pub fn latest(self) -> Optional<T, L, Unbounded> {
         Optional::new(
-            self.location.outer().clone(),
+            self.location.parent_location().clone(),
             HydroNode::YieldConcat {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
-                    .outer()
+                    .parent_location()
                     .new_node_metadata(Optional::<T, L, Unbounded>::collection_kind()),
             },
         )

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -1228,8 +1228,8 @@ where
         _nondet: NonDet,
     ) -> Singleton<T, Tick<L::DropConsistency>, Bounded> {
         assert_eq!(
-            Location::id(tick.outer()),
-            Location::id(self.location.tick.outer())
+            Location::id(tick.parent_location()),
+            Location::id(self.location.tick.parent_location())
         );
         Singleton::new(
             tick.drop_consistency(),
@@ -1259,7 +1259,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> Singleton<T, Tick<L::DropConsistency>, Bounded> {
-        assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(&self.location)
+        );
         Singleton::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -1541,12 +1544,12 @@ where
     /// ```
     pub fn latest(self) -> Optional<T, L, InitNone> {
         Optional::new(
-            self.location.outer().clone(),
+            self.location.parent_location().clone(),
             HydroNode::YieldConcat {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
-                    .outer()
+                    .parent_location()
                     .new_node_metadata(Optional::<T, L, InitNone>::collection_kind()),
             },
         )

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -1227,6 +1227,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> Singleton<T, Tick<L::DropConsistency>, Bounded> {
+        assert_eq!(
+            Location::id(tick.outer()),
+            Location::id(self.location.tick.outer())
+        );
         Singleton::new(
             tick.drop_consistency(),
             HydroNode::Batch {

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -3110,6 +3110,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> Stream<T, Tick<L::DropConsistency>, Bounded, O, R> {
+        assert_eq!(
+            Location::id(tick.outer()),
+            Location::id(self.location.tick.outer())
+        );
         Stream::new(
             tick.drop_consistency(),
             HydroNode::Batch {

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -2156,7 +2156,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> Stream<T, Tick<L::DropConsistency>, Bounded, O, R> {
-        assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(&self.location)
+        );
         Stream::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -3111,8 +3114,8 @@ where
         _nondet: NonDet,
     ) -> Stream<T, Tick<L::DropConsistency>, Bounded, O, R> {
         assert_eq!(
-            Location::id(tick.outer()),
-            Location::id(self.location.tick.outer())
+            Location::id(tick.parent_location()),
+            Location::id(self.location.tick.parent_location())
         );
         Stream::new(
             tick.drop_consistency(),
@@ -3239,13 +3242,17 @@ where
     /// which will stream all the elements across _all_ tick iterations by concatenating the batches.
     pub fn all_ticks(self) -> Stream<T, L, Unbounded, O, R> {
         Stream::new(
-            self.location.outer().clone(),
+            self.location.parent_location().clone(),
             HydroNode::YieldConcat {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                metadata: self
-                    .location
-                    .outer()
-                    .new_node_metadata(Stream::<T, L, Unbounded, O, R>::collection_kind()),
+                metadata: self.location.parent_location().new_node_metadata(Stream::<
+                    T,
+                    L,
+                    Unbounded,
+                    O,
+                    R,
+                >::collection_kind(
+                )),
             },
         )
     }

--- a/hydro_lang/src/location/tick.rs
+++ b/hydro_lang/src/location/tick.rs
@@ -176,12 +176,18 @@ impl<'a, L> Tick<L>
 where
     L: Location<'a>,
 {
-    /// Returns a reference to the outer (parent) location that this tick is nested within.
+    /// Returns a reference to the parent location that this tick is located at.
     ///
     /// For example, if a `Tick` was created from a `Process`, this returns a reference
     /// to that `Process`.
-    pub fn outer(&self) -> &L {
+    pub fn parent_location(&self) -> &L {
         &self.l
+    }
+
+    /// Use [`Self::parent_location`] instead.
+    #[deprecated(note = "use `.parent_location()` instead")]
+    pub fn outer(&self) -> &L {
+        self.parent_location()
     }
 
     /// Creates a bounded stream of `()` values inside this tick, with a fixed batch size.


### PR DESCRIPTION
Also renames `Tick::outer()` to `parent_location()`, making the original a deprecated alias for the new method.

The `*_atomic` batch/snapshot methods accepted any tick without validating
that it lives on the same location as the atomic section, unlike their
non-atomic counterparts (`Stream::batch`, `Singleton::snapshot`, etc.) which
assert location equality. A mismatched tick (e.g. one created on a different
process) would only be caught later, if at all, by downstream clock
unification.

Add the analogous assertion to all six atomic variants:

- `Stream::batch_atomic`
- `KeyedStream::batch_atomic`
- `Singleton::snapshot_atomic`
- `Optional::snapshot_atomic`
- `KeyedSingleton::snapshot_atomic`
- `KeyedSingleton::batch_atomic`

Each now asserts that `Location::id(tick.outer())` equals
`Location::id(self.location.tick.outer())`, i.e. the passed tick must live on
the atomic's underlying location. This cannot be expressed in the type system
since the `L2: Location<'a, DropConsistency = L::DropConsistency>` bound only
pins the location *type*, not the instance.

The assertion deliberately does not require the tick to be the atomic's own
tick: independently created ticks on the same location are a supported
pattern (their clocks are unified with the atomic's clock by
`unify_atomic_ticks`), as used by `hydro_std::request_response`.

Verified: full workspace `cargo check --all-targets` passes; hydro_lang
atomic/sliced sim tests, hydro_std request_response tests, and hydro_test
tutorial tests all pass.