### PR TITLE
refactor(hydro_lang): Make `LocationId::Tick` tick `ClockId` optional, fix #3144

### DIFF
--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -1923,7 +1923,19 @@ impl HydroRoot {
 #[cfg(feature = "build")]
 fn tick_of(loc: &LocationId) -> Option<ClockId> {
     match loc {
-        LocationId::Tick(id, _) => Some(*id),
+        // Regular tick.
+        &LocationId::Tick {
+            tick: Some(tick),
+            parent_location: _,
+        } => Some(tick),
+        // Tick around atomic.
+        LocationId::Tick {
+            tick: None,
+            parent_location,
+        } => Some(
+            tick_of(parent_location)
+                .expect("Tick should have either own clock ID or clock ID within parent_location."),
+        ),
         LocationId::Atomic(inner) => tick_of(inner),
         _ => None,
     }
@@ -1932,9 +1944,14 @@ fn tick_of(loc: &LocationId) -> Option<ClockId> {
 #[cfg(feature = "build")]
 fn remap_location(loc: &mut LocationId, uf: &mut HashMap<ClockId, ClockId>) {
     match loc {
-        LocationId::Tick(id, inner) => {
-            *id = uf_find(uf, *id);
-            remap_location(inner, uf);
+        LocationId::Tick {
+            tick,
+            parent_location,
+        } => {
+            if let Some(tick) = tick {
+                *tick = uf_find(uf, *tick);
+            }
+            remap_location(parent_location, uf);
         }
         LocationId::Atomic(inner) => {
             remap_location(inner, uf);
@@ -6127,8 +6144,8 @@ where
                 D::m2m_connect(&from_node, &sink_port, &to_node, &source_port),
             )
         }
-        (LocationId::Tick(_, _), _) => panic!(),
-        (_, LocationId::Tick(_, _)) => panic!(),
+        (LocationId::Tick { .. }, _) => panic!(),
+        (_, LocationId::Tick { .. }) => panic!(),
         (LocationId::Atomic(_), _) => panic!(),
         (_, LocationId::Atomic(_)) => panic!(),
     };

--- a/hydro_lang/src/location/dynamic.rs
+++ b/hydro_lang/src/location/dynamic.rs
@@ -37,7 +37,12 @@ pub enum LocationId {
         Box<LocationId>,
     ),
     /// A tick within a location.
-    Tick(ClockId, Box<LocationId>),
+    Tick {
+        /// The `ClockId` of this tick, or `None` if `parent_location` is an `Atomic`
+        tick: Option<ClockId>,
+        /// What location this tick is within.
+        parent_location: Box<LocationId>,
+    },
 }
 
 /// Implement Debug to Display-print the key, reduces snapshot verbosity.
@@ -47,7 +52,10 @@ impl std::fmt::Debug for LocationId {
             LocationId::Process(key) => write!(f, "Process({key})"),
             LocationId::Cluster(key) => write!(f, "Cluster({key})"),
             LocationId::Atomic(tick) => write!(f, "Atomic({tick:?})"),
-            LocationId::Tick(tick, id) => write!(f, "Tick({tick}, {id:?})"),
+            LocationId::Tick {
+                tick,
+                parent_location,
+            } => write!(f, "Tick({tick:?}, {parent_location:?})"),
         }
     }
 }
@@ -70,7 +78,10 @@ impl LocationId {
             LocationId::Process(_) => self,
             LocationId::Cluster(_) => self,
             LocationId::Atomic(tick) => tick.root(),
-            LocationId::Tick(_, id) => id.root(),
+            LocationId::Tick {
+                tick: _,
+                parent_location,
+            } => parent_location.root(),
         }
     }
 
@@ -78,7 +89,7 @@ impl LocationId {
         match self {
             LocationId::Process(_) | LocationId::Cluster(_) => true,
             LocationId::Atomic(_) => false,
-            LocationId::Tick(_, _) => false,
+            LocationId::Tick { .. } => false,
         }
     }
 
@@ -86,7 +97,7 @@ impl LocationId {
         match self {
             LocationId::Process(_) | LocationId::Cluster(_) => true,
             LocationId::Atomic(_) => true,
-            LocationId::Tick(_, _) => false,
+            LocationId::Tick { .. } => false,
         }
     }
 
@@ -95,14 +106,17 @@ impl LocationId {
             LocationId::Process(id) => *id,
             LocationId::Cluster(id) => *id,
             LocationId::Atomic(_) => panic!("cannot get raw id for atomic"),
-            LocationId::Tick(_, _) => panic!("cannot get raw id for tick"),
+            LocationId::Tick { .. } => panic!("cannot get raw id for tick"),
         }
     }
 
     pub fn swap_root(&mut self, new_root: LocationId) {
         match self {
-            LocationId::Tick(_, id) => {
-                id.swap_root(new_root);
+            LocationId::Tick {
+                tick: _,
+                parent_location,
+            } => {
+                parent_location.swap_root(new_root);
             }
             LocationId::Atomic(tick) => {
                 tick.swap_root(new_root);

--- a/hydro_lang/src/location/mod.rs
+++ b/hydro_lang/src/location/mod.rs
@@ -244,7 +244,11 @@ pub trait Location<'a>: DynLocation {
     /// Prefer using [`Location::tick`] when you know the location is top-level.
     fn try_tick(&self) -> Option<Tick<Self>> {
         if Self::is_top_level() {
-            let id = self.flow_state().borrow_mut().next_clock_id();
+            let id = if let LocationId::Atomic { .. } = self.id() {
+                None
+            } else {
+                Some(self.flow_state().borrow_mut().next_clock_id())
+            };
             Some(Tick {
                 id,
                 l: self.clone(),
@@ -285,15 +289,7 @@ pub trait Location<'a>: DynLocation {
     /// # }
     /// ```
     fn tick(&self) -> Tick<Self> {
-        if let LocationId::Tick(_, _) = self.id() {
-            panic!("cannot create nested ticks");
-        }
-
-        let id = self.flow_state().borrow_mut().next_clock_id();
-        Tick {
-            id,
-            l: self.clone(),
-        }
+        self.try_tick().expect("cannot create nested ticks")
     }
 
     /// Creates an unbounded stream that continuously emits unit values `()`.

--- a/hydro_lang/src/location/tick.rs
+++ b/hydro_lang/src/location/tick.rs
@@ -114,14 +114,18 @@ pub trait DeferTick {
 /// Marks the stream as being inside the single global clock domain.
 #[derive(Clone)]
 pub struct Tick<L> {
-    pub(crate) id: ClockId,
+    /// `None` if `l` is `Atomic`.
+    pub(crate) id: Option<ClockId>,
     /// Location.
     pub(crate) l: L,
 }
 
 impl<L: DynLocation> DynLocation for Tick<L> {
     fn dyn_id(&self) -> LocationId {
-        LocationId::Tick(self.id, Box::new(self.l.dyn_id()))
+        LocationId::Tick {
+            tick: self.id,
+            parent_location: Box::new(self.l.dyn_id()),
+        }
     }
 
     fn flow_state(&self) -> &FlowState {

--- a/hydro_lang/src/sim/builder.rs
+++ b/hydro_lang/src/sim/builder.rs
@@ -54,7 +54,10 @@ impl SimBuilder {
             LocationId::Process(_) => self.process_graphs.entry(location.clone()).or_default(),
             LocationId::Cluster(_) => self.cluster_graphs.entry(location.clone()).or_default(),
             LocationId::Atomic(tick) => self.get_dfir_mut(tick.as_ref()),
-            LocationId::Tick(_, l) => match l.root() {
+            LocationId::Tick {
+                tick: _,
+                parent_location,
+            } => match parent_location.root() {
                 LocationId::Process(_) => {
                     self.process_tick_dfirs.entry(location.clone()).or_default()
                 }
@@ -88,7 +91,7 @@ impl SimBuilder {
         // top-level process/cluster location. Route each to the map with the matching
         // trait-object type (`TickInputHook` vs `ObservationHook`).
         let map: syn::Ident = match out_location {
-            LocationId::Tick(_, _) => syn::parse_quote!(__hydro_hooks),
+            LocationId::Tick { .. } => syn::parse_quote!(__hydro_hooks),
             LocationId::Process(_) | LocationId::Cluster(_) => {
                 syn::parse_quote!(__hydro_observation_hooks)
             }
@@ -145,7 +148,7 @@ impl SimBuilder {
         // Like `add_hook`, tick-input and observation hooks go to separately typed maps
         // (`ScriptedTickHooks` vs `ScriptedObservationHooks`), matching the target kind.
         let (target, map): (syn::Expr, syn::Ident) = match out_location {
-            LocationId::Tick(_, _) => (
+            LocationId::Tick { .. } => (
                 syn::parse_quote! {
                     #root::sim::runtime::ScriptTarget::Tick {
                         location: #root::sim::runtime::SimLocation {
@@ -257,17 +260,20 @@ impl SimBuilder {
         let root = get_this_crate();
         let tick_location_ser = serde_json::to_string(tick_location).unwrap();
         match tick_location {
-            LocationId::Tick(_, l) => match l.root() {
+            LocationId::Tick {
+                tick: _,
+                parent_location,
+            } => match parent_location.root() {
                 LocationId::Process(_) => {
                     self.add_extra_stmt_internal(
-                        l.root(),
+                        parent_location.root(),
                         syn::parse_quote! {
                             __hydro_inline_hooks.entry(#root::sim::runtime::SimLocation { location: #root::sim::runtime::parse_location(#tick_location_ser), cluster_id: None }).or_default().push(#expr);
                         },
                     );
                 }
                 LocationId::Cluster(_) => {
-                    self.add_extra_stmt_internal(l.root(), syn::parse_quote! {
+                    self.add_extra_stmt_internal(parent_location.root(), syn::parse_quote! {
                         __hydro_inline_hooks.entry(#root::sim::runtime::SimLocation { location: #root::sim::runtime::parse_location(#tick_location_ser), cluster_id: Some(__current_cluster_id) }).or_default().push(#expr);
                     });
                 }
@@ -924,9 +930,18 @@ impl DfirBuilder for SimBuilder {
         out_ident: &syn::Ident,
     ) {
         if let LocationId::Atomic(tick) = in_location
-            && let LocationId::Tick(_, outer) = tick.as_ref()
+            && let LocationId::Tick {
+                tick: _,
+                parent_location,
+            } = tick.as_ref()
         {
-            self.yield_from_tick(in_ident, in_location, in_kind, out_ident, outer.as_ref());
+            self.yield_from_tick(
+                in_ident,
+                in_location,
+                in_kind,
+                out_ident,
+                parent_location.as_ref(),
+            );
         } else {
             unreachable!()
         }

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -1325,7 +1325,11 @@ impl<'a> CompiledSimInstance<'a> {
                     location,
                     cluster_id,
                 };
-                let LocationId::Tick(_, parent_location) = &key.location else {
+                let LocationId::Tick {
+                    tick: _,
+                    parent_location,
+                } = &key.location
+                else {
                     unreachable!("tick DFIRs are always keyed by a tick location")
                 };
                 let parent_location = (**parent_location).clone();

--- a/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
+++ b/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
@@ -83,7 +83,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(0, Cluster(loc1v1)),
+                                                                                        location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                                                                         collection_kind: Stream {
                                                                                             bound: Bounded,
                                                                                             order: TotalOrder,
@@ -93,7 +93,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(0, Cluster(loc1v1)),
+                                                                                    location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                                                                     collection_kind: Stream {
                                                                                         bound: Bounded,
                                                                                         order: TotalOrder,
@@ -103,7 +103,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(0, Cluster(loc1v1)),
+                                                                                location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: TotalOrder,
@@ -113,7 +113,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(0, Cluster(loc1v1)),
+                                                                            location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                                                             collection_kind: Singleton {
                                                                                 bound: Bounded,
                                                                                 element_type: (u64 , u64),
@@ -121,7 +121,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(0, Cluster(loc1v1)),
+                                                                        location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: TotalOrder,
@@ -201,7 +201,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(1, Process(loc2v1)),
+                                        location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: (u64 , u64),
@@ -241,7 +241,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(1, Process(loc2v1)),
+                                                                            location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: TotalOrder,
@@ -251,7 +251,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(1, Process(loc2v1)),
+                                                                        location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: TotalOrder,
@@ -261,7 +261,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(1, Process(loc2v1)),
+                                                                    location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: TotalOrder,
@@ -271,7 +271,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(1, Process(loc2v1)),
+                                                                location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: (),
@@ -279,7 +279,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(1, Process(loc2v1)),
+                                                            location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: (),
@@ -287,7 +287,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(1, Process(loc2v1)),
+                                                        location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: core :: option :: Option < () >,
@@ -299,7 +299,7 @@ expression: built.ir()
                                                         value: :: std :: option :: Option :: None,
                                                         first_tick_only: false,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(1, Process(loc2v1)),
+                                                            location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: core :: option :: Option < () >,
@@ -307,7 +307,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(1, Process(loc2v1)),
+                                                        location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: core :: option :: Option < () >,
@@ -315,7 +315,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(1, Process(loc2v1)),
+                                                    location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -323,7 +323,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(1, Process(loc2v1)),
+                                                location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -331,7 +331,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(1, Process(loc2v1)),
+                                            location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: bool,
@@ -339,7 +339,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(1, Process(loc2v1)),
+                                        location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: bool,
@@ -347,7 +347,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(1, Process(loc2v1)),
+                                    location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: ((u64 , u64) , bool),
@@ -355,7 +355,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(1, Process(loc2v1)),
+                                location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (u64 , u64),
@@ -363,7 +363,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(1, Process(loc2v1)),
+                            location_id: Tick(Some(ClockId(1)), Process(loc2v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: TotalOrder,

--- a/hydro_test/src/cluster/snapshots/many_to_many_ir.snap
+++ b/hydro_test/src/cluster/snapshots/many_to_many_ir.snap
@@ -88,7 +88,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(0, Cluster(loc1v1)),
+                                                            location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                                             collection_kind: KeyedSingleton {
                                                                 bound: Bounded,
                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >,
@@ -97,7 +97,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(0, Cluster(loc1v1)),
+                                                        location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                                         collection_kind: KeyedSingleton {
                                                             bound: Bounded,
                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < () >,
@@ -106,7 +106,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(0, Cluster(loc1v1)),
+                                                    location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                                     collection_kind: KeyedStream {
                                                         bound: Bounded,
                                                         value_order: TotalOrder,
@@ -117,7 +117,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(0, Cluster(loc1v1)),
+                                                location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: NoOrder,
@@ -127,7 +127,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(0, Cluster(loc1v1)),
+                                            location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: NoOrder,
@@ -138,7 +138,7 @@ expression: built.ir()
                                     },
                                     trusted: true,
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(0, Cluster(loc1v1)),
+                                        location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: TotalOrder,
@@ -163,7 +163,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(0, Cluster(loc1v1)),
+                                        location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: TotalOrder,
@@ -173,7 +173,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(0, Cluster(loc1v1)),
+                                    location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: TotalOrder,
@@ -183,7 +183,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(0, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                 collection_kind: KeyedStream {
                                     bound: Bounded,
                                     value_order: TotalOrder,

--- a/hydro_test/src/cluster/snapshots/map_reduce_ir.snap
+++ b/hydro_test/src/cluster/snapshots/map_reduce_ir.snap
@@ -106,7 +106,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(0, Process(loc1v1)),
+                                                                                                                    location_id: Tick(Some(ClockId(0)), Process(loc1v1)),
                                                                                                                     collection_kind: Stream {
                                                                                                                         bound: Bounded,
                                                                                                                         order: TotalOrder,
@@ -179,7 +179,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(0, Process(loc1v1)),
+                                                                                                                                                location_id: Tick(Some(ClockId(0)), Process(loc1v1)),
                                                                                                                                                 collection_kind: KeyedSingleton {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: map_reduce :: Worker >,
@@ -188,7 +188,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(0, Process(loc1v1)),
+                                                                                                                                            location_id: Tick(Some(ClockId(0)), Process(loc1v1)),
                                                                                                                                             collection_kind: KeyedSingleton {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: map_reduce :: Worker >,
@@ -197,7 +197,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(0, Process(loc1v1)),
+                                                                                                                                        location_id: Tick(Some(ClockId(0)), Process(loc1v1)),
                                                                                                                                         collection_kind: KeyedStream {
                                                                                                                                             bound: Bounded,
                                                                                                                                             value_order: TotalOrder,
@@ -208,7 +208,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(0, Process(loc1v1)),
+                                                                                                                                    location_id: Tick(Some(ClockId(0)), Process(loc1v1)),
                                                                                                                                     collection_kind: Stream {
                                                                                                                                         bound: Bounded,
                                                                                                                                         order: NoOrder,
@@ -218,7 +218,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(0, Process(loc1v1)),
+                                                                                                                                location_id: Tick(Some(ClockId(0)), Process(loc1v1)),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Bounded,
                                                                                                                                     order: NoOrder,
@@ -229,7 +229,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                         trusted: false,
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(0, Process(loc1v1)),
+                                                                                                                            location_id: Tick(Some(ClockId(0)), Process(loc1v1)),
                                                                                                                             collection_kind: Stream {
                                                                                                                                 bound: Bounded,
                                                                                                                                 order: TotalOrder,
@@ -239,7 +239,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(0, Process(loc1v1)),
+                                                                                                                        location_id: Tick(Some(ClockId(0)), Process(loc1v1)),
                                                                                                                         collection_kind: Singleton {
                                                                                                                             bound: Bounded,
                                                                                                                             element_type: std :: vec :: Vec < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: map_reduce :: Worker > >,
@@ -247,7 +247,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(0, Process(loc1v1)),
+                                                                                                                    location_id: Tick(Some(ClockId(0)), Process(loc1v1)),
                                                                                                                     collection_kind: Optional {
                                                                                                                         bound: Bounded,
                                                                                                                         element_type: std :: vec :: Vec < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: map_reduce :: Worker > >,
@@ -255,7 +255,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(0, Process(loc1v1)),
+                                                                                                                location_id: Tick(Some(ClockId(0)), Process(loc1v1)),
                                                                                                                 collection_kind: Stream {
                                                                                                                     bound: Bounded,
                                                                                                                     order: TotalOrder,
@@ -265,7 +265,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(0, Process(loc1v1)),
+                                                                                                            location_id: Tick(Some(ClockId(0)), Process(loc1v1)),
                                                                                                             collection_kind: Stream {
                                                                                                                 bound: Bounded,
                                                                                                                 order: TotalOrder,
@@ -327,7 +327,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(1, Cluster(loc2v1)),
+                                                                                    location_id: Tick(Some(ClockId(1)), Cluster(loc2v1)),
                                                                                     collection_kind: KeyedStream {
                                                                                         bound: Bounded,
                                                                                         value_order: TotalOrder,
@@ -338,7 +338,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(1, Cluster(loc2v1)),
+                                                                                location_id: Tick(Some(ClockId(1)), Cluster(loc2v1)),
                                                                                 collection_kind: KeyedSingleton {
                                                                                     bound: Bounded,
                                                                                     key_type: std :: string :: String,
@@ -347,7 +347,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(1, Cluster(loc2v1)),
+                                                                            location_id: Tick(Some(ClockId(1)), Cluster(loc2v1)),
                                                                             collection_kind: KeyedStream {
                                                                                 bound: Bounded,
                                                                                 value_order: TotalOrder,
@@ -358,7 +358,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(1, Cluster(loc2v1)),
+                                                                        location_id: Tick(Some(ClockId(1)), Cluster(loc2v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: NoOrder,
@@ -368,7 +368,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(1, Cluster(loc2v1)),
+                                                                    location_id: Tick(Some(ClockId(1)), Cluster(loc2v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: NoOrder,
@@ -461,7 +461,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(2, Process(loc1v1)),
+                                location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                                 collection_kind: KeyedSingleton {
                                     bound: Bounded,
                                     key_type: std :: string :: String,
@@ -470,7 +470,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(2, Process(loc1v1)),
+                            location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                             collection_kind: KeyedStream {
                                 bound: Bounded,
                                 value_order: TotalOrder,
@@ -481,7 +481,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(2, Process(loc1v1)),
+                        location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -18,7 +18,7 @@ expression: built.ir()
                                     0,
                                 ),
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(0, Cluster(loc3v1)),
+                                    location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: (u32 , core :: option :: Option < i32 >),
@@ -26,7 +26,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(0, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (u32 , core :: option :: Option < i32 >),
@@ -41,7 +41,7 @@ expression: built.ir()
                                         value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_LINE_COL ! ([] [(0u32 , None)]) },
                                         first_tick_only: false,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(0, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: (u32 , core :: option :: Option < i32 >),
@@ -49,7 +49,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(0, Cluster(loc3v1)),
+                                        location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: (u32 , core :: option :: Option < i32 >),
@@ -70,7 +70,7 @@ expression: built.ir()
                                                             value: { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_LINE_COL ! ([] [()]) },
                                                             first_tick_only: true,
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(0, Cluster(loc3v1)),
+                                                                location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: (),
@@ -78,7 +78,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(0, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: (),
@@ -86,7 +86,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(0, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: core :: option :: Option < () >,
@@ -98,7 +98,7 @@ expression: built.ir()
                                                         value: :: std :: option :: Option :: None,
                                                         first_tick_only: false,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(0, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: core :: option :: Option < () >,
@@ -106,7 +106,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(0, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: core :: option :: Option < () >,
@@ -114,7 +114,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(0, Cluster(loc3v1)),
+                                                    location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -122,7 +122,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(0, Cluster(loc3v1)),
+                                                location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -130,7 +130,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(0, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: bool,
@@ -138,7 +138,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(0, Cluster(loc3v1)),
+                                        location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: bool,
@@ -146,7 +146,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(0, Cluster(loc3v1)),
+                                    location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: ((u32 , core :: option :: Option < i32 >) , bool),
@@ -154,7 +154,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(0, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (u32 , core :: option :: Option < i32 >),
@@ -162,7 +162,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(0, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (u32 , core :: option :: Option < i32 >),
@@ -170,7 +170,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(0, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: (u32 , core :: option :: Option < i32 >),
@@ -191,7 +191,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(0, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                             collection_kind: Singleton {
                                 bound: Bounded,
                                 element_type: usize,
@@ -199,7 +199,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(0, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: usize,
@@ -207,7 +207,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(0, Cluster(loc3v1)),
+                    location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                     collection_kind: Optional {
                         bound: Bounded,
                         element_type: ((u32 , core :: option :: Option < i32 >) , usize),
@@ -215,7 +215,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(0, Cluster(loc3v1)),
+                location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                 collection_kind: Optional {
                     bound: Bounded,
                     element_type: (u32 , core :: option :: Option < i32 >),
@@ -395,7 +395,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(3, Cluster(loc1v1)),
+                                                            location_id: Tick(Some(ClockId(3)), Cluster(loc1v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -424,7 +424,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(3, Cluster(loc1v1)),
+                                                            location_id: Tick(Some(ClockId(3)), Cluster(loc1v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -432,7 +432,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(3, Cluster(loc1v1)),
+                                                        location_id: Tick(Some(ClockId(3)), Cluster(loc1v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -456,7 +456,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(15, Cluster(loc1v1)),
+                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -464,7 +464,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                        location_id: Atomic(Tick(Some(ClockId(15)), Cluster(loc1v1))),
                                         collection_kind: Singleton {
                                             bound: Unbounded,
                                             element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -472,7 +472,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(15, Cluster(loc1v1)),
+                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -480,7 +480,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(15, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -495,7 +495,7 @@ expression: built.ir()
                                             8,
                                         ),
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(15, Cluster(loc1v1)),
+                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: u32,
@@ -503,7 +503,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(15, Cluster(loc1v1)),
+                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: u32,
@@ -515,7 +515,7 @@ expression: built.ir()
                                         value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [0]) },
                                         first_tick_only: false,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(15, Cluster(loc1v1)),
+                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: u32,
@@ -523,7 +523,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(15, Cluster(loc1v1)),
+                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: u32,
@@ -531,7 +531,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(15, Cluster(loc1v1)),
+                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: u32,
@@ -539,7 +539,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(15, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: u32,
@@ -547,7 +547,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(15, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > , u32),
@@ -555,7 +555,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(15, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                         collection_kind: Singleton {
                             bound: Bounded,
                             element_type: (core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > , u32),
@@ -563,7 +563,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(15, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                     collection_kind: Singleton {
                         bound: Bounded,
                         element_type: u32,
@@ -571,7 +571,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(15, Cluster(loc1v1)),
+                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: u32,
@@ -667,7 +667,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(6, Cluster(loc1v1)),
+                                                                location_id: Tick(Some(ClockId(6)), Cluster(loc1v1)),
                                                                 collection_kind: KeyedSingleton {
                                                                     bound: Bounded,
                                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -676,7 +676,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(6, Cluster(loc1v1)),
+                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc1v1)),
                                                             collection_kind: KeyedSingleton {
                                                                 bound: Bounded,
                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -685,7 +685,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(6, Cluster(loc1v1)),
+                                                        location_id: Tick(Some(ClockId(6)), Cluster(loc1v1)),
                                                         collection_kind: KeyedStream {
                                                             bound: Bounded,
                                                             value_order: TotalOrder,
@@ -696,7 +696,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(6, Cluster(loc1v1)),
+                                                    location_id: Tick(Some(ClockId(6)), Cluster(loc1v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: NoOrder,
@@ -706,7 +706,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(6, Cluster(loc1v1)),
+                                                location_id: Tick(Some(ClockId(6)), Cluster(loc1v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: NoOrder,
@@ -717,7 +717,7 @@ expression: built.ir()
                                         },
                                         trusted: true,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(6, Cluster(loc1v1)),
+                                            location_id: Tick(Some(ClockId(6)), Cluster(loc1v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -747,7 +747,7 @@ expression: built.ir()
                                                                                                 input: Tee {
                                                                                                     inner: <shared 1>,
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                         collection_kind: Singleton {
                                                                                                             bound: Bounded,
                                                                                                             element_type: u32,
@@ -755,7 +755,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                     collection_kind: Singleton {
                                                                                                         bound: Bounded,
                                                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -763,7 +763,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                 collection_kind: Singleton {
                                                                                                     bound: Bounded,
                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -771,7 +771,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                                                            location_id: Atomic(Tick(Some(ClockId(15)), Cluster(loc1v1))),
                                                                                             collection_kind: Singleton {
                                                                                                 bound: Unbounded,
                                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -779,7 +779,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                         collection_kind: Singleton {
                                                                                             bound: Bounded,
                                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -787,7 +787,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                     collection_kind: Singleton {
                                                                                         bound: Bounded,
                                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -802,7 +802,7 @@ expression: built.ir()
                                                                                             7,
                                                                                         ),
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                             collection_kind: Singleton {
                                                                                                 bound: Bounded,
                                                                                                 element_type: bool,
@@ -810,7 +810,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                         collection_kind: Singleton {
                                                                                             bound: Bounded,
                                                                                             element_type: bool,
@@ -818,7 +818,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                     collection_kind: Optional {
                                                                                         bound: Bounded,
                                                                                         element_type: bool,
@@ -826,7 +826,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                 collection_kind: Optional {
                                                                                     bound: Bounded,
                                                                                     element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool),
@@ -834,7 +834,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                             collection_kind: Optional {
                                                                                 bound: Bounded,
                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -850,7 +850,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(5, Cluster(loc1v1)),
+                                                                    location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                                     collection_kind: Optional {
                                                                         bound: Bounded,
                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -890,7 +890,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(5, Cluster(loc1v1)),
+                                                                                                        location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Bounded,
                                                                                                             order: TotalOrder,
@@ -900,7 +900,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(5, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Bounded,
                                                                                                         order: TotalOrder,
@@ -910,7 +910,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(5, Cluster(loc1v1)),
+                                                                                                location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
                                                                                                     order: TotalOrder,
@@ -920,7 +920,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(5, Cluster(loc1v1)),
+                                                                                            location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                                                             collection_kind: Optional {
                                                                                                 bound: Bounded,
                                                                                                 element_type: (),
@@ -928,7 +928,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(5, Cluster(loc1v1)),
+                                                                                        location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                                                         collection_kind: Optional {
                                                                                             bound: Bounded,
                                                                                             element_type: (),
@@ -936,7 +936,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(5, Cluster(loc1v1)),
+                                                                                    location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                                                     collection_kind: Optional {
                                                                                         bound: Bounded,
                                                                                         element_type: core :: option :: Option < () >,
@@ -948,7 +948,7 @@ expression: built.ir()
                                                                                     value: :: std :: option :: Option :: None,
                                                                                     first_tick_only: false,
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(5, Cluster(loc1v1)),
+                                                                                        location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                                                         collection_kind: Singleton {
                                                                                             bound: Bounded,
                                                                                             element_type: core :: option :: Option < () >,
@@ -956,7 +956,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(5, Cluster(loc1v1)),
+                                                                                    location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                                                     collection_kind: Optional {
                                                                                         bound: Bounded,
                                                                                         element_type: core :: option :: Option < () >,
@@ -964,7 +964,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(5, Cluster(loc1v1)),
+                                                                                location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                                                 collection_kind: Optional {
                                                                                     bound: Bounded,
                                                                                     element_type: core :: option :: Option < () >,
@@ -972,7 +972,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(5, Cluster(loc1v1)),
+                                                                            location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                                             collection_kind: Singleton {
                                                                                 bound: Bounded,
                                                                                 element_type: core :: option :: Option < () >,
@@ -980,7 +980,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(5, Cluster(loc1v1)),
+                                                                        location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                                         collection_kind: Singleton {
                                                                             bound: Bounded,
                                                                             element_type: bool,
@@ -988,7 +988,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(5, Cluster(loc1v1)),
+                                                                    location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                                     collection_kind: Optional {
                                                                         bound: Bounded,
                                                                         element_type: bool,
@@ -996,7 +996,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(5, Cluster(loc1v1)),
+                                                                location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool),
@@ -1004,7 +1004,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(5, Cluster(loc1v1)),
+                                                            location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1012,7 +1012,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(5, Cluster(loc1v1)),
+                                                        location_id: Tick(Some(ClockId(5)), Cluster(loc1v1)),
                                                         collection_kind: Stream {
                                                             bound: Bounded,
                                                             order: TotalOrder,
@@ -1042,7 +1042,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(6, Cluster(loc1v1)),
+                                            location_id: Tick(Some(ClockId(6)), Cluster(loc1v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -1052,7 +1052,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(6, Cluster(loc1v1)),
+                                        location_id: Tick(Some(ClockId(6)), Cluster(loc1v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: TotalOrder,
@@ -1062,7 +1062,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(6, Cluster(loc1v1)),
+                                    location_id: Tick(Some(ClockId(6)), Cluster(loc1v1)),
                                     collection_kind: KeyedStream {
                                         bound: Bounded,
                                         value_order: TotalOrder,
@@ -1139,7 +1139,7 @@ expression: built.ir()
                                 9,
                             ),
                             metadata: HydroIrMetadata {
-                                location_id: Tick(9, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: NoOrder,
@@ -1149,7 +1149,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(9, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -1271,7 +1271,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                                            location_id: Tick(Some(ClockId(8)), Cluster(loc1v1)),
                                                                                                                             collection_kind: KeyedSingleton {
                                                                                                                                 bound: Bounded,
                                                                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -1280,7 +1280,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                                        location_id: Tick(Some(ClockId(8)), Cluster(loc1v1)),
                                                                                                                         collection_kind: KeyedSingleton {
                                                                                                                             bound: Bounded,
                                                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -1289,7 +1289,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                                    location_id: Tick(Some(ClockId(8)), Cluster(loc1v1)),
                                                                                                                     collection_kind: KeyedStream {
                                                                                                                         bound: Bounded,
                                                                                                                         value_order: TotalOrder,
@@ -1300,7 +1300,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                                location_id: Tick(Some(ClockId(8)), Cluster(loc1v1)),
                                                                                                                 collection_kind: Stream {
                                                                                                                     bound: Bounded,
                                                                                                                     order: NoOrder,
@@ -1310,7 +1310,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                            location_id: Tick(Some(ClockId(8)), Cluster(loc1v1)),
                                                                                                             collection_kind: Stream {
                                                                                                                 bound: Bounded,
                                                                                                                 order: NoOrder,
@@ -1321,7 +1321,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                     trusted: true,
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                        location_id: Tick(Some(ClockId(8)), Cluster(loc1v1)),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Bounded,
                                                                                                             order: TotalOrder,
@@ -1341,7 +1341,7 @@ expression: built.ir()
                                                                                                                         left: Tee {
                                                                                                                             inner: <shared 4>,
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                 collection_kind: Singleton {
                                                                                                                                     bound: Bounded,
                                                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1406,7 +1406,7 @@ expression: built.ir()
                                                                                                                                                                                         },
                                                                                                                                                                                     },
                                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                                        location_id: Tick(7, Cluster(loc1v1)),
+                                                                                                                                                                                        location_id: Tick(Some(ClockId(7)), Cluster(loc1v1)),
                                                                                                                                                                                         collection_kind: Singleton {
                                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                                             element_type: core :: option :: Option < hydro_test :: __staged :: __deps :: tokio :: time :: Instant >,
@@ -1414,7 +1414,7 @@ expression: built.ir()
                                                                                                                                                                                     },
                                                                                                                                                                                 },
                                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                                    location_id: Tick(7, Cluster(loc1v1)),
+                                                                                                                                                                                    location_id: Tick(Some(ClockId(7)), Cluster(loc1v1)),
                                                                                                                                                                                     collection_kind: Optional {
                                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                                         element_type: (),
@@ -1430,7 +1430,7 @@ expression: built.ir()
                                                                                                                                                                             },
                                                                                                                                                                         },
                                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                                 element_type: (),
@@ -1444,7 +1444,7 @@ expression: built.ir()
                                                                                                                                                                             input: Tee {
                                                                                                                                                                                 inner: <shared 6>,
                                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                                     collection_kind: Singleton {
                                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                                         element_type: bool,
@@ -1452,7 +1452,7 @@ expression: built.ir()
                                                                                                                                                                                 },
                                                                                                                                                                             },
                                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                                 collection_kind: Singleton {
                                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                                     element_type: bool,
@@ -1460,7 +1460,7 @@ expression: built.ir()
                                                                                                                                                                             },
                                                                                                                                                                         },
                                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                                 element_type: bool,
@@ -1468,7 +1468,7 @@ expression: built.ir()
                                                                                                                                                                         },
                                                                                                                                                                     },
                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                         collection_kind: Optional {
                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                             element_type: (() , bool),
@@ -1476,7 +1476,7 @@ expression: built.ir()
                                                                                                                                                                     },
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                     collection_kind: Optional {
                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                         element_type: (),
@@ -1484,7 +1484,7 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                             },
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: Optional {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: (),
@@ -1492,7 +1492,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: core :: option :: Option < () >,
@@ -1504,7 +1504,7 @@ expression: built.ir()
                                                                                                                                                             value: :: std :: option :: Option :: None,
                                                                                                                                                             first_tick_only: false,
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: Singleton {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: core :: option :: Option < () >,
@@ -1512,7 +1512,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: core :: option :: Option < () >,
@@ -1520,7 +1520,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Optional {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             element_type: core :: option :: Option < () >,
@@ -1528,7 +1528,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Singleton {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         element_type: core :: option :: Option < () >,
@@ -1536,7 +1536,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Singleton {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     element_type: bool,
@@ -1574,7 +1574,7 @@ expression: built.ir()
                                                                                                                                                                                 },
                                                                                                                                                                             },
                                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                                     order: TotalOrder,
@@ -1584,7 +1584,7 @@ expression: built.ir()
                                                                                                                                                                             },
                                                                                                                                                                         },
                                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                             collection_kind: Stream {
                                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                                 order: TotalOrder,
@@ -1594,7 +1594,7 @@ expression: built.ir()
                                                                                                                                                                         },
                                                                                                                                                                     },
                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                         collection_kind: Stream {
                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                             order: TotalOrder,
@@ -1604,7 +1604,7 @@ expression: built.ir()
                                                                                                                                                                     },
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                     collection_kind: Optional {
                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                         element_type: (),
@@ -1612,7 +1612,7 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                             },
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: Optional {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: (),
@@ -1620,7 +1620,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: core :: option :: Option < () >,
@@ -1632,7 +1632,7 @@ expression: built.ir()
                                                                                                                                                             value: :: std :: option :: Option :: None,
                                                                                                                                                             first_tick_only: false,
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: Singleton {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: core :: option :: Option < () >,
@@ -1640,7 +1640,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: core :: option :: Option < () >,
@@ -1648,7 +1648,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Optional {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             element_type: core :: option :: Option < () >,
@@ -1656,7 +1656,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Singleton {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         element_type: core :: option :: Option < () >,
@@ -1664,7 +1664,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Singleton {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     element_type: bool,
@@ -1672,7 +1672,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                             collection_kind: Optional {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 element_type: (bool , bool),
@@ -1680,7 +1680,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                         collection_kind: Singleton {
                                                                                                                                             bound: Bounded,
                                                                                                                                             element_type: (bool , bool),
@@ -1688,7 +1688,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                     collection_kind: Singleton {
                                                                                                                                         bound: Bounded,
                                                                                                                                         element_type: bool,
@@ -1696,7 +1696,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                 collection_kind: Optional {
                                                                                                                                     bound: Bounded,
                                                                                                                                     element_type: bool,
@@ -1704,7 +1704,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                             collection_kind: Optional {
                                                                                                                                 bound: Bounded,
                                                                                                                                 element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool),
@@ -1712,7 +1712,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                         collection_kind: Optional {
                                                                                                                             bound: Bounded,
                                                                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1720,7 +1720,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                     collection_kind: Stream {
                                                                                                                         bound: Bounded,
                                                                                                                         order: TotalOrder,
@@ -1750,7 +1750,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                        location_id: Tick(Some(ClockId(8)), Cluster(loc1v1)),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Bounded,
                                                                                                             order: TotalOrder,
@@ -1760,7 +1760,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(Some(ClockId(8)), Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Bounded,
                                                                                                         order: TotalOrder,
@@ -1770,7 +1770,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(8, Cluster(loc1v1)),
+                                                                                                location_id: Tick(Some(ClockId(8)), Cluster(loc1v1)),
                                                                                                 collection_kind: KeyedStream {
                                                                                                     bound: Bounded,
                                                                                                     value_order: TotalOrder,
@@ -1823,7 +1823,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Cluster(loc2v1)),
+                                                                            location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: NoOrder,
@@ -1833,7 +1833,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
+                                                                        location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: NoOrder,
@@ -1858,7 +1858,7 @@ expression: built.ir()
                                                                                                         input: Tee {
                                                                                                             inner: <shared 9>,
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(2, Cluster(loc2v1)),
+                                                                                                                location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                                                                 collection_kind: Stream {
                                                                                                                     bound: Bounded,
                                                                                                                     order: NoOrder,
@@ -1868,7 +1868,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(2, Cluster(loc2v1)),
+                                                                                                            location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                                                             collection_kind: Stream {
                                                                                                                 bound: Bounded,
                                                                                                                 order: NoOrder,
@@ -1878,7 +1878,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Atomic(Tick(2, Cluster(loc2v1))),
+                                                                                                        location_id: Atomic(Tick(Some(ClockId(2)), Cluster(loc2v1))),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Unbounded,
                                                                                                             order: NoOrder,
@@ -1889,7 +1889,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 trusted: false,
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Atomic(Tick(2, Cluster(loc2v1))),
+                                                                                                    location_id: Atomic(Tick(Some(ClockId(2)), Cluster(loc2v1))),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Unbounded,
                                                                                                         order: TotalOrder,
@@ -1899,7 +1899,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Atomic(Tick(2, Cluster(loc2v1))),
+                                                                                                location_id: Atomic(Tick(Some(ClockId(2)), Cluster(loc2v1))),
                                                                                                 collection_kind: Optional {
                                                                                                     bound: InitNone,
                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1907,7 +1907,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(2, Cluster(loc2v1)),
+                                                                                            location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                                             collection_kind: Optional {
                                                                                                 bound: Bounded,
                                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -1915,7 +1915,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(2, Cluster(loc2v1)),
+                                                                                        location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                                         collection_kind: Optional {
                                                                                             bound: Bounded,
                                                                                             element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -1927,7 +1927,7 @@ expression: built.ir()
                                                                                         value: :: std :: option :: Option :: None,
                                                                                         first_tick_only: false,
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(2, Cluster(loc2v1)),
+                                                                                            location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                                             collection_kind: Singleton {
                                                                                                 bound: Bounded,
                                                                                                 element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -1935,7 +1935,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(2, Cluster(loc2v1)),
+                                                                                        location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                                         collection_kind: Optional {
                                                                                             bound: Bounded,
                                                                                             element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -1943,7 +1943,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(2, Cluster(loc2v1)),
+                                                                                    location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                                     collection_kind: Optional {
                                                                                         bound: Bounded,
                                                                                         element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -1951,7 +1951,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(2, Cluster(loc2v1)),
+                                                                                location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                                 collection_kind: Singleton {
                                                                                     bound: Bounded,
                                                                                     element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -1959,7 +1959,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Cluster(loc2v1)),
+                                                                            location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                             collection_kind: Singleton {
                                                                                 bound: Bounded,
                                                                                 element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -1967,7 +1967,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
+                                                                        location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -1975,7 +1975,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
+                                                                    location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: NoOrder,
@@ -1990,7 +1990,7 @@ expression: built.ir()
                                                                         4,
                                                                     ),
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
+                                                                        location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                         collection_kind: Singleton {
                                                                             bound: Bounded,
                                                                             element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
@@ -1998,7 +1998,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
+                                                                    location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                     collection_kind: Optional {
                                                                         bound: Bounded,
                                                                         element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
@@ -2006,7 +2006,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(2, Cluster(loc2v1)),
+                                                                location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                 collection_kind: Stream {
                                                                     bound: Bounded,
                                                                     order: NoOrder,
@@ -2016,7 +2016,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(2, Cluster(loc2v1)),
+                                                            location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                             collection_kind: Stream {
                                                                 bound: Bounded,
                                                                 order: NoOrder,
@@ -2098,7 +2098,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(9, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -2108,7 +2108,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(9, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -2118,7 +2118,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(9, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -2142,7 +2142,7 @@ expression: built.ir()
                                             inner: Tee {
                                                 inner: <shared 7>,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(9, Cluster(loc1v1)),
+                                                    location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: NoOrder,
@@ -2152,7 +2152,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(9, Cluster(loc1v1)),
+                                                location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                                 collection_kind: KeyedStream {
                                                     bound: Bounded,
                                                     value_order: NoOrder,
@@ -2163,7 +2163,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(9, Cluster(loc1v1)),
+                                            location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                             collection_kind: KeyedSingleton {
                                                 bound: Bounded,
                                                 key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2172,7 +2172,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(9, Cluster(loc1v1)),
+                                        location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                         collection_kind: KeyedSingleton {
                                             bound: Bounded,
                                             key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2181,7 +2181,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(9, Cluster(loc1v1)),
+                                    location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
                                         bound: Bounded,
                                         key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2190,7 +2190,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(9, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                 collection_kind: KeyedStream {
                                     bound: Bounded,
                                     value_order: TotalOrder,
@@ -2201,7 +2201,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(9, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -2211,7 +2211,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(9, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -2221,7 +2221,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(9, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -2231,7 +2231,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(9, Cluster(loc1v1)),
+                location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -2256,7 +2256,7 @@ expression: built.ir()
                             input: Tee {
                                 inner: <shared 12>,
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(9, Cluster(loc1v1)),
+                                    location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
                                         bound: Bounded,
                                         key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2265,7 +2265,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(9, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                 collection_kind: KeyedSingleton {
                                     bound: Bounded,
                                     key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2274,7 +2274,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(9, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                             collection_kind: KeyedStream {
                                 bound: Bounded,
                                 value_order: TotalOrder,
@@ -2285,7 +2285,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(9, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -2295,7 +2295,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(9, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -2307,7 +2307,7 @@ expression: built.ir()
             neg: Tee {
                 inner: <shared 11>,
                 metadata: HydroIrMetadata {
-                    location_id: Tick(9, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -2317,7 +2317,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(9, Cluster(loc1v1)),
+                location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -2372,7 +2372,7 @@ expression: built.ir()
                                                                                                                     pos: Tee {
                                                                                                                         inner: <shared 7>,
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                            location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                                                                                                             collection_kind: Stream {
                                                                                                                                 bound: Bounded,
                                                                                                                                 order: NoOrder,
@@ -2390,7 +2390,7 @@ expression: built.ir()
                                                                                                                                     input: Tee {
                                                                                                                                         inner: <shared 12>,
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                                            location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                                                                                                                             collection_kind: KeyedSingleton {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2399,7 +2399,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                                        location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                                                                                                                         collection_kind: KeyedSingleton {
                                                                                                                                             bound: Bounded,
                                                                                                                                             key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2408,7 +2408,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                                    location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                                                                                                                     collection_kind: KeyedStream {
                                                                                                                                         bound: Bounded,
                                                                                                                                         value_order: TotalOrder,
@@ -2419,7 +2419,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                                location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Bounded,
                                                                                                                                     order: NoOrder,
@@ -2429,7 +2429,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                            location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                                                                                                             collection_kind: Stream {
                                                                                                                                 bound: Bounded,
                                                                                                                                 order: NoOrder,
@@ -2439,7 +2439,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                        location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                                                                                                         collection_kind: Stream {
                                                                                                                             bound: Bounded,
                                                                                                                             order: NoOrder,
@@ -2454,7 +2454,7 @@ expression: built.ir()
                                                                                                                             10,
                                                                                                                         ),
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                            location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                                                                                                             collection_kind: Stream {
                                                                                                                                 bound: Bounded,
                                                                                                                                 order: NoOrder,
@@ -2464,7 +2464,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                        location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                                                                                                         collection_kind: Stream {
                                                                                                                             bound: Bounded,
                                                                                                                             order: NoOrder,
@@ -2474,7 +2474,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                    location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                                                                                                     collection_kind: Stream {
                                                                                                                         bound: Bounded,
                                                                                                                         order: NoOrder,
@@ -2484,7 +2484,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                location_id: Tick(Some(ClockId(9)), Cluster(loc1v1)),
                                                                                                                 collection_kind: Stream {
                                                                                                                     bound: Bounded,
                                                                                                                     order: NoOrder,
@@ -2605,7 +2605,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >),
@@ -2616,7 +2616,7 @@ expression: built.ir()
                                                             inner: Tee {
                                                                 inner: <shared 4>,
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                     collection_kind: Singleton {
                                                                         bound: Bounded,
                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2624,7 +2624,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2632,7 +2632,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: ((hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -2640,7 +2640,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
@@ -2648,7 +2648,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
@@ -2656,7 +2656,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: (),
@@ -2664,7 +2664,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(15, Cluster(loc1v1)),
+                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < () >,
@@ -2676,7 +2676,7 @@ expression: built.ir()
                                             value: :: std :: option :: Option :: None,
                                             first_tick_only: false,
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -2684,7 +2684,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(15, Cluster(loc1v1)),
+                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < () >,
@@ -2692,7 +2692,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(15, Cluster(loc1v1)),
+                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < () >,
@@ -2700,7 +2700,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(15, Cluster(loc1v1)),
+                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < () >,
@@ -2708,7 +2708,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(15, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: bool,
@@ -2724,7 +2724,7 @@ expression: built.ir()
                                             left: Tee {
                                                 inner: <shared 2>,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -2734,7 +2734,7 @@ expression: built.ir()
                                             right: Tee {
                                                 inner: <shared 5>,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -2742,7 +2742,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: (core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -2750,7 +2750,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(15, Cluster(loc1v1)),
+                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: (core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -2758,7 +2758,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(15, Cluster(loc1v1)),
+                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: bool,
@@ -2766,7 +2766,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                    location_id: Atomic(Tick(Some(ClockId(15)), Cluster(loc1v1))),
                                     collection_kind: Singleton {
                                         bound: Unbounded,
                                         element_type: bool,
@@ -2774,7 +2774,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(15, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: bool,
@@ -2782,7 +2782,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(15, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (bool , bool),
@@ -2790,7 +2790,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(15, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                         collection_kind: Singleton {
                             bound: Bounded,
                             element_type: (bool , bool),
@@ -2798,7 +2798,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(15, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                     collection_kind: Singleton {
                         bound: Bounded,
                         element_type: bool,
@@ -2806,7 +2806,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(15, Cluster(loc1v1)),
+                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: bool,
@@ -2872,7 +2872,7 @@ expression: built.ir()
                                     11,
                                 ),
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(11, Cluster(loc3v1)),
+                                    location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: TotalOrder,
@@ -2882,7 +2882,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(11, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: TotalOrder,
@@ -2906,7 +2906,7 @@ expression: built.ir()
                                                                 inner: Tee {
                                                                     inner: <shared 0>,
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(0, Cluster(loc3v1)),
+                                                                        location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: (u32 , core :: option :: Option < i32 >),
@@ -2914,7 +2914,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(0, Cluster(loc3v1)),
+                                                                    location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: TotalOrder,
@@ -2924,7 +2924,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(0, Cluster(loc3v1)),
+                                                                location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                                 collection_kind: KeyedStream {
                                                                     bound: Bounded,
                                                                     value_order: TotalOrder,
@@ -3038,7 +3038,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(11, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: TotalOrder,
@@ -3048,7 +3048,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(11, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: TotalOrder,
@@ -3058,7 +3058,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(11, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,
@@ -3169,7 +3169,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                                        location_id: Tick(Some(ClockId(10)), Cluster(loc1v1)),
                                                                                                                         collection_kind: KeyedSingleton {
                                                                                                                             bound: Bounded,
                                                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
@@ -3178,7 +3178,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                                    location_id: Tick(Some(ClockId(10)), Cluster(loc1v1)),
                                                                                                                     collection_kind: KeyedSingleton {
                                                                                                                         bound: Bounded,
                                                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
@@ -3187,7 +3187,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                                location_id: Tick(Some(ClockId(10)), Cluster(loc1v1)),
                                                                                                                 collection_kind: KeyedStream {
                                                                                                                     bound: Bounded,
                                                                                                                     value_order: TotalOrder,
@@ -3198,7 +3198,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                            location_id: Tick(Some(ClockId(10)), Cluster(loc1v1)),
                                                                                                             collection_kind: Stream {
                                                                                                                 bound: Bounded,
                                                                                                                 order: NoOrder,
@@ -3208,7 +3208,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                        location_id: Tick(Some(ClockId(10)), Cluster(loc1v1)),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Bounded,
                                                                                                             order: NoOrder,
@@ -3219,7 +3219,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 trusted: true,
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(Some(ClockId(10)), Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Bounded,
                                                                                                         order: TotalOrder,
@@ -3237,7 +3237,7 @@ expression: built.ir()
                                                                                                                 left: Tee {
                                                                                                                     inner: <shared 4>,
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                         collection_kind: Singleton {
                                                                                                                             bound: Bounded,
                                                                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -3254,7 +3254,7 @@ expression: built.ir()
                                                                                                                                     left: Tee {
                                                                                                                                         inner: <shared 13>,
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                             collection_kind: Singleton {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 element_type: bool,
@@ -3277,7 +3277,7 @@ expression: built.ir()
                                                                                                                                                                     input: Tee {
                                                                                                                                                                         inner: <shared 13>,
                                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                             collection_kind: Singleton {
                                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                                 element_type: bool,
@@ -3285,7 +3285,7 @@ expression: built.ir()
                                                                                                                                                                         },
                                                                                                                                                                     },
                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                         collection_kind: Singleton {
                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                             element_type: core :: option :: Option < () >,
@@ -3293,7 +3293,7 @@ expression: built.ir()
                                                                                                                                                                     },
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                     collection_kind: Optional {
                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                         element_type: (),
@@ -3301,7 +3301,7 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                             },
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: Optional {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: (),
@@ -3309,7 +3309,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: (),
@@ -3317,7 +3317,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Optional {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             element_type: core :: option :: Option < () >,
@@ -3329,7 +3329,7 @@ expression: built.ir()
                                                                                                                                                         value: :: std :: option :: Option :: None,
                                                                                                                                                         first_tick_only: false,
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Singleton {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: core :: option :: Option < () >,
@@ -3337,7 +3337,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Optional {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             element_type: core :: option :: Option < () >,
@@ -3345,7 +3345,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Optional {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         element_type: core :: option :: Option < () >,
@@ -3353,7 +3353,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Singleton {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     element_type: core :: option :: Option < () >,
@@ -3361,7 +3361,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                             collection_kind: Singleton {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 element_type: bool,
@@ -3369,7 +3369,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                         collection_kind: Optional {
                                                                                                                                             bound: Bounded,
                                                                                                                                             element_type: (bool , bool),
@@ -3377,7 +3377,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                     collection_kind: Singleton {
                                                                                                                                         bound: Bounded,
                                                                                                                                         element_type: (bool , bool),
@@ -3385,7 +3385,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                 collection_kind: Singleton {
                                                                                                                                     bound: Bounded,
                                                                                                                                     element_type: bool,
@@ -3393,7 +3393,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                             collection_kind: Singleton {
                                                                                                                                 bound: Bounded,
                                                                                                                                 element_type: bool,
@@ -3401,7 +3401,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                         collection_kind: Optional {
                                                                                                                             bound: Bounded,
                                                                                                                             element_type: bool,
@@ -3409,7 +3409,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                     collection_kind: Optional {
                                                                                                                         bound: Bounded,
                                                                                                                         element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool),
@@ -3417,7 +3417,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                 collection_kind: Optional {
                                                                                                                     bound: Bounded,
                                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -3425,7 +3425,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                             collection_kind: Stream {
                                                                                                                 bound: Bounded,
                                                                                                                 order: TotalOrder,
@@ -3445,7 +3445,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(Some(ClockId(10)), Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Bounded,
                                                                                                         order: TotalOrder,
@@ -3455,7 +3455,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(10, Cluster(loc1v1)),
+                                                                                                location_id: Tick(Some(ClockId(10)), Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
                                                                                                     order: TotalOrder,
@@ -3465,7 +3465,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(10, Cluster(loc1v1)),
+                                                                                            location_id: Tick(Some(ClockId(10)), Cluster(loc1v1)),
                                                                                             collection_kind: KeyedStream {
                                                                                                 bound: Bounded,
                                                                                                 value_order: TotalOrder,
@@ -3563,7 +3563,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(11, Cluster(loc3v1)),
+                                                    location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -3571,7 +3571,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(11, Cluster(loc3v1)),
+                                                location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -3579,7 +3579,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(11, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: (),
@@ -3587,7 +3587,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(11, Cluster(loc3v1)),
+                                        location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < () >,
@@ -3599,7 +3599,7 @@ expression: built.ir()
                                         value: :: std :: option :: Option :: None,
                                         first_tick_only: false,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(11, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < () >,
@@ -3607,7 +3607,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(11, Cluster(loc3v1)),
+                                        location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < () >,
@@ -3615,7 +3615,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(11, Cluster(loc3v1)),
+                                    location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < () >,
@@ -3623,7 +3623,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(11, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: core :: option :: Option < () >,
@@ -3631,7 +3631,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(11, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                             collection_kind: Singleton {
                                 bound: Bounded,
                                 element_type: bool,
@@ -3639,7 +3639,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(11, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: bool,
@@ -3647,7 +3647,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(11, Cluster(loc3v1)),
+                    location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: TotalOrder,
@@ -3657,7 +3657,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(11, Cluster(loc3v1)),
+                location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: TotalOrder,
@@ -3718,7 +3718,7 @@ expression: built.ir()
                                                                                             left: Tee {
                                                                                                 inner: <shared 15>,
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(11, Cluster(loc3v1)),
+                                                                                                    location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Bounded,
                                                                                                         order: TotalOrder,
@@ -3730,7 +3730,7 @@ expression: built.ir()
                                                                                             right: Tee {
                                                                                                 inner: <shared 17>,
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(11, Cluster(loc3v1)),
+                                                                                                    location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                                                                                                     collection_kind: Optional {
                                                                                                         bound: Bounded,
                                                                                                         element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
@@ -3738,7 +3738,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(11, Cluster(loc3v1)),
+                                                                                                location_id: Tick(Some(ClockId(11)), Cluster(loc3v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
                                                                                                     order: TotalOrder,
@@ -3821,7 +3821,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                 collection_kind: Stream {
                                                                     bound: Bounded,
                                                                     order: TotalOrder,
@@ -3835,7 +3835,7 @@ expression: built.ir()
                                                             input: Tee {
                                                                 inner: <shared 13>,
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                     collection_kind: Singleton {
                                                                         bound: Bounded,
                                                                         element_type: bool,
@@ -3843,7 +3843,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: bool,
@@ -3851,7 +3851,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                             collection_kind: Stream {
                                                                 bound: Bounded,
                                                                 order: TotalOrder,
@@ -3861,7 +3861,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                         collection_kind: Stream {
                                                             bound: Bounded,
                                                             order: TotalOrder,
@@ -3871,7 +3871,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                    location_id: Atomic(Tick(Some(ClockId(15)), Cluster(loc1v1))),
                                                     collection_kind: Stream {
                                                         bound: Unbounded,
                                                         order: TotalOrder,
@@ -3881,7 +3881,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: TotalOrder,
@@ -3891,7 +3891,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(15, Cluster(loc1v1)),
+                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -3934,7 +3934,7 @@ expression: built.ir()
                                                                                                                             inner: Tee {
                                                                                                                                 inner: <shared 14>,
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                     collection_kind: Optional {
                                                                                                                                         bound: Bounded,
                                                                                                                                         element_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
@@ -3942,7 +3942,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Bounded,
                                                                                                                                     order: TotalOrder,
@@ -3952,7 +3952,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                             collection_kind: Stream {
                                                                                                                                 bound: Bounded,
                                                                                                                                 order: NoOrder,
@@ -3962,7 +3962,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                         collection_kind: Stream {
                                                                                                                             bound: Bounded,
                                                                                                                             order: NoOrder,
@@ -3972,7 +3972,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                     collection_kind: Stream {
                                                                                                                         bound: Bounded,
                                                                                                                         order: NoOrder,
@@ -3982,7 +3982,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                 collection_kind: Stream {
                                                                                                                     bound: Bounded,
                                                                                                                     order: NoOrder,
@@ -3992,7 +3992,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                             collection_kind: KeyedStream {
                                                                                                                 bound: Bounded,
                                                                                                                 value_order: NoOrder,
@@ -4003,7 +4003,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                         collection_kind: KeyedSingleton {
                                                                                                             bound: Bounded,
                                                                                                             key_type: usize,
@@ -4012,7 +4012,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                     collection_kind: KeyedSingleton {
                                                                                                         bound: Bounded,
                                                                                                         key_type: usize,
@@ -4021,7 +4021,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                 collection_kind: KeyedSingleton {
                                                                                                     bound: Bounded,
                                                                                                     key_type: usize,
@@ -4030,7 +4030,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                             collection_kind: KeyedStream {
                                                                                                 bound: Bounded,
                                                                                                 value_order: TotalOrder,
@@ -4041,7 +4041,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                         collection_kind: Stream {
                                                                                             bound: Bounded,
                                                                                             order: NoOrder,
@@ -4051,7 +4051,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                     collection_kind: Stream {
                                                                                         bound: Bounded,
                                                                                         order: NoOrder,
@@ -4062,7 +4062,7 @@ expression: built.ir()
                                                                             },
                                                                             trusted: true,
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: TotalOrder,
@@ -4072,7 +4072,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                             collection_kind: Optional {
                                                                                 bound: Bounded,
                                                                                 element_type: usize,
@@ -4080,7 +4080,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: usize,
@@ -4088,7 +4088,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                                    location_id: Atomic(Tick(Some(ClockId(15)), Cluster(loc1v1))),
                                                                     collection_kind: Optional {
                                                                         bound: Unbounded,
                                                                         element_type: usize,
@@ -4096,7 +4096,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: usize,
@@ -4104,7 +4104,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: usize,
@@ -4120,7 +4120,7 @@ expression: built.ir()
                                                                             12,
                                                                         ),
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                             collection_kind: Singleton {
                                                                                 bound: Bounded,
                                                                                 element_type: usize,
@@ -4128,7 +4128,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: usize,
@@ -4140,7 +4140,7 @@ expression: built.ir()
                                                                         value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [0]) },
                                                                         first_tick_only: false,
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                             collection_kind: Singleton {
                                                                                 bound: Bounded,
                                                                                 element_type: usize,
@@ -4148,7 +4148,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: usize,
@@ -4156,7 +4156,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                     collection_kind: Optional {
                                                                         bound: Bounded,
                                                                         element_type: usize,
@@ -4164,7 +4164,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                 collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: usize,
@@ -4172,7 +4172,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: usize,
@@ -4180,7 +4180,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -4188,7 +4188,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -4196,7 +4196,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -4204,7 +4204,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(15, Cluster(loc1v1)),
+                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: usize,
@@ -4212,7 +4212,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(15, Cluster(loc1v1)),
+                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: TotalOrder,
@@ -4222,7 +4222,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(15, Cluster(loc1v1)),
+                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: TotalOrder,
@@ -4232,7 +4232,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(15, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: TotalOrder,
@@ -4242,7 +4242,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(15, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                             collection_kind: Singleton {
                                 bound: Bounded,
                                 element_type: usize,
@@ -4252,7 +4252,7 @@ expression: built.ir()
                     right: Tee {
                         inner: <shared 20>,
                         metadata: HydroIrMetadata {
-                            location_id: Tick(15, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                             collection_kind: Singleton {
                                 bound: Bounded,
                                 element_type: usize,
@@ -4260,7 +4260,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(15, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: (usize , usize),
@@ -4268,7 +4268,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(15, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                     collection_kind: Singleton {
                         bound: Bounded,
                         element_type: (usize , usize),
@@ -4276,7 +4276,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(15, Cluster(loc1v1)),
+                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: usize,
@@ -4298,7 +4298,7 @@ expression: built.ir()
                                 13,
                             ),
                             metadata: HydroIrMetadata {
-                                location_id: Tick(14, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: NoOrder,
@@ -4308,7 +4308,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(14, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -4427,7 +4427,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                                    location_id: Tick(Some(ClockId(13)), Cluster(loc1v1)),
                                                                                                                     collection_kind: KeyedSingleton {
                                                                                                                         bound: Bounded,
                                                                                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -4436,7 +4436,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                                location_id: Tick(Some(ClockId(13)), Cluster(loc1v1)),
                                                                                                                 collection_kind: KeyedSingleton {
                                                                                                                     bound: Bounded,
                                                                                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -4445,7 +4445,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                            location_id: Tick(Some(ClockId(13)), Cluster(loc1v1)),
                                                                                                             collection_kind: KeyedStream {
                                                                                                                 bound: Bounded,
                                                                                                                 value_order: TotalOrder,
@@ -4456,7 +4456,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                        location_id: Tick(Some(ClockId(13)), Cluster(loc1v1)),
                                                                                                         collection_kind: Stream {
                                                                                                             bound: Bounded,
                                                                                                             order: NoOrder,
@@ -4466,7 +4466,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                    location_id: Tick(Some(ClockId(13)), Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Bounded,
                                                                                                         order: NoOrder,
@@ -4477,7 +4477,7 @@ expression: built.ir()
                                                                                             },
                                                                                             trusted: true,
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                location_id: Tick(Some(ClockId(13)), Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
                                                                                                     order: TotalOrder,
@@ -4504,7 +4504,7 @@ expression: built.ir()
                                                                                                                                         inner: Tee {
                                                                                                                                             inner: <shared 19>,
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     order: TotalOrder,
@@ -4514,7 +4514,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                                                                                                            location_id: Atomic(Tick(Some(ClockId(15)), Cluster(loc1v1))),
                                                                                                                                             collection_kind: Stream {
                                                                                                                                                 bound: Unbounded,
                                                                                                                                                 order: TotalOrder,
@@ -4524,7 +4524,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                         collection_kind: Stream {
                                                                                                                                             bound: Bounded,
                                                                                                                                             order: TotalOrder,
@@ -4537,7 +4537,7 @@ expression: built.ir()
                                                                                                                                     inner: Tee {
                                                                                                                                         inner: <shared 4>,
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                             collection_kind: Singleton {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -4545,7 +4545,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                         collection_kind: Optional {
                                                                                                                                             bound: Bounded,
                                                                                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -4553,7 +4553,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                     collection_kind: Stream {
                                                                                                                                         bound: Bounded,
                                                                                                                                         order: TotalOrder,
@@ -4563,7 +4563,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Bounded,
                                                                                                                                     order: TotalOrder,
@@ -4582,7 +4582,7 @@ expression: built.ir()
                                                                                                                                                 inner: Tee {
                                                                                                                                                     inner: <shared 22>,
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                         collection_kind: KeyedSingleton {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             key_type: usize,
@@ -4591,7 +4591,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                     collection_kind: KeyedStream {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         value_order: TotalOrder,
@@ -4602,7 +4602,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     order: NoOrder,
@@ -4615,7 +4615,7 @@ expression: built.ir()
                                                                                                                                             inner: Tee {
                                                                                                                                                 inner: <shared 4>,
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Singleton {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -4623,7 +4623,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Optional {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -4631,7 +4631,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                             collection_kind: Stream {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 order: NoOrder,
@@ -4654,7 +4654,7 @@ expression: built.ir()
                                                                                                                                                                     input: Tee {
                                                                                                                                                                         inner: <shared 23>,
                                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                             collection_kind: Stream {
                                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                                 order: NoOrder,
@@ -4664,7 +4664,7 @@ expression: built.ir()
                                                                                                                                                                         },
                                                                                                                                                                     },
                                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                         collection_kind: Stream {
                                                                                                                                                                             bound: Bounded,
                                                                                                                                                                             order: NoOrder,
@@ -4675,7 +4675,7 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                                 trusted: true,
                                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                     collection_kind: Stream {
                                                                                                                                                                         bound: Bounded,
                                                                                                                                                                         order: TotalOrder,
@@ -4685,7 +4685,7 @@ expression: built.ir()
                                                                                                                                                                 },
                                                                                                                                                             },
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: Optional {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: usize,
@@ -4693,7 +4693,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: core :: option :: Option < usize >,
@@ -4705,7 +4705,7 @@ expression: built.ir()
                                                                                                                                                             value: :: std :: option :: Option :: None,
                                                                                                                                                             first_tick_only: false,
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: Singleton {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: core :: option :: Option < usize >,
@@ -4713,7 +4713,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: core :: option :: Option < usize >,
@@ -4721,7 +4721,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Optional {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             element_type: core :: option :: Option < usize >,
@@ -4729,7 +4729,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Singleton {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         element_type: core :: option :: Option < usize >,
@@ -4737,7 +4737,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Singleton {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     element_type: core :: option :: Option < usize >,
@@ -4745,7 +4745,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                             collection_kind: Optional {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 element_type: core :: option :: Option < usize >,
@@ -4753,7 +4753,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                         collection_kind: Stream {
                                                                                                                                             bound: Bounded,
                                                                                                                                             order: NoOrder,
@@ -4763,7 +4763,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                     collection_kind: Stream {
                                                                                                                                         bound: Bounded,
                                                                                                                                         order: NoOrder,
@@ -4783,7 +4783,7 @@ expression: built.ir()
                                                                                                                                                     left: Tee {
                                                                                                                                                         inner: <shared 21>,
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: usize,
@@ -4794,7 +4794,7 @@ expression: built.ir()
                                                                                                                                                         inner: Tee {
                                                                                                                                                             inner: <shared 28>,
                                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                                 collection_kind: Singleton {
                                                                                                                                                                     bound: Bounded,
                                                                                                                                                                     element_type: core :: option :: Option < usize >,
@@ -4802,7 +4802,7 @@ expression: built.ir()
                                                                                                                                                             },
                                                                                                                                                         },
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                             collection_kind: Optional {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 element_type: core :: option :: Option < usize >,
@@ -4810,7 +4810,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Optional {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             element_type: (usize , core :: option :: Option < usize >),
@@ -4818,7 +4818,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Stream {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         order: TotalOrder,
@@ -4828,7 +4828,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     order: TotalOrder,
@@ -4844,7 +4844,7 @@ expression: built.ir()
                                                                                                                                                     inner: Tee {
                                                                                                                                                         inner: <shared 22>,
                                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                             collection_kind: KeyedSingleton {
                                                                                                                                                                 bound: Bounded,
                                                                                                                                                                 key_type: usize,
@@ -4853,7 +4853,7 @@ expression: built.ir()
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                         collection_kind: KeyedStream {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             value_order: TotalOrder,
@@ -4864,7 +4864,7 @@ expression: built.ir()
                                                                                                                                                     },
                                                                                                                                                 },
                                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                     collection_kind: Stream {
                                                                                                                                                         bound: Bounded,
                                                                                                                                                         order: NoOrder,
@@ -4874,7 +4874,7 @@ expression: built.ir()
                                                                                                                                                 },
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Stream {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     order: NoOrder,
@@ -4884,7 +4884,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                             collection_kind: Stream {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 order: TotalOrder,
@@ -4897,7 +4897,7 @@ expression: built.ir()
                                                                                                                                         inner: Tee {
                                                                                                                                             inner: <shared 4>,
                                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                                 collection_kind: Singleton {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -4905,7 +4905,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                             collection_kind: Optional {
                                                                                                                                                 bound: Bounded,
                                                                                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -4913,7 +4913,7 @@ expression: built.ir()
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                         collection_kind: Stream {
                                                                                                                                             bound: Bounded,
                                                                                                                                             order: TotalOrder,
@@ -4923,7 +4923,7 @@ expression: built.ir()
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                     collection_kind: Stream {
                                                                                                                                         bound: Bounded,
                                                                                                                                         order: TotalOrder,
@@ -4933,7 +4933,7 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                 collection_kind: Stream {
                                                                                                                                     bound: Bounded,
                                                                                                                                     order: NoOrder,
@@ -4943,7 +4943,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                             collection_kind: Stream {
                                                                                                                                 bound: Bounded,
                                                                                                                                 order: NoOrder,
@@ -4957,7 +4957,7 @@ expression: built.ir()
                                                                                                                         input: Tee {
                                                                                                                             inner: <shared 13>,
                                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                                 collection_kind: Singleton {
                                                                                                                                     bound: Bounded,
                                                                                                                                     element_type: bool,
@@ -4965,7 +4965,7 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                             collection_kind: Optional {
                                                                                                                                 bound: Bounded,
                                                                                                                                 element_type: bool,
@@ -4973,7 +4973,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                         collection_kind: Stream {
                                                                                                                             bound: Bounded,
                                                                                                                             order: NoOrder,
@@ -4983,7 +4983,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                                     collection_kind: Stream {
                                                                                                                         bound: Bounded,
                                                                                                                         order: NoOrder,
@@ -4993,7 +4993,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                                                                                location_id: Atomic(Tick(Some(ClockId(15)), Cluster(loc1v1))),
                                                                                                                 collection_kind: Stream {
                                                                                                                     bound: Unbounded,
                                                                                                                     order: NoOrder,
@@ -5003,7 +5003,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                                                                                            location_id: Atomic(Tick(Some(ClockId(15)), Cluster(loc1v1))),
                                                                                                             collection_kind: Stream {
                                                                                                                 bound: Unbounded,
                                                                                                                 order: NoOrder,
@@ -5033,7 +5033,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(13, Cluster(loc1v1)),
+                                                                                                location_id: Tick(Some(ClockId(13)), Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
                                                                                                     order: NoOrder,
@@ -5043,7 +5043,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(13, Cluster(loc1v1)),
+                                                                                            location_id: Tick(Some(ClockId(13)), Cluster(loc1v1)),
                                                                                             collection_kind: Stream {
                                                                                                 bound: Bounded,
                                                                                                 order: NoOrder,
@@ -5053,7 +5053,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(13, Cluster(loc1v1)),
+                                                                                        location_id: Tick(Some(ClockId(13)), Cluster(loc1v1)),
                                                                                         collection_kind: KeyedStream {
                                                                                             bound: Bounded,
                                                                                             value_order: NoOrder,
@@ -5106,7 +5106,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
+                                                                    location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: NoOrder,
@@ -5116,7 +5116,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(2, Cluster(loc2v1)),
+                                                                location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                 collection_kind: Stream {
                                                                     bound: Bounded,
                                                                     order: NoOrder,
@@ -5129,7 +5129,7 @@ expression: built.ir()
                                                             inner: Tee {
                                                                 inner: <shared 10>,
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
+                                                                    location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                     collection_kind: Singleton {
                                                                         bound: Bounded,
                                                                         element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -5137,7 +5137,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(2, Cluster(loc2v1)),
+                                                                location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -5145,7 +5145,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(2, Cluster(loc2v1)),
+                                                            location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                             collection_kind: Stream {
                                                                 bound: Bounded,
                                                                 order: NoOrder,
@@ -5155,7 +5155,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(2, Cluster(loc2v1)),
+                                                        location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                         collection_kind: Stream {
                                                             bound: Bounded,
                                                             order: NoOrder,
@@ -5227,7 +5227,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(14, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -5237,7 +5237,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(14, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -5247,7 +5247,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(14, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -5271,7 +5271,7 @@ expression: built.ir()
                                             inner: Tee {
                                                 inner: <shared 24>,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(14, Cluster(loc1v1)),
+                                                    location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: NoOrder,
@@ -5281,7 +5281,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(14, Cluster(loc1v1)),
+                                                location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                                                 collection_kind: KeyedStream {
                                                     bound: Bounded,
                                                     value_order: NoOrder,
@@ -5292,7 +5292,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(14, Cluster(loc1v1)),
+                                            location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                                             collection_kind: KeyedSingleton {
                                                 bound: Bounded,
                                                 key_type: (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -5301,7 +5301,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(14, Cluster(loc1v1)),
+                                        location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                                         collection_kind: KeyedSingleton {
                                             bound: Bounded,
                                             key_type: (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -5310,7 +5310,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(14, Cluster(loc1v1)),
+                                    location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
                                         bound: Bounded,
                                         key_type: (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -5319,7 +5319,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(14, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                                 collection_kind: KeyedStream {
                                     bound: Bounded,
                                     value_order: TotalOrder,
@@ -5330,7 +5330,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(14, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -5340,7 +5340,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(14, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -5350,7 +5350,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(14, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -5360,7 +5360,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(14, Cluster(loc1v1)),
+                location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -5384,7 +5384,7 @@ expression: built.ir()
                             inner: Tee {
                                 inner: <shared 30>,
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(14, Cluster(loc1v1)),
+                                    location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                                     collection_kind: KeyedSingleton {
                                         bound: Bounded,
                                         key_type: (usize , hydro_test :: __staged :: cluster :: paxos :: Ballot),
@@ -5393,7 +5393,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(14, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                                 collection_kind: KeyedStream {
                                     bound: Bounded,
                                     value_order: TotalOrder,
@@ -5404,7 +5404,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(14, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -5414,7 +5414,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(14, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -5424,7 +5424,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(14, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -5436,7 +5436,7 @@ expression: built.ir()
             neg: Tee {
                 inner: <shared 29>,
                 metadata: HydroIrMetadata {
-                    location_id: Tick(14, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -5446,7 +5446,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(14, Cluster(loc1v1)),
+                location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -5470,7 +5470,7 @@ expression: built.ir()
                                 15,
                             ),
                             metadata: HydroIrMetadata {
-                                location_id: Tick(15, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: NoOrder,
@@ -5480,7 +5480,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(15, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -5495,7 +5495,7 @@ expression: built.ir()
                                 inner: Tee {
                                     inner: <shared 27>,
                                     metadata: HydroIrMetadata {
-                                        location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                        location_id: Atomic(Tick(Some(ClockId(15)), Cluster(loc1v1))),
                                         collection_kind: Stream {
                                             bound: Unbounded,
                                             order: NoOrder,
@@ -5505,7 +5505,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(15, Cluster(loc1v1)),
+                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: NoOrder,
@@ -5515,7 +5515,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Atomic(Tick(15, Cluster(loc1v1))),
+                                location_id: Atomic(Tick(Some(ClockId(15)), Cluster(loc1v1))),
                                 collection_kind: Stream {
                                     bound: Unbounded,
                                     order: NoOrder,
@@ -5525,7 +5525,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(15, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -5535,7 +5535,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(15, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -5545,7 +5545,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(15, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -5565,7 +5565,7 @@ expression: built.ir()
                                     pos: Tee {
                                         inner: <shared 31>,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(14, Cluster(loc1v1)),
+                                            location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: NoOrder,
@@ -5580,7 +5580,7 @@ expression: built.ir()
                                                 14,
                                             ),
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(14, Cluster(loc1v1)),
+                                                location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: NoOrder,
@@ -5590,7 +5590,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(14, Cluster(loc1v1)),
+                                            location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: NoOrder,
@@ -5600,7 +5600,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(14, Cluster(loc1v1)),
+                                        location_id: Tick(Some(ClockId(14)), Cluster(loc1v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: NoOrder,
@@ -5630,7 +5630,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(15, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -5640,7 +5640,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(15, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -5650,7 +5650,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(15, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -5660,7 +5660,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(15, Cluster(loc1v1)),
+                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -5698,7 +5698,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(2, Cluster(loc2v1)),
+                                                location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -5706,7 +5706,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(2, Cluster(loc2v1)),
+                                            location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: usize,
@@ -5714,7 +5714,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(2, Cluster(loc2v1)),
+                                        location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < usize >,
@@ -5726,7 +5726,7 @@ expression: built.ir()
                                         value: :: std :: option :: Option :: None,
                                         first_tick_only: false,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(2, Cluster(loc2v1)),
+                                            location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < usize >,
@@ -5734,7 +5734,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(2, Cluster(loc2v1)),
+                                        location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < usize >,
@@ -5742,7 +5742,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(2, Cluster(loc2v1)),
+                                    location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < usize >,
@@ -5750,7 +5750,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(2, Cluster(loc2v1)),
+                                location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: core :: option :: Option < usize >,
@@ -5774,7 +5774,7 @@ expression: built.ir()
                                                                 left: Tee {
                                                                     inner: <shared 26>,
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
+                                                                        location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: NoOrder,
@@ -5787,7 +5787,7 @@ expression: built.ir()
                                                                     inner: Tee {
                                                                         inner: <shared 10>,
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(2, Cluster(loc2v1)),
+                                                                            location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                             collection_kind: Singleton {
                                                                                 bound: Bounded,
                                                                                 element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -5795,7 +5795,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(2, Cluster(loc2v1)),
+                                                                        location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
@@ -5803,7 +5803,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(2, Cluster(loc2v1)),
+                                                                    location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: NoOrder,
@@ -5813,7 +5813,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(2, Cluster(loc2v1)),
+                                                                location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                                 collection_kind: Stream {
                                                                     bound: Bounded,
                                                                     order: NoOrder,
@@ -5823,7 +5823,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Atomic(Tick(2, Cluster(loc2v1))),
+                                                            location_id: Atomic(Tick(Some(ClockId(2)), Cluster(loc2v1))),
                                                             collection_kind: Stream {
                                                                 bound: Unbounded,
                                                                 order: NoOrder,
@@ -5833,7 +5833,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Atomic(Tick(2, Cluster(loc2v1))),
+                                                        location_id: Atomic(Tick(Some(ClockId(2)), Cluster(loc2v1))),
                                                         collection_kind: KeyedStream {
                                                             bound: Unbounded,
                                                             value_order: NoOrder,
@@ -5845,7 +5845,7 @@ expression: built.ir()
                                                 },
                                                 trusted: false,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Atomic(Tick(2, Cluster(loc2v1))),
+                                                    location_id: Atomic(Tick(Some(ClockId(2)), Cluster(loc2v1))),
                                                     collection_kind: KeyedStream {
                                                         bound: Unbounded,
                                                         value_order: TotalOrder,
@@ -5858,7 +5858,7 @@ expression: built.ir()
                                             watermark: Tee {
                                                 inner: <shared 34>,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(2, Cluster(loc2v1)),
+                                                    location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -5866,7 +5866,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Atomic(Tick(2, Cluster(loc2v1))),
+                                                location_id: Atomic(Tick(Some(ClockId(2)), Cluster(loc2v1))),
                                                 collection_kind: KeyedSingleton {
                                                     bound: Unbounded,
                                                     key_type: usize,
@@ -5875,7 +5875,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(2, Cluster(loc2v1)),
+                                            location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                             collection_kind: KeyedSingleton {
                                                 bound: Bounded,
                                                 key_type: usize,
@@ -5884,7 +5884,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(2, Cluster(loc2v1)),
+                                        location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                         collection_kind: KeyedStream {
                                             bound: Bounded,
                                             value_order: TotalOrder,
@@ -5895,7 +5895,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(2, Cluster(loc2v1)),
+                                    location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: NoOrder,
@@ -5905,7 +5905,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(2, Cluster(loc2v1)),
+                                location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >,
@@ -5913,7 +5913,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(2, Cluster(loc2v1)),
+                            location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
@@ -5921,7 +5921,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(2, Cluster(loc2v1)),
+                        location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                         collection_kind: Singleton {
                             bound: Bounded,
                             element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
@@ -5929,7 +5929,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Atomic(Tick(2, Cluster(loc2v1))),
+                    location_id: Atomic(Tick(Some(ClockId(2)), Cluster(loc2v1))),
                     collection_kind: Singleton {
                         bound: Unbounded,
                         element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
@@ -5937,7 +5937,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(2, Cluster(loc2v1)),
+                location_id: Tick(Some(ClockId(2)), Cluster(loc2v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
@@ -5997,7 +5997,7 @@ expression: built.ir()
                         left: Tee {
                             inner: <shared 4>,
                             metadata: HydroIrMetadata {
-                                location_id: Tick(15, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -6009,7 +6009,7 @@ expression: built.ir()
                             input: Tee {
                                 inner: <shared 18>,
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(15, Cluster(loc1v1)),
+                                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: bool,
@@ -6017,7 +6017,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(15, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: bool,
@@ -6025,7 +6025,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(15, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool),
@@ -6033,7 +6033,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(15, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -6041,7 +6041,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(15, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: TotalOrder,
@@ -6161,7 +6161,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(16, Cluster(loc1v1)),
+                                                                                                location_id: Tick(Some(ClockId(16)), Cluster(loc1v1)),
                                                                                                 collection_kind: KeyedSingleton {
                                                                                                     bound: Bounded,
                                                                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica >,
@@ -6170,7 +6170,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(16, Cluster(loc1v1)),
+                                                                                            location_id: Tick(Some(ClockId(16)), Cluster(loc1v1)),
                                                                                             collection_kind: KeyedSingleton {
                                                                                                 bound: Bounded,
                                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica >,
@@ -6179,7 +6179,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(16, Cluster(loc1v1)),
+                                                                                        location_id: Tick(Some(ClockId(16)), Cluster(loc1v1)),
                                                                                         collection_kind: KeyedStream {
                                                                                             bound: Bounded,
                                                                                             value_order: TotalOrder,
@@ -6190,7 +6190,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(16, Cluster(loc1v1)),
+                                                                                    location_id: Tick(Some(ClockId(16)), Cluster(loc1v1)),
                                                                                     collection_kind: Stream {
                                                                                         bound: Bounded,
                                                                                         order: NoOrder,
@@ -6200,7 +6200,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(16, Cluster(loc1v1)),
+                                                                                location_id: Tick(Some(ClockId(16)), Cluster(loc1v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: NoOrder,
@@ -6211,7 +6211,7 @@ expression: built.ir()
                                                                         },
                                                                         trusted: true,
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(16, Cluster(loc1v1)),
+                                                                            location_id: Tick(Some(ClockId(16)), Cluster(loc1v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: TotalOrder,
@@ -6230,7 +6230,7 @@ expression: built.ir()
                                                                                         left: Tee {
                                                                                             inner: <shared 32>,
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
                                                                                                     order: NoOrder,
@@ -6242,7 +6242,7 @@ expression: built.ir()
                                                                                         right: Tee {
                                                                                             inner: <shared 33>,
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                                 collection_kind: Stream {
                                                                                                     bound: Bounded,
                                                                                                     order: NoOrder,
@@ -6252,7 +6252,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                            location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                             collection_kind: Stream {
                                                                                                 bound: Bounded,
                                                                                                 order: NoOrder,
@@ -6262,7 +6262,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                        location_id: Tick(Some(ClockId(15)), Cluster(loc1v1)),
                                                                                         collection_kind: Stream {
                                                                                             bound: Bounded,
                                                                                             order: NoOrder,
@@ -6292,7 +6292,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(16, Cluster(loc1v1)),
+                                                                            location_id: Tick(Some(ClockId(16)), Cluster(loc1v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: NoOrder,
@@ -6302,7 +6302,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(16, Cluster(loc1v1)),
+                                                                        location_id: Tick(Some(ClockId(16)), Cluster(loc1v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: NoOrder,
@@ -6312,7 +6312,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(16, Cluster(loc1v1)),
+                                                                    location_id: Tick(Some(ClockId(16)), Cluster(loc1v1)),
                                                                     collection_kind: KeyedStream {
                                                                         bound: Bounded,
                                                                         value_order: NoOrder,
@@ -6385,7 +6385,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(17, Cluster(loc5v1)),
+                                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: NoOrder,
@@ -6400,7 +6400,7 @@ expression: built.ir()
                                             16,
                                         ),
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(17, Cluster(loc5v1)),
+                                            location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -6410,7 +6410,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(17, Cluster(loc5v1)),
+                                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: TotalOrder,
@@ -6420,7 +6420,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(17, Cluster(loc5v1)),
+                                    location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: NoOrder,
@@ -6430,7 +6430,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(17, Cluster(loc5v1)),
+                                location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: TotalOrder,
@@ -6440,7 +6440,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(17, Cluster(loc5v1)),
+                            location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: TotalOrder,
@@ -6458,7 +6458,7 @@ expression: built.ir()
                                     left: Tee {
                                         inner: <shared 35>,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(17, Cluster(loc5v1)),
+                                            location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -6476,7 +6476,7 @@ expression: built.ir()
                                                             17,
                                                         ),
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(17, Cluster(loc5v1)),
+                                                            location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: usize,
@@ -6484,7 +6484,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(17, Cluster(loc5v1)),
+                                                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -6496,7 +6496,7 @@ expression: built.ir()
                                                         value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: sequence_payloads :: * ; crate :: __staged :: __stageleft_quote_src_cluster_kv_replica_sequence_payloads_rs_LINE_COL ! ([] [0]) },
                                                         first_tick_only: false,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(17, Cluster(loc5v1)),
+                                                            location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: usize,
@@ -6504,7 +6504,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(17, Cluster(loc5v1)),
+                                                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -6512,7 +6512,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(17, Cluster(loc5v1)),
+                                                    location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -6520,7 +6520,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(17, Cluster(loc5v1)),
+                                                location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -6528,7 +6528,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(17, Cluster(loc5v1)),
+                                            location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: usize,
@@ -6536,7 +6536,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(17, Cluster(loc5v1)),
+                                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: TotalOrder,
@@ -6546,7 +6546,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(17, Cluster(loc5v1)),
+                                    location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: usize,
@@ -6554,7 +6554,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(17, Cluster(loc5v1)),
+                                location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: usize,
@@ -6562,7 +6562,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(17, Cluster(loc5v1)),
+                            location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: usize,
@@ -6570,7 +6570,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(17, Cluster(loc5v1)),
+                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,
@@ -6580,7 +6580,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(17, Cluster(loc5v1)),
+                    location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: TotalOrder,
@@ -6590,7 +6590,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(17, Cluster(loc5v1)),
+                location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: TotalOrder,
@@ -6622,7 +6622,7 @@ expression: built.ir()
                                             left: Tee {
                                                 inner: <shared 35>,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(17, Cluster(loc5v1)),
+                                                    location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: TotalOrder,
@@ -6635,7 +6635,7 @@ expression: built.ir()
                                                 inner: Tee {
                                                     inner: <shared 36>,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(17, Cluster(loc5v1)),
+                                                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                         collection_kind: Singleton {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -6643,7 +6643,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(17, Cluster(loc5v1)),
+                                                    location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -6651,7 +6651,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(17, Cluster(loc5v1)),
+                                                location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: TotalOrder,
@@ -6661,7 +6661,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(17, Cluster(loc5v1)),
+                                            location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: TotalOrder,
@@ -6671,7 +6671,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(17, Cluster(loc5v1)),
+                                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: TotalOrder,
@@ -6681,7 +6681,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(17, Cluster(loc5v1)),
+                                    location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: TotalOrder,
@@ -6691,7 +6691,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Atomic(Tick(17, Cluster(loc5v1))),
+                                location_id: Atomic(Tick(Some(ClockId(17)), Cluster(loc5v1))),
                                 collection_kind: Stream {
                                     bound: Unbounded,
                                     order: TotalOrder,
@@ -6701,7 +6701,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Atomic(Tick(17, Cluster(loc5v1))),
+                            location_id: Atomic(Tick(Some(ClockId(17)), Cluster(loc5v1))),
                             collection_kind: Singleton {
                                 bound: Unbounded,
                                 element_type: (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize),
@@ -6709,7 +6709,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(17, Cluster(loc5v1)),
+                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                         collection_kind: Singleton {
                             bound: Bounded,
                             element_type: (std :: collections :: hash_map :: HashMap < u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32) > , usize),
@@ -6717,7 +6717,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(17, Cluster(loc5v1)),
+                    location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                     collection_kind: Singleton {
                         bound: Bounded,
                         element_type: usize,
@@ -6725,7 +6725,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(17, Cluster(loc5v1)),
+                location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: usize,
@@ -6758,7 +6758,7 @@ expression: built.ir()
                                                                 18,
                                                             ),
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(17, Cluster(loc5v1)),
+                                                                location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: usize,
@@ -6766,7 +6766,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(17, Cluster(loc5v1)),
+                                                            location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: usize,
@@ -6774,7 +6774,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(17, Cluster(loc5v1)),
+                                                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                         collection_kind: Stream {
                                                             bound: Bounded,
                                                             order: TotalOrder,
@@ -6784,7 +6784,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Atomic(Tick(17, Cluster(loc5v1))),
+                                                    location_id: Atomic(Tick(Some(ClockId(17)), Cluster(loc5v1))),
                                                     collection_kind: Stream {
                                                         bound: Unbounded,
                                                         order: TotalOrder,
@@ -6794,7 +6794,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Atomic(Tick(17, Cluster(loc5v1))),
+                                                location_id: Atomic(Tick(Some(ClockId(17)), Cluster(loc5v1))),
                                                 collection_kind: Optional {
                                                     bound: InitNone,
                                                     element_type: usize,
@@ -6802,7 +6802,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(17, Cluster(loc5v1)),
+                                            location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: usize,
@@ -6810,7 +6810,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(17, Cluster(loc5v1)),
+                                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < usize >,
@@ -6822,7 +6822,7 @@ expression: built.ir()
                                         value: :: std :: option :: Option :: None,
                                         first_tick_only: false,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(17, Cluster(loc5v1)),
+                                            location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < usize >,
@@ -6830,7 +6830,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(17, Cluster(loc5v1)),
+                                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < usize >,
@@ -6838,7 +6838,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(17, Cluster(loc5v1)),
+                                    location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < usize >,
@@ -6846,7 +6846,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(17, Cluster(loc5v1)),
+                                location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: core :: option :: Option < usize >,
@@ -6860,7 +6860,7 @@ expression: built.ir()
                                         inner: Tee {
                                             inner: <shared 37>,
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(17, Cluster(loc5v1)),
+                                                location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -6868,7 +6868,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(17, Cluster(loc5v1)),
+                                            location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: usize,
@@ -6876,7 +6876,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(17, Cluster(loc5v1)),
+                                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: usize,
@@ -6888,7 +6888,7 @@ expression: built.ir()
                                         value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: kv_replica :: * ; crate :: __staged :: __stageleft_quote_src_cluster_kv_replica_mod_rs_LINE_COL ! ([] [0]) },
                                         first_tick_only: false,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(17, Cluster(loc5v1)),
+                                            location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: usize,
@@ -6896,7 +6896,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(17, Cluster(loc5v1)),
+                                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: usize,
@@ -6904,7 +6904,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(17, Cluster(loc5v1)),
+                                    location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: usize,
@@ -6912,7 +6912,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(17, Cluster(loc5v1)),
+                                location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: usize,
@@ -6920,7 +6920,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(17, Cluster(loc5v1)),
+                            location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (core :: option :: Option < usize > , usize),
@@ -6928,7 +6928,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(17, Cluster(loc5v1)),
+                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                         collection_kind: Singleton {
                             bound: Bounded,
                             element_type: (core :: option :: Option < usize > , usize),
@@ -6936,7 +6936,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(17, Cluster(loc5v1)),
+                    location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                     collection_kind: Optional {
                         bound: Bounded,
                         element_type: usize,
@@ -6944,7 +6944,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(17, Cluster(loc5v1)),
+                location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                 collection_kind: Optional {
                     bound: Bounded,
                     element_type: usize,
@@ -7051,7 +7051,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(18, Cluster(loc5v1)),
+                                                                                                location_id: Tick(Some(ClockId(18)), Cluster(loc5v1)),
                                                                                                 collection_kind: KeyedSingleton {
                                                                                                     bound: Bounded,
                                                                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -7060,7 +7060,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(18, Cluster(loc5v1)),
+                                                                                            location_id: Tick(Some(ClockId(18)), Cluster(loc5v1)),
                                                                                             collection_kind: KeyedSingleton {
                                                                                                 bound: Bounded,
                                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Acceptor >,
@@ -7069,7 +7069,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(18, Cluster(loc5v1)),
+                                                                                        location_id: Tick(Some(ClockId(18)), Cluster(loc5v1)),
                                                                                         collection_kind: KeyedStream {
                                                                                             bound: Bounded,
                                                                                             value_order: TotalOrder,
@@ -7080,7 +7080,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(18, Cluster(loc5v1)),
+                                                                                    location_id: Tick(Some(ClockId(18)), Cluster(loc5v1)),
                                                                                     collection_kind: Stream {
                                                                                         bound: Bounded,
                                                                                         order: NoOrder,
@@ -7090,7 +7090,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(18, Cluster(loc5v1)),
+                                                                                location_id: Tick(Some(ClockId(18)), Cluster(loc5v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: NoOrder,
@@ -7101,7 +7101,7 @@ expression: built.ir()
                                                                         },
                                                                         trusted: true,
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(18, Cluster(loc5v1)),
+                                                                            location_id: Tick(Some(ClockId(18)), Cluster(loc5v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: TotalOrder,
@@ -7116,7 +7116,7 @@ expression: built.ir()
                                                                                 inner: Tee {
                                                                                     inner: <shared 39>,
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(17, Cluster(loc5v1)),
+                                                                                        location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                                                         collection_kind: Optional {
                                                                                             bound: Bounded,
                                                                                             element_type: usize,
@@ -7124,7 +7124,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(17, Cluster(loc5v1)),
+                                                                                    location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                                                     collection_kind: Stream {
                                                                                         bound: Bounded,
                                                                                         order: TotalOrder,
@@ -7144,7 +7144,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(18, Cluster(loc5v1)),
+                                                                            location_id: Tick(Some(ClockId(18)), Cluster(loc5v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: TotalOrder,
@@ -7154,7 +7154,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(18, Cluster(loc5v1)),
+                                                                        location_id: Tick(Some(ClockId(18)), Cluster(loc5v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: TotalOrder,
@@ -7164,7 +7164,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(18, Cluster(loc5v1)),
+                                                                    location_id: Tick(Some(ClockId(18)), Cluster(loc5v1)),
                                                                     collection_kind: KeyedStream {
                                                                         bound: Bounded,
                                                                         value_order: TotalOrder,
@@ -7206,7 +7206,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(19, Cluster(loc2v1)),
+                                                    location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                                                     collection_kind: KeyedSingleton {
                                                         bound: Bounded,
                                                         key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica >,
@@ -7215,7 +7215,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(19, Cluster(loc2v1)),
+                                                location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                                                 collection_kind: KeyedSingleton {
                                                     bound: Bounded,
                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica >,
@@ -7224,7 +7224,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(19, Cluster(loc2v1)),
+                                            location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                                             collection_kind: KeyedStream {
                                                 bound: Bounded,
                                                 value_order: TotalOrder,
@@ -7235,7 +7235,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(19, Cluster(loc2v1)),
+                                        location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: NoOrder,
@@ -7257,7 +7257,7 @@ expression: built.ir()
                                                         inner: Tee {
                                                             inner: <shared 40>,
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(19, Cluster(loc2v1)),
+                                                                location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                                                                 collection_kind: KeyedSingleton {
                                                                     bound: Bounded,
                                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: kv_replica :: Replica >,
@@ -7266,7 +7266,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(19, Cluster(loc2v1)),
+                                                            location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                                                             collection_kind: KeyedStream {
                                                                 bound: Bounded,
                                                                 value_order: TotalOrder,
@@ -7277,7 +7277,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(19, Cluster(loc2v1)),
+                                                        location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                                                         collection_kind: Stream {
                                                             bound: Bounded,
                                                             order: NoOrder,
@@ -7288,7 +7288,7 @@ expression: built.ir()
                                                 },
                                                 trusted: true,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(19, Cluster(loc2v1)),
+                                                    location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: TotalOrder,
@@ -7298,7 +7298,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(19, Cluster(loc2v1)),
+                                                location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -7306,7 +7306,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(19, Cluster(loc2v1)),
+                                            location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: bool,
@@ -7314,7 +7314,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(19, Cluster(loc2v1)),
+                                        location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: bool,
@@ -7322,7 +7322,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(19, Cluster(loc2v1)),
+                                    location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: NoOrder,
@@ -7332,7 +7332,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(19, Cluster(loc2v1)),
+                                location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: NoOrder,
@@ -7342,7 +7342,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(19, Cluster(loc2v1)),
+                            location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -7353,7 +7353,7 @@ expression: built.ir()
                     },
                     trusted: true,
                     metadata: HydroIrMetadata {
-                        location_id: Tick(19, Cluster(loc2v1)),
+                        location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,
@@ -7363,7 +7363,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(19, Cluster(loc2v1)),
+                    location_id: Tick(Some(ClockId(19)), Cluster(loc2v1)),
                     collection_kind: Optional {
                         bound: Bounded,
                         element_type: usize,
@@ -7393,7 +7393,7 @@ expression: built.ir()
                                 19,
                             ),
                             metadata: HydroIrMetadata {
-                                location_id: Tick(20, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: NoOrder,
@@ -7403,7 +7403,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(20, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -7442,7 +7442,7 @@ expression: built.ir()
                                                         input: Tee {
                                                             inner: <shared 38>,
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(17, Cluster(loc5v1)),
+                                                                location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                                 collection_kind: Stream {
                                                                     bound: Bounded,
                                                                     order: TotalOrder,
@@ -7452,7 +7452,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(17, Cluster(loc5v1)),
+                                                            location_id: Tick(Some(ClockId(17)), Cluster(loc5v1)),
                                                             collection_kind: Stream {
                                                                 bound: Bounded,
                                                                 order: TotalOrder,
@@ -7534,7 +7534,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(20, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -7544,7 +7544,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(20, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -7554,7 +7554,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(20, Cluster(loc3v1)),
+                    location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -7576,7 +7576,7 @@ expression: built.ir()
                                         inner: Tee {
                                             inner: <shared 41>,
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(20, Cluster(loc3v1)),
+                                                location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: NoOrder,
@@ -7586,7 +7586,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(20, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                                             collection_kind: KeyedStream {
                                                 bound: Bounded,
                                                 value_order: NoOrder,
@@ -7597,7 +7597,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(20, Cluster(loc3v1)),
+                                        location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                                         collection_kind: KeyedSingleton {
                                             bound: Bounded,
                                             key_type: (u32 , i32),
@@ -7606,7 +7606,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(20, Cluster(loc3v1)),
+                                    location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                                     collection_kind: KeyedSingleton {
                                         bound: Bounded,
                                         key_type: (u32 , i32),
@@ -7615,7 +7615,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(20, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                                 collection_kind: KeyedStream {
                                     bound: Bounded,
                                     value_order: TotalOrder,
@@ -7626,7 +7626,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(20, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -7636,7 +7636,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(20, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -7646,7 +7646,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(20, Cluster(loc3v1)),
+                    location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -7656,7 +7656,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(20, Cluster(loc3v1)),
+                location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -7677,7 +7677,7 @@ expression: built.ir()
                     20,
                 ),
                 metadata: HydroIrMetadata {
-                    location_id: Tick(20, Cluster(loc3v1)),
+                    location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -7687,7 +7687,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(20, Cluster(loc3v1)),
+                location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -7735,7 +7735,7 @@ expression: built.ir()
                     inner: Tee {
                         inner: <shared 43>,
                         metadata: HydroIrMetadata {
-                            location_id: Tick(20, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(20)), Cluster(loc3v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -7834,7 +7834,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(21, Cluster(loc3v1)),
+                                                                                                location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                                                                 collection_kind: KeyedSingleton {
                                                                                                     bound: Bounded,
                                                                                                     key_type: u32,
@@ -7843,7 +7843,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(21, Cluster(loc3v1)),
+                                                                                            location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                                                             collection_kind: KeyedSingleton {
                                                                                                 bound: Bounded,
                                                                                                 key_type: u32,
@@ -7852,7 +7852,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(21, Cluster(loc3v1)),
+                                                                                        location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                                                         collection_kind: KeyedStream {
                                                                                             bound: Bounded,
                                                                                             value_order: TotalOrder,
@@ -7863,7 +7863,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(21, Cluster(loc3v1)),
+                                                                                    location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                                                     collection_kind: Stream {
                                                                                         bound: Bounded,
                                                                                         order: NoOrder,
@@ -7894,7 +7894,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(21, Cluster(loc3v1)),
+                                                                                                        location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                                                                         collection_kind: KeyedStream {
                                                                                                             bound: Bounded,
                                                                                                             value_order: NoOrder,
@@ -7906,7 +7906,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 trusted: false,
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(21, Cluster(loc3v1)),
+                                                                                                    location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                                                                     collection_kind: KeyedStream {
                                                                                                         bound: Bounded,
                                                                                                         value_order: TotalOrder,
@@ -7917,7 +7917,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(21, Cluster(loc3v1)),
+                                                                                                location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                                                                 collection_kind: KeyedSingleton {
                                                                                                     bound: Bounded,
                                                                                                     key_type: u32,
@@ -7926,7 +7926,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(21, Cluster(loc3v1)),
+                                                                                            location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                                                             collection_kind: KeyedSingleton {
                                                                                                 bound: Bounded,
                                                                                                 key_type: u32,
@@ -7935,7 +7935,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(21, Cluster(loc3v1)),
+                                                                                        location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                                                         collection_kind: KeyedStream {
                                                                                             bound: Bounded,
                                                                                             value_order: TotalOrder,
@@ -7946,7 +7946,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(21, Cluster(loc3v1)),
+                                                                                    location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                                                     collection_kind: Stream {
                                                                                         bound: Bounded,
                                                                                         order: NoOrder,
@@ -7956,7 +7956,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(21, Cluster(loc3v1)),
+                                                                                location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: NoOrder,
@@ -7966,7 +7966,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(21, Cluster(loc3v1)),
+                                                                            location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                                             collection_kind: KeyedStream {
                                                                                 bound: Bounded,
                                                                                 value_order: NoOrder,
@@ -7977,7 +7977,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(21, Cluster(loc3v1)),
+                                                                        location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                                         collection_kind: KeyedSingleton {
                                                                             bound: Bounded,
                                                                             key_type: u32,
@@ -7986,7 +7986,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(21, Cluster(loc3v1)),
+                                                                    location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                                     collection_kind: KeyedSingleton {
                                                                         bound: Bounded,
                                                                         key_type: u32,
@@ -7995,7 +7995,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(21, Cluster(loc3v1)),
+                                                                location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                                 collection_kind: KeyedStream {
                                                                     bound: Bounded,
                                                                     value_order: TotalOrder,
@@ -8006,7 +8006,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(21, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(21)), Cluster(loc3v1)),
                                                             collection_kind: KeyedStream {
                                                                 bound: Bounded,
                                                                 value_order: NoOrder,
@@ -8048,7 +8048,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(22, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: NoOrder,
@@ -8058,7 +8058,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(22, Cluster(loc3v1)),
+                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: NoOrder,
@@ -8068,7 +8068,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(22, Cluster(loc3v1)),
+                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >,
@@ -8076,7 +8076,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(22, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >,
@@ -8096,7 +8096,7 @@ expression: built.ir()
                                                             21,
                                                         ),
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8104,7 +8104,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(22, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8116,7 +8116,7 @@ expression: built.ir()
                                                         value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_LINE_COL ! ([] [Rc :: new (RefCell :: new (Histogram :: < u64 > :: new (3) . unwrap ()))]) },
                                                         first_tick_only: false,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8124,7 +8124,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(22, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8132,7 +8132,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8140,7 +8140,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(22, Cluster(loc3v1)),
+                                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8148,7 +8148,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(22, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8189,7 +8189,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                     collection_kind: Stream {
                                                                                         bound: Bounded,
                                                                                         order: TotalOrder,
@@ -8199,7 +8199,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(22, Cluster(loc3v1)),
+                                                                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: TotalOrder,
@@ -8209,7 +8209,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: TotalOrder,
@@ -8219,7 +8219,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(22, Cluster(loc3v1)),
+                                                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: (),
@@ -8227,7 +8227,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                     collection_kind: Optional {
                                                                         bound: Bounded,
                                                                         element_type: (),
@@ -8235,7 +8235,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(22, Cluster(loc3v1)),
+                                                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: (),
@@ -8243,7 +8243,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: core :: option :: Option < () >,
@@ -8255,7 +8255,7 @@ expression: built.ir()
                                                             value: :: std :: option :: Option :: None,
                                                             first_tick_only: false,
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(22, Cluster(loc3v1)),
+                                                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                 collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: core :: option :: Option < () >,
@@ -8263,7 +8263,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: core :: option :: Option < () >,
@@ -8271,7 +8271,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(22, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: core :: option :: Option < () >,
@@ -8279,7 +8279,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -8287,7 +8287,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(22, Cluster(loc3v1)),
+                                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: bool,
@@ -8295,7 +8295,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(22, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: bool,
@@ -8303,7 +8303,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(22, Cluster(loc3v1)),
+                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool),
@@ -8311,7 +8311,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(22, Cluster(loc3v1)),
+                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8319,7 +8319,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(22, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8327,7 +8327,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(22, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >),
@@ -8335,7 +8335,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(22, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8348,7 +8348,7 @@ expression: built.ir()
                         input: Tee {
                             inner: <shared 46>,
                             metadata: HydroIrMetadata {
-                                location_id: Tick(22, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >,
@@ -8356,7 +8356,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(22, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                             collection_kind: Singleton {
                                 bound: Bounded,
                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8364,7 +8364,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(22, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8372,7 +8372,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(22, Cluster(loc3v1)),
+                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                     collection_kind: Optional {
                         bound: Bounded,
                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8380,7 +8380,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(22, Cluster(loc3v1)),
+                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8406,7 +8406,7 @@ expression: built.ir()
                                     inner: Tee {
                                         inner: <shared 47>,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(22, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: NoOrder,
@@ -8417,7 +8417,7 @@ expression: built.ir()
                                     },
                                     trusted: true,
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(22, Cluster(loc3v1)),
+                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: TotalOrder,
@@ -8427,7 +8427,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(22, Cluster(loc3v1)),
+                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: usize,
@@ -8435,7 +8435,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(22, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: usize,
@@ -8455,7 +8455,7 @@ expression: built.ir()
                                                             22,
                                                         ),
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: usize,
@@ -8463,7 +8463,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(22, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -8475,7 +8475,7 @@ expression: built.ir()
                                                         value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_LINE_COL ! ([] [0usize]) },
                                                         first_tick_only: false,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: usize,
@@ -8483,7 +8483,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(22, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -8491,7 +8491,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -8499,7 +8499,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(22, Cluster(loc3v1)),
+                                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -8507,7 +8507,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(22, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: usize,
@@ -8527,7 +8527,7 @@ expression: built.ir()
                                                             input: Tee {
                                                                 inner: <shared 50>,
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                     collection_kind: Optional {
                                                                         bound: Bounded,
                                                                         element_type: (),
@@ -8535,7 +8535,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(22, Cluster(loc3v1)),
+                                                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: (),
@@ -8543,7 +8543,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: core :: option :: Option < () >,
@@ -8555,7 +8555,7 @@ expression: built.ir()
                                                             value: :: std :: option :: Option :: None,
                                                             first_tick_only: false,
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(22, Cluster(loc3v1)),
+                                                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                 collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: core :: option :: Option < () >,
@@ -8563,7 +8563,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: core :: option :: Option < () >,
@@ -8571,7 +8571,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(22, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: core :: option :: Option < () >,
@@ -8579,7 +8579,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -8587,7 +8587,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(22, Cluster(loc3v1)),
+                                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: bool,
@@ -8595,7 +8595,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(22, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: bool,
@@ -8603,7 +8603,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(22, Cluster(loc3v1)),
+                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: (usize , bool),
@@ -8611,7 +8611,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(22, Cluster(loc3v1)),
+                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: usize,
@@ -8619,7 +8619,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(22, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: usize,
@@ -8627,7 +8627,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(22, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (usize , usize),
@@ -8635,7 +8635,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(22, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: usize,
@@ -8646,7 +8646,7 @@ expression: built.ir()
                     inner: Tee {
                         inner: <shared 51>,
                         metadata: HydroIrMetadata {
-                            location_id: Tick(22, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                             collection_kind: Singleton {
                                 bound: Bounded,
                                 element_type: usize,
@@ -8654,7 +8654,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(22, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: usize,
@@ -8662,7 +8662,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(22, Cluster(loc3v1)),
+                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                     collection_kind: Optional {
                         bound: Bounded,
                         element_type: usize,
@@ -8670,7 +8670,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(22, Cluster(loc3v1)),
+                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: usize,
@@ -8698,7 +8698,7 @@ expression: built.ir()
                                                     23,
                                                 ),
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(23, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8706,7 +8706,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(23, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8718,7 +8718,7 @@ expression: built.ir()
                                                 value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_LINE_COL ! ([] [Rc :: new (RefCell :: new (Histogram :: < u64 > :: new (3) . unwrap ()))]) },
                                                 first_tick_only: false,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(23, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8726,7 +8726,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(23, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8734,7 +8734,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(23, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8742,7 +8742,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(23, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8750,7 +8750,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(23, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8797,7 +8797,7 @@ expression: built.ir()
                                                                                             left: Tee {
                                                                                                 inner: <shared 49>,
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                                                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                                     collection_kind: Singleton {
                                                                                                         bound: Bounded,
                                                                                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8817,7 +8817,7 @@ expression: built.ir()
                                                                                                                     input: Tee {
                                                                                                                         inner: <shared 50>,
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                                                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                                                             collection_kind: Optional {
                                                                                                                                 bound: Bounded,
                                                                                                                                 element_type: (),
@@ -8825,7 +8825,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(22, Cluster(loc3v1)),
+                                                                                                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                                                         collection_kind: Optional {
                                                                                                                             bound: Bounded,
                                                                                                                             element_type: (),
@@ -8833,7 +8833,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                                                                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                                                     collection_kind: Optional {
                                                                                                                         bound: Bounded,
                                                                                                                         element_type: core :: option :: Option < () >,
@@ -8845,7 +8845,7 @@ expression: built.ir()
                                                                                                                     value: :: std :: option :: Option :: None,
                                                                                                                     first_tick_only: false,
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(22, Cluster(loc3v1)),
+                                                                                                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                                                         collection_kind: Singleton {
                                                                                                                             bound: Bounded,
                                                                                                                             element_type: core :: option :: Option < () >,
@@ -8853,7 +8853,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                                                                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                                                     collection_kind: Optional {
                                                                                                                         bound: Bounded,
                                                                                                                         element_type: core :: option :: Option < () >,
@@ -8861,7 +8861,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(22, Cluster(loc3v1)),
+                                                                                                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                                                 collection_kind: Optional {
                                                                                                                     bound: Bounded,
                                                                                                                     element_type: core :: option :: Option < () >,
@@ -8869,7 +8869,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                                             collection_kind: Singleton {
                                                                                                                 bound: Bounded,
                                                                                                                 element_type: core :: option :: Option < () >,
@@ -8877,7 +8877,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(22, Cluster(loc3v1)),
+                                                                                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                                         collection_kind: Singleton {
                                                                                                             bound: Bounded,
                                                                                                             element_type: bool,
@@ -8885,7 +8885,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                                                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                                     collection_kind: Optional {
                                                                                                         bound: Bounded,
                                                                                                         element_type: bool,
@@ -8893,7 +8893,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(22, Cluster(loc3v1)),
+                                                                                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                                 collection_kind: Optional {
                                                                                                     bound: Bounded,
                                                                                                     element_type: (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool),
@@ -8901,7 +8901,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                             collection_kind: Optional {
                                                                                                 bound: Bounded,
                                                                                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -8909,7 +8909,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(22, Cluster(loc3v1)),
+                                                                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                         collection_kind: Stream {
                                                                                             bound: Bounded,
                                                                                             order: TotalOrder,
@@ -8990,7 +8990,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(23, Process(loc4v1)),
+                                                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                         collection_kind: Stream {
                                                             bound: Bounded,
                                                             order: NoOrder,
@@ -9001,7 +9001,7 @@ expression: built.ir()
                                                 },
                                                 trusted: false,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(23, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: TotalOrder,
@@ -9011,7 +9011,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(23, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -9019,7 +9019,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(23, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >,
@@ -9031,7 +9031,7 @@ expression: built.ir()
                                             value: :: std :: option :: Option :: None,
                                             first_tick_only: false,
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(23, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >,
@@ -9039,7 +9039,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(23, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >,
@@ -9047,7 +9047,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(23, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >,
@@ -9055,7 +9055,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(23, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >,
@@ -9063,7 +9063,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(23, Process(loc4v1)),
+                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >),
@@ -9071,7 +9071,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(23, Process(loc4v1)),
+                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                             collection_kind: Singleton {
                                 bound: Bounded,
                                 element_type: (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >),
@@ -9107,7 +9107,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(23, Process(loc4v1)),
+                                                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                             collection_kind: Stream {
                                                                 bound: Bounded,
                                                                 order: TotalOrder,
@@ -9117,7 +9117,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(23, Process(loc4v1)),
+                                                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                         collection_kind: Stream {
                                                             bound: Bounded,
                                                             order: TotalOrder,
@@ -9127,7 +9127,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(23, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: TotalOrder,
@@ -9137,7 +9137,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(23, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: (),
@@ -9145,7 +9145,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(23, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: (),
@@ -9153,7 +9153,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(23, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: (),
@@ -9161,7 +9161,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(23, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < () >,
@@ -9173,7 +9173,7 @@ expression: built.ir()
                                     value: :: std :: option :: Option :: None,
                                     first_tick_only: false,
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(23, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < () >,
@@ -9181,7 +9181,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(23, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < () >,
@@ -9189,7 +9189,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(23, Process(loc4v1)),
+                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: core :: option :: Option < () >,
@@ -9197,7 +9197,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(23, Process(loc4v1)),
+                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                             collection_kind: Singleton {
                                 bound: Bounded,
                                 element_type: core :: option :: Option < () >,
@@ -9205,7 +9205,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(23, Process(loc4v1)),
+                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < () >),
@@ -9213,7 +9213,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(23, Process(loc4v1)),
+                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                     collection_kind: Singleton {
                         bound: Bounded,
                         element_type: ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < () >),
@@ -9221,7 +9221,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(23, Process(loc4v1)),
+                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -9267,7 +9267,7 @@ expression: built.ir()
                                                     left: Tee {
                                                         inner: <shared 53>,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: usize,
@@ -9287,7 +9287,7 @@ expression: built.ir()
                                                                             input: Tee {
                                                                                 inner: <shared 50>,
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                     collection_kind: Optional {
                                                                                         bound: Bounded,
                                                                                         element_type: (),
@@ -9295,7 +9295,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(22, Cluster(loc3v1)),
+                                                                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                 collection_kind: Optional {
                                                                                     bound: Bounded,
                                                                                     element_type: (),
@@ -9303,7 +9303,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                             collection_kind: Optional {
                                                                                 bound: Bounded,
                                                                                 element_type: core :: option :: Option < () >,
@@ -9315,7 +9315,7 @@ expression: built.ir()
                                                                             value: :: std :: option :: Option :: None,
                                                                             first_tick_only: false,
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(22, Cluster(loc3v1)),
+                                                                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                                 collection_kind: Singleton {
                                                                                     bound: Bounded,
                                                                                     element_type: core :: option :: Option < () >,
@@ -9323,7 +9323,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                             collection_kind: Optional {
                                                                                 bound: Bounded,
                                                                                 element_type: core :: option :: Option < () >,
@@ -9331,7 +9331,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(22, Cluster(loc3v1)),
+                                                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: core :: option :: Option < () >,
@@ -9339,7 +9339,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                     collection_kind: Singleton {
                                                                         bound: Bounded,
                                                                         element_type: core :: option :: Option < () >,
@@ -9347,7 +9347,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(22, Cluster(loc3v1)),
+                                                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                                 collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: bool,
@@ -9355,7 +9355,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(22, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: bool,
@@ -9363,7 +9363,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(22, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: (usize , bool),
@@ -9371,7 +9371,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(22, Cluster(loc3v1)),
+                                                    location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -9379,7 +9379,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(22, Cluster(loc3v1)),
+                                                location_id: Tick(Some(ClockId(22)), Cluster(loc3v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: TotalOrder,
@@ -9440,7 +9440,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(23, Process(loc4v1)),
+                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -9462,7 +9462,7 @@ expression: built.ir()
                                                     24,
                                                 ),
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(23, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -9470,7 +9470,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(23, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -9482,7 +9482,7 @@ expression: built.ir()
                                                 value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_LINE_COL ! ([] [0usize]) },
                                                 first_tick_only: false,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(23, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -9490,7 +9490,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(23, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -9498,7 +9498,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(23, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: usize,
@@ -9506,7 +9506,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(23, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: usize,
@@ -9514,7 +9514,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(23, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: usize,
@@ -9534,7 +9534,7 @@ expression: built.ir()
                                                     input: Tee {
                                                         inner: <shared 55>,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(23, Process(loc4v1)),
+                                                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: (),
@@ -9542,7 +9542,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(23, Process(loc4v1)),
+                                                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: (),
@@ -9550,7 +9550,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(23, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -9562,7 +9562,7 @@ expression: built.ir()
                                                     value: :: std :: option :: Option :: None,
                                                     first_tick_only: false,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(23, Process(loc4v1)),
+                                                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                         collection_kind: Singleton {
                                                             bound: Bounded,
                                                             element_type: core :: option :: Option < () >,
@@ -9570,7 +9570,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(23, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -9578,7 +9578,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(23, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -9586,7 +9586,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(23, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < () >,
@@ -9594,7 +9594,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(23, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: bool,
@@ -9602,7 +9602,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(23, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: bool,
@@ -9610,7 +9610,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(23, Process(loc4v1)),
+                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (usize , bool),
@@ -9618,7 +9618,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(23, Process(loc4v1)),
+                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: usize,
@@ -9626,7 +9626,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(23, Process(loc4v1)),
+                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,
@@ -9636,7 +9636,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(23, Process(loc4v1)),
+                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -9646,7 +9646,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(23, Process(loc4v1)),
+                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: usize,
@@ -9665,7 +9665,7 @@ expression: built.ir()
                         left: Tee {
                             inner: <shared 56>,
                             metadata: HydroIrMetadata {
-                                location_id: Tick(23, Process(loc4v1)),
+                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: usize,
@@ -9685,7 +9685,7 @@ expression: built.ir()
                                                 input: Tee {
                                                     inner: <shared 55>,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(23, Process(loc4v1)),
+                                                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: (),
@@ -9693,7 +9693,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(23, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: (),
@@ -9701,7 +9701,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(23, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -9713,7 +9713,7 @@ expression: built.ir()
                                                 value: :: std :: option :: Option :: None,
                                                 first_tick_only: false,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(23, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -9721,7 +9721,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(23, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -9729,7 +9729,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(23, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < () >,
@@ -9737,7 +9737,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(23, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < () >,
@@ -9745,7 +9745,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(23, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: bool,
@@ -9753,7 +9753,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(23, Process(loc4v1)),
+                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: bool,
@@ -9761,7 +9761,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(23, Process(loc4v1)),
+                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (usize , bool),
@@ -9769,7 +9769,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(23, Process(loc4v1)),
+                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: usize,
@@ -9777,7 +9777,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(23, Process(loc4v1)),
+                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: TotalOrder,
@@ -9810,7 +9810,7 @@ expression: built.ir()
                             left: Tee {
                                 inner: <shared 54>,
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(23, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -9830,7 +9830,7 @@ expression: built.ir()
                                                     input: Tee {
                                                         inner: <shared 55>,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(23, Process(loc4v1)),
+                                                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: (),
@@ -9838,7 +9838,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(23, Process(loc4v1)),
+                                                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: (),
@@ -9846,7 +9846,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(23, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -9858,7 +9858,7 @@ expression: built.ir()
                                                     value: :: std :: option :: Option :: None,
                                                     first_tick_only: false,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(23, Process(loc4v1)),
+                                                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                         collection_kind: Singleton {
                                                             bound: Bounded,
                                                             element_type: core :: option :: Option < () >,
@@ -9866,7 +9866,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(23, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -9874,7 +9874,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(23, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -9882,7 +9882,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(23, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < () >,
@@ -9890,7 +9890,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(23, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: bool,
@@ -9898,7 +9898,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(23, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: bool,
@@ -9906,7 +9906,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(23, Process(loc4v1)),
+                                location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool),
@@ -9914,7 +9914,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(23, Process(loc4v1)),
+                            location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -9922,7 +9922,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(23, Process(loc4v1)),
+                        location_id: Tick(Some(ClockId(23)), Process(loc4v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,

--- a/hydro_test/src/cluster/snapshots/raft_ir.snap
+++ b/hydro_test/src/cluster/snapshots/raft_ir.snap
@@ -9,7 +9,7 @@ expression: built.ir()
                 value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: raft :: * ; crate :: __staged :: __stageleft_quote_src_cluster_raft_rs_LINE_COL ! ([CLUSTER_SELF_ID__free = hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: raft :: Replica > :: from_tagless ((__hydro_lang_cluster_self_id_loc1v1) . clone ()) , cluster_members__free = __hydro_lang_cluster_ids_loc1v1 ,] [cluster_members__free . iter () . map (| id | MemberId :: from_tagless (id . clone ())) . filter (| member | * member != CLUSTER_SELF_ID__free) . collect :: < Vec < _ > > ()]) },
                 first_tick_only: false,
                 metadata: HydroIrMetadata {
-                    location_id: Tick(0, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                     collection_kind: Singleton {
                         bound: Bounded,
                         element_type: std :: vec :: Vec < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: raft :: Replica > >,
@@ -23,7 +23,7 @@ expression: built.ir()
                 },
             ),
             metadata: HydroIrMetadata {
-                location_id: Tick(0, Cluster(loc1v1)),
+                location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: std :: vec :: Vec < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: raft :: Replica > >,
@@ -53,7 +53,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(0, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -63,7 +63,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(0, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                     collection_kind: Singleton {
                         bound: Bounded,
                         element_type: std :: vec :: Vec < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: raft :: Replica > , hydro_test :: __staged :: cluster :: raft :: RaftRpc < std :: string :: String , hydro_test :: __staged :: cluster :: raft :: Replica >) >,
@@ -77,7 +77,7 @@ expression: built.ir()
                 },
             ),
             metadata: HydroIrMetadata {
-                location_id: Tick(0, Cluster(loc1v1)),
+                location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: std :: vec :: Vec < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: raft :: Replica > , hydro_test :: __staged :: cluster :: raft :: RaftRpc < std :: string :: String , hydro_test :: __staged :: cluster :: raft :: Replica >) >,
@@ -119,7 +119,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(0, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,
@@ -129,7 +129,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(0, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                     collection_kind: Singleton {
                         bound: Bounded,
                         element_type: std :: vec :: Vec < std :: string :: String >,
@@ -143,7 +143,7 @@ expression: built.ir()
                 },
             ),
             metadata: HydroIrMetadata {
-                location_id: Tick(0, Cluster(loc1v1)),
+                location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: std :: vec :: Vec < std :: string :: String >,
@@ -175,7 +175,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(0, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: TotalOrder,
@@ -185,7 +185,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(0, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                         collection_kind: Singleton {
                             bound: Bounded,
                             element_type: usize,
@@ -193,7 +193,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(0, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                     collection_kind: Singleton {
                         bound: Bounded,
                         element_type: bool,
@@ -207,7 +207,7 @@ expression: built.ir()
                 },
             ),
             metadata: HydroIrMetadata {
-                location_id: Tick(0, Cluster(loc1v1)),
+                location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: bool,
@@ -239,7 +239,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(0, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: TotalOrder,
@@ -249,7 +249,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(0, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                         collection_kind: Singleton {
                             bound: Bounded,
                             element_type: usize,
@@ -257,7 +257,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(0, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                     collection_kind: Singleton {
                         bound: Bounded,
                         element_type: bool,
@@ -271,7 +271,7 @@ expression: built.ir()
                 },
             ),
             metadata: HydroIrMetadata {
-                location_id: Tick(0, Cluster(loc1v1)),
+                location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: bool,
@@ -293,7 +293,7 @@ expression: built.ir()
                                 1,
                             ),
                             metadata: HydroIrMetadata {
-                                location_id: Tick(0, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: hydro_test :: __staged :: cluster :: raft :: RaftServerState < std :: string :: String , hydro_test :: __staged :: cluster :: raft :: Replica >,
@@ -301,7 +301,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(0, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: hydro_test :: __staged :: cluster :: raft :: RaftServerState < std :: string :: String , hydro_test :: __staged :: cluster :: raft :: Replica >,
@@ -313,7 +313,7 @@ expression: built.ir()
                             value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: raft :: * ; crate :: __staged :: __stageleft_quote_src_cluster_raft_rs_LINE_COL ! ([] [RaftServerState :: new ()]) },
                             first_tick_only: false,
                             metadata: HydroIrMetadata {
-                                location_id: Tick(0, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: hydro_test :: __staged :: cluster :: raft :: RaftServerState < std :: string :: String , hydro_test :: __staged :: cluster :: raft :: Replica >,
@@ -321,7 +321,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(0, Cluster(loc1v1)),
+                            location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: hydro_test :: __staged :: cluster :: raft :: RaftServerState < std :: string :: String , hydro_test :: __staged :: cluster :: raft :: Replica >,
@@ -329,7 +329,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(0, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: hydro_test :: __staged :: cluster :: raft :: RaftServerState < std :: string :: String , hydro_test :: __staged :: cluster :: raft :: Replica >,
@@ -337,7 +337,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(0, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                     collection_kind: Singleton {
                         bound: Bounded,
                         element_type: hydro_test :: __staged :: cluster :: raft :: RaftServerState < std :: string :: String , hydro_test :: __staged :: cluster :: raft :: Replica >,
@@ -351,7 +351,7 @@ expression: built.ir()
                 },
             ),
             metadata: HydroIrMetadata {
-                location_id: Tick(0, Cluster(loc1v1)),
+                location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: hydro_test :: __staged :: cluster :: raft :: RaftServerState < std :: string :: String , hydro_test :: __staged :: cluster :: raft :: Replica >,
@@ -390,7 +390,7 @@ expression: built.ir()
                                     value: { use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: raft :: * ; crate :: __staged :: __stageleft_quote_src_cluster_raft_rs_LINE_COL ! ([] [()]) },
                                     first_tick_only: false,
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(0, Cluster(loc1v1)),
+                                        location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: (),
@@ -398,7 +398,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(0, Cluster(loc1v1)),
+                                    location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: TotalOrder,
@@ -408,7 +408,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(0, Cluster(loc1v1)),
+                                location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: TotalOrder,
@@ -469,7 +469,7 @@ expression: built.ir()
                         stageleft :: runtime_support :: type_hint :: < std :: vec :: Vec < hydro_test :: __staged :: cluster :: raft :: LeaderView < hydro_test :: __staged :: cluster :: raft :: Replica > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: raft :: * ; crate :: __staged :: __stageleft_quote_src_cluster_raft_rs_LINE_COL ! ([] [Vec :: new ()]) }),
                     ),
                     metadata: HydroIrMetadata {
-                        location_id: Tick(0, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,
@@ -485,7 +485,7 @@ expression: built.ir()
                     },
                 ),
                 metadata: HydroIrMetadata {
-                    location_id: Tick(0, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: TotalOrder,
@@ -519,7 +519,7 @@ expression: built.ir()
                                         stageleft :: runtime_support :: type_hint :: < std :: vec :: Vec < hydro_test :: __staged :: cluster :: raft :: LogEntry < std :: string :: String > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: raft :: * ; crate :: __staged :: __stageleft_quote_src_cluster_raft_rs_LINE_COL ! ([] [Vec :: new ()]) }),
                                     ),
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(0, Cluster(loc1v1)),
+                                        location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: TotalOrder,
@@ -535,7 +535,7 @@ expression: built.ir()
                                     },
                                 ),
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(0, Cluster(loc1v1)),
+                                    location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: TotalOrder,
@@ -566,7 +566,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Atomic(Tick(1, Cluster(loc1v1))),
+                        location_id: Atomic(Tick(Some(ClockId(1)), Cluster(loc1v1))),
                         collection_kind: Stream {
                             bound: Unbounded,
                             order: TotalOrder,
@@ -606,7 +606,7 @@ expression: built.ir()
                         stageleft :: runtime_support :: type_hint :: < std :: vec :: Vec < (std :: string :: String , core :: option :: Option < hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: raft :: Replica > >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: raft :: * ; crate :: __staged :: __stageleft_quote_src_cluster_raft_rs_LINE_COL ! ([] [Vec :: new ()]) }),
                     ),
                     metadata: HydroIrMetadata {
-                        location_id: Tick(0, Cluster(loc1v1)),
+                        location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,
@@ -622,7 +622,7 @@ expression: built.ir()
                     },
                 ),
                 metadata: HydroIrMetadata {
-                    location_id: Tick(0, Cluster(loc1v1)),
+                    location_id: Tick(Some(ClockId(0)), Cluster(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: TotalOrder,

--- a/hydro_test/src/cluster/snapshots/two_pc_ir.snap
+++ b/hydro_test/src/cluster/snapshots/two_pc_ir.snap
@@ -18,7 +18,7 @@ expression: built.ir()
                                     0,
                                 ),
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(0, Cluster(loc3v1)),
+                                    location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: (u32 , core :: option :: Option < i32 >),
@@ -26,7 +26,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(0, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (u32 , core :: option :: Option < i32 >),
@@ -41,7 +41,7 @@ expression: built.ir()
                                         value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_LINE_COL ! ([] [(0u32 , None)]) },
                                         first_tick_only: false,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(0, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: (u32 , core :: option :: Option < i32 >),
@@ -49,7 +49,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(0, Cluster(loc3v1)),
+                                        location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: (u32 , core :: option :: Option < i32 >),
@@ -70,7 +70,7 @@ expression: built.ir()
                                                             value: { use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_LINE_COL ! ([] [()]) },
                                                             first_tick_only: true,
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(0, Cluster(loc3v1)),
+                                                                location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: (),
@@ -78,7 +78,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(0, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: (),
@@ -86,7 +86,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(0, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: core :: option :: Option < () >,
@@ -98,7 +98,7 @@ expression: built.ir()
                                                         value: :: std :: option :: Option :: None,
                                                         first_tick_only: false,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(0, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: core :: option :: Option < () >,
@@ -106,7 +106,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(0, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: core :: option :: Option < () >,
@@ -114,7 +114,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(0, Cluster(loc3v1)),
+                                                    location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -122,7 +122,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(0, Cluster(loc3v1)),
+                                                location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -130,7 +130,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(0, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: bool,
@@ -138,7 +138,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(0, Cluster(loc3v1)),
+                                        location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: bool,
@@ -146,7 +146,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(0, Cluster(loc3v1)),
+                                    location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: ((u32 , core :: option :: Option < i32 >) , bool),
@@ -154,7 +154,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(0, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (u32 , core :: option :: Option < i32 >),
@@ -162,7 +162,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(0, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (u32 , core :: option :: Option < i32 >),
@@ -170,7 +170,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(0, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: (u32 , core :: option :: Option < i32 >),
@@ -191,7 +191,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(0, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                             collection_kind: Singleton {
                                 bound: Bounded,
                                 element_type: usize,
@@ -199,7 +199,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(0, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: usize,
@@ -207,7 +207,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(0, Cluster(loc3v1)),
+                    location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                     collection_kind: Optional {
                         bound: Bounded,
                         element_type: ((u32 , core :: option :: Option < i32 >) , usize),
@@ -215,7 +215,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(0, Cluster(loc3v1)),
+                location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                 collection_kind: Optional {
                     bound: Bounded,
                     element_type: (u32 , core :: option :: Option < i32 >),
@@ -237,7 +237,7 @@ expression: built.ir()
                                 2,
                             ),
                             metadata: HydroIrMetadata {
-                                location_id: Tick(2, Process(loc1v1)),
+                                location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: NoOrder,
@@ -247,7 +247,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(2, Process(loc1v1)),
+                            location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -359,7 +359,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(1, Process(loc1v1)),
+                                                                                            location_id: Tick(Some(ClockId(1)), Process(loc1v1)),
                                                                                             collection_kind: KeyedSingleton {
                                                                                                 bound: Bounded,
                                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
@@ -368,7 +368,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(1, Process(loc1v1)),
+                                                                                        location_id: Tick(Some(ClockId(1)), Process(loc1v1)),
                                                                                         collection_kind: KeyedSingleton {
                                                                                             bound: Bounded,
                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
@@ -377,7 +377,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(1, Process(loc1v1)),
+                                                                                    location_id: Tick(Some(ClockId(1)), Process(loc1v1)),
                                                                                     collection_kind: KeyedStream {
                                                                                         bound: Bounded,
                                                                                         value_order: TotalOrder,
@@ -388,7 +388,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(1, Process(loc1v1)),
+                                                                                location_id: Tick(Some(ClockId(1)), Process(loc1v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: NoOrder,
@@ -398,7 +398,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(1, Process(loc1v1)),
+                                                                            location_id: Tick(Some(ClockId(1)), Process(loc1v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: NoOrder,
@@ -409,7 +409,7 @@ expression: built.ir()
                                                                     },
                                                                     trusted: true,
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(1, Process(loc1v1)),
+                                                                        location_id: Tick(Some(ClockId(1)), Process(loc1v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: TotalOrder,
@@ -448,7 +448,7 @@ expression: built.ir()
                                                                                                             inner: Tee {
                                                                                                                 inner: <shared 0>,
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(0, Cluster(loc3v1)),
+                                                                                                                    location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                                                                                     collection_kind: Optional {
                                                                                                                         bound: Bounded,
                                                                                                                         element_type: (u32 , core :: option :: Option < i32 >),
@@ -456,7 +456,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(0, Cluster(loc3v1)),
+                                                                                                                location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                                                                                 collection_kind: Stream {
                                                                                                                     bound: Bounded,
                                                                                                                     order: TotalOrder,
@@ -466,7 +466,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(0, Cluster(loc3v1)),
+                                                                                                            location_id: Tick(Some(ClockId(0)), Cluster(loc3v1)),
                                                                                                             collection_kind: KeyedStream {
                                                                                                                 bound: Bounded,
                                                                                                                 value_order: TotalOrder,
@@ -590,7 +590,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(1, Process(loc1v1)),
+                                                                        location_id: Tick(Some(ClockId(1)), Process(loc1v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: NoOrder,
@@ -600,7 +600,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(1, Process(loc1v1)),
+                                                                    location_id: Tick(Some(ClockId(1)), Process(loc1v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: NoOrder,
@@ -610,7 +610,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(1, Process(loc1v1)),
+                                                                location_id: Tick(Some(ClockId(1)), Process(loc1v1)),
                                                                 collection_kind: KeyedStream {
                                                                     bound: Bounded,
                                                                     value_order: NoOrder,
@@ -703,7 +703,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(2, Process(loc1v1)),
+                            location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -713,7 +713,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(2, Process(loc1v1)),
+                        location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -723,7 +723,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(2, Process(loc1v1)),
+                    location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -745,7 +745,7 @@ expression: built.ir()
                                         inner: Tee {
                                             inner: <shared 1>,
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(2, Process(loc1v1)),
+                                                location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: NoOrder,
@@ -755,7 +755,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(2, Process(loc1v1)),
+                                            location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                                             collection_kind: KeyedStream {
                                                 bound: Bounded,
                                                 value_order: NoOrder,
@@ -766,7 +766,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(2, Process(loc1v1)),
+                                        location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                                         collection_kind: KeyedSingleton {
                                             bound: Bounded,
                                             key_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)),
@@ -775,7 +775,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(2, Process(loc1v1)),
+                                    location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                                     collection_kind: KeyedSingleton {
                                         bound: Bounded,
                                         key_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)),
@@ -784,7 +784,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(2, Process(loc1v1)),
+                                location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                                 collection_kind: KeyedStream {
                                     bound: Bounded,
                                     value_order: TotalOrder,
@@ -795,7 +795,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(2, Process(loc1v1)),
+                            location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -805,7 +805,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(2, Process(loc1v1)),
+                        location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -815,7 +815,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(2, Process(loc1v1)),
+                    location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -825,7 +825,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(2, Process(loc1v1)),
+                location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -846,7 +846,7 @@ expression: built.ir()
                     3,
                 ),
                 metadata: HydroIrMetadata {
-                    location_id: Tick(2, Process(loc1v1)),
+                    location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -856,7 +856,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(2, Process(loc1v1)),
+                location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -907,7 +907,7 @@ expression: built.ir()
                                 4,
                             ),
                             metadata: HydroIrMetadata {
-                                location_id: Tick(4, Process(loc1v1)),
+                                location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                                 collection_kind: Stream {
                                     bound: Bounded,
                                     order: NoOrder,
@@ -917,7 +917,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(4, Process(loc1v1)),
+                            location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -1029,7 +1029,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(3, Process(loc1v1)),
+                                                                                            location_id: Tick(Some(ClockId(3)), Process(loc1v1)),
                                                                                             collection_kind: KeyedSingleton {
                                                                                                 bound: Bounded,
                                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
@@ -1038,7 +1038,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(3, Process(loc1v1)),
+                                                                                        location_id: Tick(Some(ClockId(3)), Process(loc1v1)),
                                                                                         collection_kind: KeyedSingleton {
                                                                                             bound: Bounded,
                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc :: Participant >,
@@ -1047,7 +1047,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(3, Process(loc1v1)),
+                                                                                    location_id: Tick(Some(ClockId(3)), Process(loc1v1)),
                                                                                     collection_kind: KeyedStream {
                                                                                         bound: Bounded,
                                                                                         value_order: TotalOrder,
@@ -1058,7 +1058,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(3, Process(loc1v1)),
+                                                                                location_id: Tick(Some(ClockId(3)), Process(loc1v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: NoOrder,
@@ -1068,7 +1068,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(3, Process(loc1v1)),
+                                                                            location_id: Tick(Some(ClockId(3)), Process(loc1v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: NoOrder,
@@ -1079,7 +1079,7 @@ expression: built.ir()
                                                                     },
                                                                     trusted: true,
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(3, Process(loc1v1)),
+                                                                        location_id: Tick(Some(ClockId(3)), Process(loc1v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: TotalOrder,
@@ -1093,7 +1093,7 @@ expression: built.ir()
                                                                         inner: Tee {
                                                                             inner: <shared 4>,
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(2, Process(loc1v1)),
+                                                                                location_id: Tick(Some(ClockId(2)), Process(loc1v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: NoOrder,
@@ -1113,7 +1113,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(3, Process(loc1v1)),
+                                                                        location_id: Tick(Some(ClockId(3)), Process(loc1v1)),
                                                                         collection_kind: Stream {
                                                                             bound: Bounded,
                                                                             order: NoOrder,
@@ -1123,7 +1123,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(3, Process(loc1v1)),
+                                                                    location_id: Tick(Some(ClockId(3)), Process(loc1v1)),
                                                                     collection_kind: Stream {
                                                                         bound: Bounded,
                                                                         order: NoOrder,
@@ -1133,7 +1133,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(3, Process(loc1v1)),
+                                                                location_id: Tick(Some(ClockId(3)), Process(loc1v1)),
                                                                 collection_kind: KeyedStream {
                                                                     bound: Bounded,
                                                                     value_order: NoOrder,
@@ -1226,7 +1226,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(4, Process(loc1v1)),
+                            location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -1236,7 +1236,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(4, Process(loc1v1)),
+                        location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -1246,7 +1246,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(4, Process(loc1v1)),
+                    location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -1268,7 +1268,7 @@ expression: built.ir()
                                         inner: Tee {
                                             inner: <shared 6>,
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(4, Process(loc1v1)),
+                                                location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: NoOrder,
@@ -1278,7 +1278,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(4, Process(loc1v1)),
+                                            location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                                             collection_kind: KeyedStream {
                                                 bound: Bounded,
                                                 value_order: NoOrder,
@@ -1289,7 +1289,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(4, Process(loc1v1)),
+                                        location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                                         collection_kind: KeyedSingleton {
                                             bound: Bounded,
                                             key_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)),
@@ -1298,7 +1298,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(4, Process(loc1v1)),
+                                    location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                                     collection_kind: KeyedSingleton {
                                         bound: Bounded,
                                         key_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: two_pc_bench :: Client > , (u32 , i32)),
@@ -1307,7 +1307,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(4, Process(loc1v1)),
+                                location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                                 collection_kind: KeyedStream {
                                     bound: Bounded,
                                     value_order: TotalOrder,
@@ -1318,7 +1318,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(4, Process(loc1v1)),
+                            location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                             collection_kind: Stream {
                                 bound: Bounded,
                                 order: NoOrder,
@@ -1328,7 +1328,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(4, Process(loc1v1)),
+                        location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -1338,7 +1338,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(4, Process(loc1v1)),
+                    location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -1348,7 +1348,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(4, Process(loc1v1)),
+                location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -1369,7 +1369,7 @@ expression: built.ir()
                     5,
                 ),
                 metadata: HydroIrMetadata {
-                    location_id: Tick(4, Process(loc1v1)),
+                    location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -1379,7 +1379,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(4, Process(loc1v1)),
+                location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                 collection_kind: Stream {
                     bound: Bounded,
                     order: NoOrder,
@@ -1444,7 +1444,7 @@ expression: built.ir()
                             inner: Tee {
                                 inner: <shared 8>,
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(4, Process(loc1v1)),
+                                    location_id: Tick(Some(ClockId(4)), Process(loc1v1)),
                                     collection_kind: Stream {
                                         bound: Bounded,
                                         order: NoOrder,
@@ -1564,7 +1564,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(5, Cluster(loc3v1)),
+                                                                                                location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                                                                 collection_kind: KeyedSingleton {
                                                                                                     bound: Bounded,
                                                                                                     key_type: u32,
@@ -1573,7 +1573,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(5, Cluster(loc3v1)),
+                                                                                            location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                                                             collection_kind: KeyedSingleton {
                                                                                                 bound: Bounded,
                                                                                                 key_type: u32,
@@ -1582,7 +1582,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(5, Cluster(loc3v1)),
+                                                                                        location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                                                         collection_kind: KeyedStream {
                                                                                             bound: Bounded,
                                                                                             value_order: TotalOrder,
@@ -1593,7 +1593,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(5, Cluster(loc3v1)),
+                                                                                    location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                                                     collection_kind: Stream {
                                                                                         bound: Bounded,
                                                                                         order: NoOrder,
@@ -1624,7 +1624,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(5, Cluster(loc3v1)),
+                                                                                                        location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                                                                         collection_kind: KeyedStream {
                                                                                                             bound: Bounded,
                                                                                                             value_order: NoOrder,
@@ -1636,7 +1636,7 @@ expression: built.ir()
                                                                                                 },
                                                                                                 trusted: false,
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(5, Cluster(loc3v1)),
+                                                                                                    location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                                                                     collection_kind: KeyedStream {
                                                                                                         bound: Bounded,
                                                                                                         value_order: TotalOrder,
@@ -1647,7 +1647,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(5, Cluster(loc3v1)),
+                                                                                                location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                                                                 collection_kind: KeyedSingleton {
                                                                                                     bound: Bounded,
                                                                                                     key_type: u32,
@@ -1656,7 +1656,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(5, Cluster(loc3v1)),
+                                                                                            location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                                                             collection_kind: KeyedSingleton {
                                                                                                 bound: Bounded,
                                                                                                 key_type: u32,
@@ -1665,7 +1665,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(5, Cluster(loc3v1)),
+                                                                                        location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                                                         collection_kind: KeyedStream {
                                                                                             bound: Bounded,
                                                                                             value_order: TotalOrder,
@@ -1676,7 +1676,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(5, Cluster(loc3v1)),
+                                                                                    location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                                                     collection_kind: Stream {
                                                                                         bound: Bounded,
                                                                                         order: NoOrder,
@@ -1686,7 +1686,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(5, Cluster(loc3v1)),
+                                                                                location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: NoOrder,
@@ -1696,7 +1696,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(5, Cluster(loc3v1)),
+                                                                            location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                                             collection_kind: KeyedStream {
                                                                                 bound: Bounded,
                                                                                 value_order: NoOrder,
@@ -1707,7 +1707,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(5, Cluster(loc3v1)),
+                                                                        location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                                         collection_kind: KeyedSingleton {
                                                                             bound: Bounded,
                                                                             key_type: u32,
@@ -1716,7 +1716,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(5, Cluster(loc3v1)),
+                                                                    location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                                     collection_kind: KeyedSingleton {
                                                                         bound: Bounded,
                                                                         key_type: u32,
@@ -1725,7 +1725,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(5, Cluster(loc3v1)),
+                                                                location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                                 collection_kind: KeyedStream {
                                                                     bound: Bounded,
                                                                     value_order: TotalOrder,
@@ -1736,7 +1736,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(5, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(5)), Cluster(loc3v1)),
                                                             collection_kind: KeyedStream {
                                                                 bound: Bounded,
                                                                 value_order: NoOrder,
@@ -1778,7 +1778,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(6, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: NoOrder,
@@ -1788,7 +1788,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(6, Cluster(loc3v1)),
+                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: NoOrder,
@@ -1798,7 +1798,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(6, Cluster(loc3v1)),
+                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >,
@@ -1806,7 +1806,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(6, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >,
@@ -1826,7 +1826,7 @@ expression: built.ir()
                                                             6,
                                                         ),
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -1834,7 +1834,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -1846,7 +1846,7 @@ expression: built.ir()
                                                         value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_LINE_COL ! ([] [Rc :: new (RefCell :: new (Histogram :: < u64 > :: new (3) . unwrap ()))]) },
                                                         first_tick_only: false,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -1854,7 +1854,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -1862,7 +1862,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -1870,7 +1870,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -1878,7 +1878,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(6, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -1919,7 +1919,7 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                     collection_kind: Stream {
                                                                                         bound: Bounded,
                                                                                         order: TotalOrder,
@@ -1929,7 +1929,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                 collection_kind: Stream {
                                                                                     bound: Bounded,
                                                                                     order: TotalOrder,
@@ -1939,7 +1939,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                             collection_kind: Stream {
                                                                                 bound: Bounded,
                                                                                 order: TotalOrder,
@@ -1949,7 +1949,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: (),
@@ -1957,7 +1957,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                     collection_kind: Optional {
                                                                         bound: Bounded,
                                                                         element_type: (),
@@ -1965,7 +1965,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: (),
@@ -1973,7 +1973,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: core :: option :: Option < () >,
@@ -1985,7 +1985,7 @@ expression: built.ir()
                                                             value: :: std :: option :: Option :: None,
                                                             first_tick_only: false,
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                 collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: core :: option :: Option < () >,
@@ -1993,7 +1993,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: core :: option :: Option < () >,
@@ -2001,7 +2001,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: core :: option :: Option < () >,
@@ -2009,7 +2009,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -2017,7 +2017,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: bool,
@@ -2025,7 +2025,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(6, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: bool,
@@ -2033,7 +2033,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(6, Cluster(loc3v1)),
+                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool),
@@ -2041,7 +2041,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(6, Cluster(loc3v1)),
+                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2049,7 +2049,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(6, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2057,7 +2057,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(6, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > , std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >),
@@ -2065,7 +2065,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(6, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2078,7 +2078,7 @@ expression: built.ir()
                         input: Tee {
                             inner: <shared 11>,
                             metadata: HydroIrMetadata {
-                                location_id: Tick(6, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 >,
@@ -2086,7 +2086,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(6, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                             collection_kind: Singleton {
                                 bound: Bounded,
                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2094,7 +2094,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(6, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2102,7 +2102,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(6, Cluster(loc3v1)),
+                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                     collection_kind: Optional {
                         bound: Bounded,
                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2110,7 +2110,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(6, Cluster(loc3v1)),
+                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2136,7 +2136,7 @@ expression: built.ir()
                                     inner: Tee {
                                         inner: <shared 12>,
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(6, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                             collection_kind: Stream {
                                                 bound: Bounded,
                                                 order: NoOrder,
@@ -2147,7 +2147,7 @@ expression: built.ir()
                                     },
                                     trusted: true,
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(6, Cluster(loc3v1)),
+                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                         collection_kind: Stream {
                                             bound: Bounded,
                                             order: TotalOrder,
@@ -2157,7 +2157,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(6, Cluster(loc3v1)),
+                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: usize,
@@ -2165,7 +2165,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(6, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: usize,
@@ -2185,7 +2185,7 @@ expression: built.ir()
                                                             7,
                                                         ),
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: usize,
@@ -2193,7 +2193,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -2205,7 +2205,7 @@ expression: built.ir()
                                                         value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_LINE_COL ! ([] [0usize]) },
                                                         first_tick_only: false,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: usize,
@@ -2213,7 +2213,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: usize,
@@ -2221,7 +2221,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -2229,7 +2229,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -2237,7 +2237,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(6, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: usize,
@@ -2257,7 +2257,7 @@ expression: built.ir()
                                                             input: Tee {
                                                                 inner: <shared 15>,
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                     collection_kind: Optional {
                                                                         bound: Bounded,
                                                                         element_type: (),
@@ -2265,7 +2265,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                 collection_kind: Optional {
                                                                     bound: Bounded,
                                                                     element_type: (),
@@ -2273,7 +2273,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: core :: option :: Option < () >,
@@ -2285,7 +2285,7 @@ expression: built.ir()
                                                             value: :: std :: option :: Option :: None,
                                                             first_tick_only: false,
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                 collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: core :: option :: Option < () >,
@@ -2293,7 +2293,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: core :: option :: Option < () >,
@@ -2301,7 +2301,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: core :: option :: Option < () >,
@@ -2309,7 +2309,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -2317,7 +2317,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: bool,
@@ -2325,7 +2325,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(6, Cluster(loc3v1)),
+                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: bool,
@@ -2333,7 +2333,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(6, Cluster(loc3v1)),
+                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: (usize , bool),
@@ -2341,7 +2341,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(6, Cluster(loc3v1)),
+                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: usize,
@@ -2349,7 +2349,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(6, Cluster(loc3v1)),
+                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: usize,
@@ -2357,7 +2357,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(6, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (usize , usize),
@@ -2365,7 +2365,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(6, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: usize,
@@ -2376,7 +2376,7 @@ expression: built.ir()
                     inner: Tee {
                         inner: <shared 16>,
                         metadata: HydroIrMetadata {
-                            location_id: Tick(6, Cluster(loc3v1)),
+                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                             collection_kind: Singleton {
                                 bound: Bounded,
                                 element_type: usize,
@@ -2384,7 +2384,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(6, Cluster(loc3v1)),
+                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: usize,
@@ -2392,7 +2392,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(6, Cluster(loc3v1)),
+                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                     collection_kind: Optional {
                         bound: Bounded,
                         element_type: usize,
@@ -2400,7 +2400,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(6, Cluster(loc3v1)),
+                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: usize,
@@ -2428,7 +2428,7 @@ expression: built.ir()
                                                     8,
                                                 ),
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2436,7 +2436,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(7, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2448,7 +2448,7 @@ expression: built.ir()
                                                 value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_LINE_COL ! ([] [Rc :: new (RefCell :: new (Histogram :: < u64 > :: new (3) . unwrap ()))]) },
                                                 first_tick_only: false,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2456,7 +2456,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(7, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2464,7 +2464,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(7, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2472,7 +2472,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(7, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2480,7 +2480,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(7, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2527,7 +2527,7 @@ expression: built.ir()
                                                                                             left: Tee {
                                                                                                 inner: <shared 14>,
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                                     collection_kind: Singleton {
                                                                                                         bound: Bounded,
                                                                                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2547,7 +2547,7 @@ expression: built.ir()
                                                                                                                     input: Tee {
                                                                                                                         inner: <shared 15>,
                                                                                                                         metadata: HydroIrMetadata {
-                                                                                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                                                             collection_kind: Optional {
                                                                                                                                 bound: Bounded,
                                                                                                                                 element_type: (),
@@ -2555,7 +2555,7 @@ expression: built.ir()
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                                                         collection_kind: Optional {
                                                                                                                             bound: Bounded,
                                                                                                                             element_type: (),
@@ -2563,7 +2563,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                                                     collection_kind: Optional {
                                                                                                                         bound: Bounded,
                                                                                                                         element_type: core :: option :: Option < () >,
@@ -2575,7 +2575,7 @@ expression: built.ir()
                                                                                                                     value: :: std :: option :: Option :: None,
                                                                                                                     first_tick_only: false,
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                                                         collection_kind: Singleton {
                                                                                                                             bound: Bounded,
                                                                                                                             element_type: core :: option :: Option < () >,
@@ -2583,7 +2583,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                                 metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                                                     collection_kind: Optional {
                                                                                                                         bound: Bounded,
                                                                                                                         element_type: core :: option :: Option < () >,
@@ -2591,7 +2591,7 @@ expression: built.ir()
                                                                                                                 },
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
-                                                                                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                                                 collection_kind: Optional {
                                                                                                                     bound: Bounded,
                                                                                                                     element_type: core :: option :: Option < () >,
@@ -2599,7 +2599,7 @@ expression: built.ir()
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                                             collection_kind: Singleton {
                                                                                                                 bound: Bounded,
                                                                                                                 element_type: core :: option :: Option < () >,
@@ -2607,7 +2607,7 @@ expression: built.ir()
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                                         collection_kind: Singleton {
                                                                                                             bound: Bounded,
                                                                                                             element_type: bool,
@@ -2615,7 +2615,7 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                                     collection_kind: Optional {
                                                                                                         bound: Bounded,
                                                                                                         element_type: bool,
@@ -2623,7 +2623,7 @@ expression: built.ir()
                                                                                                 },
                                                                                             },
                                                                                             metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                                                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                                 collection_kind: Optional {
                                                                                                     bound: Bounded,
                                                                                                     element_type: (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool),
@@ -2631,7 +2631,7 @@ expression: built.ir()
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
-                                                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                             collection_kind: Optional {
                                                                                                 bound: Bounded,
                                                                                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2639,7 +2639,7 @@ expression: built.ir()
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                         collection_kind: Stream {
                                                                                             bound: Bounded,
                                                                                             order: TotalOrder,
@@ -2720,7 +2720,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(7, Process(loc4v1)),
+                                                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                         collection_kind: Stream {
                                                             bound: Bounded,
                                                             order: NoOrder,
@@ -2731,7 +2731,7 @@ expression: built.ir()
                                                 },
                                                 trusted: false,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: TotalOrder,
@@ -2741,7 +2741,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(7, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2749,7 +2749,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(7, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >,
@@ -2761,7 +2761,7 @@ expression: built.ir()
                                             value: :: std :: option :: Option :: None,
                                             first_tick_only: false,
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(7, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                 collection_kind: Singleton {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >,
@@ -2769,7 +2769,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(7, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >,
@@ -2777,7 +2777,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(7, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >,
@@ -2785,7 +2785,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(7, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >,
@@ -2793,7 +2793,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(7, Process(loc4v1)),
+                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >),
@@ -2801,7 +2801,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(7, Process(loc4v1)),
+                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                             collection_kind: Singleton {
                                 bound: Bounded,
                                 element_type: (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >),
@@ -2837,7 +2837,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(7, Process(loc4v1)),
+                                                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                             collection_kind: Stream {
                                                                 bound: Bounded,
                                                                 order: TotalOrder,
@@ -2847,7 +2847,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(7, Process(loc4v1)),
+                                                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                         collection_kind: Stream {
                                                             bound: Bounded,
                                                             order: TotalOrder,
@@ -2857,7 +2857,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                     collection_kind: Stream {
                                                         bound: Bounded,
                                                         order: TotalOrder,
@@ -2867,7 +2867,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(7, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: (),
@@ -2875,7 +2875,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(7, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: (),
@@ -2883,7 +2883,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(7, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                         collection_kind: Optional {
                                             bound: Bounded,
                                             element_type: (),
@@ -2891,7 +2891,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(7, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < () >,
@@ -2903,7 +2903,7 @@ expression: built.ir()
                                     value: :: std :: option :: Option :: None,
                                     first_tick_only: false,
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(7, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < () >,
@@ -2911,7 +2911,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(7, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: core :: option :: Option < () >,
@@ -2919,7 +2919,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(7, Process(loc4v1)),
+                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: core :: option :: Option < () >,
@@ -2927,7 +2927,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(7, Process(loc4v1)),
+                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                             collection_kind: Singleton {
                                 bound: Bounded,
                                 element_type: core :: option :: Option < () >,
@@ -2935,7 +2935,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(7, Process(loc4v1)),
+                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < () >),
@@ -2943,7 +2943,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(7, Process(loc4v1)),
+                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                     collection_kind: Singleton {
                         bound: Bounded,
                         element_type: ((std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , core :: option :: Option < std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > >) , core :: option :: Option < () >),
@@ -2951,7 +2951,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(7, Process(loc4v1)),
+                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -2997,7 +2997,7 @@ expression: built.ir()
                                                     left: Tee {
                                                         inner: <shared 18>,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                             collection_kind: Singleton {
                                                                 bound: Bounded,
                                                                 element_type: usize,
@@ -3017,7 +3017,7 @@ expression: built.ir()
                                                                             input: Tee {
                                                                                 inner: <shared 15>,
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                     collection_kind: Optional {
                                                                                         bound: Bounded,
                                                                                         element_type: (),
@@ -3025,7 +3025,7 @@ expression: built.ir()
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                 collection_kind: Optional {
                                                                                     bound: Bounded,
                                                                                     element_type: (),
@@ -3033,7 +3033,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                             collection_kind: Optional {
                                                                                 bound: Bounded,
                                                                                 element_type: core :: option :: Option < () >,
@@ -3045,7 +3045,7 @@ expression: built.ir()
                                                                             value: :: std :: option :: Option :: None,
                                                                             first_tick_only: false,
                                                                             metadata: HydroIrMetadata {
-                                                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                                 collection_kind: Singleton {
                                                                                     bound: Bounded,
                                                                                     element_type: core :: option :: Option < () >,
@@ -3053,7 +3053,7 @@ expression: built.ir()
                                                                             },
                                                                         },
                                                                         metadata: HydroIrMetadata {
-                                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                             collection_kind: Optional {
                                                                                 bound: Bounded,
                                                                                 element_type: core :: option :: Option < () >,
@@ -3061,7 +3061,7 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                     metadata: HydroIrMetadata {
-                                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                         collection_kind: Optional {
                                                                             bound: Bounded,
                                                                             element_type: core :: option :: Option < () >,
@@ -3069,7 +3069,7 @@ expression: built.ir()
                                                                     },
                                                                 },
                                                                 metadata: HydroIrMetadata {
-                                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                     collection_kind: Singleton {
                                                                         bound: Bounded,
                                                                         element_type: core :: option :: Option < () >,
@@ -3077,7 +3077,7 @@ expression: built.ir()
                                                                 },
                                                             },
                                                             metadata: HydroIrMetadata {
-                                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                                 collection_kind: Singleton {
                                                                     bound: Bounded,
                                                                     element_type: bool,
@@ -3085,7 +3085,7 @@ expression: built.ir()
                                                             },
                                                         },
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(6, Cluster(loc3v1)),
+                                                            location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: bool,
@@ -3093,7 +3093,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(6, Cluster(loc3v1)),
+                                                        location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: (usize , bool),
@@ -3101,7 +3101,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(6, Cluster(loc3v1)),
+                                                    location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -3109,7 +3109,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(6, Cluster(loc3v1)),
+                                                location_id: Tick(Some(ClockId(6)), Cluster(loc3v1)),
                                                 collection_kind: Stream {
                                                     bound: Bounded,
                                                     order: TotalOrder,
@@ -3170,7 +3170,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(7, Process(loc4v1)),
+                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: NoOrder,
@@ -3192,7 +3192,7 @@ expression: built.ir()
                                                     9,
                                                 ),
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -3200,7 +3200,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(7, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -3212,7 +3212,7 @@ expression: built.ir()
                                                 value: { use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: bench_client :: * ; hydro_std :: __stageleft_quote_src_bench_client_mod_rs_LINE_COL ! ([] [0usize]) },
                                                 first_tick_only: false,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: usize,
@@ -3220,7 +3220,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(7, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: usize,
@@ -3228,7 +3228,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(7, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: usize,
@@ -3236,7 +3236,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(7, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: usize,
@@ -3244,7 +3244,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(7, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: usize,
@@ -3264,7 +3264,7 @@ expression: built.ir()
                                                     input: Tee {
                                                         inner: <shared 20>,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(7, Process(loc4v1)),
+                                                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: (),
@@ -3272,7 +3272,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(7, Process(loc4v1)),
+                                                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: (),
@@ -3280,7 +3280,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -3292,7 +3292,7 @@ expression: built.ir()
                                                     value: :: std :: option :: Option :: None,
                                                     first_tick_only: false,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(7, Process(loc4v1)),
+                                                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                         collection_kind: Singleton {
                                                             bound: Bounded,
                                                             element_type: core :: option :: Option < () >,
@@ -3300,7 +3300,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -3308,7 +3308,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(7, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -3316,7 +3316,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(7, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < () >,
@@ -3324,7 +3324,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(7, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: bool,
@@ -3332,7 +3332,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(7, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: bool,
@@ -3340,7 +3340,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(7, Process(loc4v1)),
+                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (usize , bool),
@@ -3348,7 +3348,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(7, Process(loc4v1)),
+                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: usize,
@@ -3356,7 +3356,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(7, Process(loc4v1)),
+                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,
@@ -3366,7 +3366,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(7, Process(loc4v1)),
+                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: NoOrder,
@@ -3376,7 +3376,7 @@ expression: built.ir()
                 },
             },
             metadata: HydroIrMetadata {
-                location_id: Tick(7, Process(loc4v1)),
+                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                 collection_kind: Singleton {
                     bound: Bounded,
                     element_type: usize,
@@ -3395,7 +3395,7 @@ expression: built.ir()
                         left: Tee {
                             inner: <shared 21>,
                             metadata: HydroIrMetadata {
-                                location_id: Tick(7, Process(loc4v1)),
+                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                 collection_kind: Singleton {
                                     bound: Bounded,
                                     element_type: usize,
@@ -3415,7 +3415,7 @@ expression: built.ir()
                                                 input: Tee {
                                                     inner: <shared 20>,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(7, Process(loc4v1)),
+                                                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: (),
@@ -3423,7 +3423,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: (),
@@ -3431,7 +3431,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(7, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -3443,7 +3443,7 @@ expression: built.ir()
                                                 value: :: std :: option :: Option :: None,
                                                 first_tick_only: false,
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                     collection_kind: Singleton {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -3451,7 +3451,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(7, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -3459,7 +3459,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(7, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                             collection_kind: Optional {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < () >,
@@ -3467,7 +3467,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(7, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: core :: option :: Option < () >,
@@ -3475,7 +3475,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(7, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: bool,
@@ -3483,7 +3483,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(7, Process(loc4v1)),
+                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: bool,
@@ -3491,7 +3491,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(7, Process(loc4v1)),
+                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: (usize , bool),
@@ -3499,7 +3499,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(7, Process(loc4v1)),
+                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                         collection_kind: Optional {
                             bound: Bounded,
                             element_type: usize,
@@ -3507,7 +3507,7 @@ expression: built.ir()
                     },
                 },
                 metadata: HydroIrMetadata {
-                    location_id: Tick(7, Process(loc4v1)),
+                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                     collection_kind: Stream {
                         bound: Bounded,
                         order: TotalOrder,
@@ -3540,7 +3540,7 @@ expression: built.ir()
                             left: Tee {
                                 inner: <shared 19>,
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(7, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                     collection_kind: Singleton {
                                         bound: Bounded,
                                         element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -3560,7 +3560,7 @@ expression: built.ir()
                                                     input: Tee {
                                                         inner: <shared 20>,
                                                         metadata: HydroIrMetadata {
-                                                            location_id: Tick(7, Process(loc4v1)),
+                                                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                             collection_kind: Optional {
                                                                 bound: Bounded,
                                                                 element_type: (),
@@ -3568,7 +3568,7 @@ expression: built.ir()
                                                         },
                                                     },
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(7, Process(loc4v1)),
+                                                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                         collection_kind: Optional {
                                                             bound: Bounded,
                                                             element_type: (),
@@ -3576,7 +3576,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -3588,7 +3588,7 @@ expression: built.ir()
                                                     value: :: std :: option :: Option :: None,
                                                     first_tick_only: false,
                                                     metadata: HydroIrMetadata {
-                                                        location_id: Tick(7, Process(loc4v1)),
+                                                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                         collection_kind: Singleton {
                                                             bound: Bounded,
                                                             element_type: core :: option :: Option < () >,
@@ -3596,7 +3596,7 @@ expression: built.ir()
                                                     },
                                                 },
                                                 metadata: HydroIrMetadata {
-                                                    location_id: Tick(7, Process(loc4v1)),
+                                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                     collection_kind: Optional {
                                                         bound: Bounded,
                                                         element_type: core :: option :: Option < () >,
@@ -3604,7 +3604,7 @@ expression: built.ir()
                                                 },
                                             },
                                             metadata: HydroIrMetadata {
-                                                location_id: Tick(7, Process(loc4v1)),
+                                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                                 collection_kind: Optional {
                                                     bound: Bounded,
                                                     element_type: core :: option :: Option < () >,
@@ -3612,7 +3612,7 @@ expression: built.ir()
                                             },
                                         },
                                         metadata: HydroIrMetadata {
-                                            location_id: Tick(7, Process(loc4v1)),
+                                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                             collection_kind: Singleton {
                                                 bound: Bounded,
                                                 element_type: core :: option :: Option < () >,
@@ -3620,7 +3620,7 @@ expression: built.ir()
                                         },
                                     },
                                     metadata: HydroIrMetadata {
-                                        location_id: Tick(7, Process(loc4v1)),
+                                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                         collection_kind: Singleton {
                                             bound: Bounded,
                                             element_type: bool,
@@ -3628,7 +3628,7 @@ expression: built.ir()
                                     },
                                 },
                                 metadata: HydroIrMetadata {
-                                    location_id: Tick(7, Process(loc4v1)),
+                                    location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                     collection_kind: Optional {
                                         bound: Bounded,
                                         element_type: bool,
@@ -3636,7 +3636,7 @@ expression: built.ir()
                                 },
                             },
                             metadata: HydroIrMetadata {
-                                location_id: Tick(7, Process(loc4v1)),
+                                location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                                 collection_kind: Optional {
                                     bound: Bounded,
                                     element_type: (std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > > , bool),
@@ -3644,7 +3644,7 @@ expression: built.ir()
                             },
                         },
                         metadata: HydroIrMetadata {
-                            location_id: Tick(7, Process(loc4v1)),
+                            location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                             collection_kind: Optional {
                                 bound: Bounded,
                                 element_type: std :: rc :: Rc < core :: cell :: RefCell < hydro_test :: __staged :: __deps :: hydro_std :: __staged :: __deps :: hdrhistogram :: Histogram < u64 > > >,
@@ -3652,7 +3652,7 @@ expression: built.ir()
                         },
                     },
                     metadata: HydroIrMetadata {
-                        location_id: Tick(7, Process(loc4v1)),
+                        location_id: Tick(Some(ClockId(7)), Process(loc4v1)),
                         collection_kind: Stream {
                             bound: Bounded,
                             order: TotalOrder,


### PR DESCRIPTION
To represent `Tick(NONE, Atomic(Tick(SOME(ClockId), L)))` unambiguously