### PR TITLE
fix(hydro_lang): assert tick `parent_location()` matches in atomic batch/snapshot methods (#3154)

### DIFF
--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -1764,7 +1764,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded> {
-        assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(&self.location)
+        );
         KeyedSingleton::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -1791,6 +1794,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded> {
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(self.location.tick.parent_location())
+        );
         KeyedSingleton::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -1952,7 +1959,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded> {
-        assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(&self.location)
+        );
         KeyedSingleton::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -1983,6 +1993,10 @@ where
         nondet: NonDet,
     ) -> KeyedSingleton<K, V, Tick<L::DropConsistency>, Bounded> {
         let _ = nondet;
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(self.location.tick.parent_location())
+        );
         KeyedSingleton::new(
             tick.drop_consistency(),
             HydroNode::Batch {

--- a/hydro_lang/src/live_collections/keyed_stream/mod.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/mod.rs
@@ -2173,7 +2173,7 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         Idemp: ValidIdempotenceFor<R>,
     {
         let other: Optional<O2, Tick<L::Root>, Bounded> = other.into();
-        check_matching_location(&self.location.root(), other.location.outer());
+        check_matching_location(&self.location.root(), other.location.parent_location());
         let (f, proof) =
             comb.splice_fn2_borrow_mut_ctx_props(&OperatorContext::<L, B>::new(&self.location));
         proof.register_proof(&f);
@@ -2695,7 +2695,10 @@ impl<'a, K, V, L: Location<'a>, B: Boundedness, O: Ordering, R: Retries>
         nondet: NonDet,
     ) -> KeyedStream<K, V, Tick<L::DropConsistency>, Bounded, O, R> {
         let _ = nondet;
-        assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(&self.location)
+        );
         KeyedStream::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -2896,6 +2899,10 @@ where
         nondet: NonDet,
     ) -> KeyedStream<K, V, Tick<L::DropConsistency>, Bounded, O, R> {
         let _ = nondet;
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(self.location.tick.parent_location())
+        );
         KeyedStream::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -2933,18 +2940,13 @@ where
     /// each key.
     pub fn all_ticks(self) -> KeyedStream<K, V, L, Unbounded, O, R> {
         KeyedStream::new(
-            self.location.outer().clone(),
+            self.location.parent_location().clone(),
             HydroNode::YieldConcat {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                metadata: self.location.outer().new_node_metadata(KeyedStream::<
-                    K,
-                    V,
-                    L,
-                    Unbounded,
-                    O,
-                    R,
-                >::collection_kind(
-                )),
+                metadata: self
+                    .location
+                    .parent_location()
+                    .new_node_metadata(KeyedStream::<K, V, L, Unbounded, O, R>::collection_kind()),
             },
         )
     }

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -1289,6 +1289,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> Optional<T, Tick<L::DropConsistency>, Bounded> {
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(self.location.tick.parent_location())
+        );
         Optional::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -1317,7 +1321,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> Optional<T, Tick<L::DropConsistency>, Bounded> {
-        assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(&self.location)
+        );
         Optional::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -1465,12 +1472,12 @@ where
     /// ```
     pub fn latest(self) -> Optional<T, L, Unbounded> {
         Optional::new(
-            self.location.outer().clone(),
+            self.location.parent_location().clone(),
             HydroNode::YieldConcat {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
-                    .outer()
+                    .parent_location()
                     .new_node_metadata(Optional::<T, L, Unbounded>::collection_kind()),
             },
         )

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -1226,6 +1226,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> Singleton<T, Tick<L::DropConsistency>, Bounded> {
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(self.location.tick.parent_location())
+        );
         Singleton::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -1254,7 +1258,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> Singleton<T, Tick<L::DropConsistency>, Bounded> {
-        assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(&self.location)
+        );
         Singleton::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -1530,12 +1537,12 @@ where
     /// ```
     pub fn latest(self) -> Singleton<T, L, Unbounded> {
         Singleton::new(
-            self.location.outer().clone(),
+            self.location.parent_location().clone(),
             HydroNode::YieldConcat {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
-                    .outer()
+                    .parent_location()
                     .new_node_metadata(Singleton::<T, L, Unbounded>::collection_kind()),
             },
         )

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -2153,7 +2153,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> Stream<T, Tick<L::DropConsistency>, Bounded, O, R> {
-        assert_eq!(Location::id(tick.outer()), Location::id(&self.location));
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(&self.location)
+        );
         Stream::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -3107,6 +3110,10 @@ where
         tick: &Tick<L2>,
         _nondet: NonDet,
     ) -> Stream<T, Tick<L::DropConsistency>, Bounded, O, R> {
+        assert_eq!(
+            Location::id(tick.parent_location()),
+            Location::id(self.location.tick.parent_location())
+        );
         Stream::new(
             tick.drop_consistency(),
             HydroNode::Batch {
@@ -3232,13 +3239,17 @@ where
     /// which will stream all the elements across _all_ tick iterations by concatenating the batches.
     pub fn all_ticks(self) -> Stream<T, L, Unbounded, O, R> {
         Stream::new(
-            self.location.outer().clone(),
+            self.location.parent_location().clone(),
             HydroNode::YieldConcat {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                metadata: self
-                    .location
-                    .outer()
-                    .new_node_metadata(Stream::<T, L, Unbounded, O, R>::collection_kind()),
+                metadata: self.location.parent_location().new_node_metadata(Stream::<
+                    T,
+                    L,
+                    Unbounded,
+                    O,
+                    R,
+                >::collection_kind(
+                )),
             },
         )
     }

--- a/hydro_lang/src/location/tick.rs
+++ b/hydro_lang/src/location/tick.rs
@@ -176,12 +176,18 @@ impl<'a, L> Tick<L>
 where
     L: Location<'a>,
 {
-    /// Returns a reference to the outer (parent) location that this tick is nested within.
+    /// Returns a reference to the parent location that this tick is located at.
     ///
     /// For example, if a `Tick` was created from a `Process`, this returns a reference
     /// to that `Process`.
-    pub fn outer(&self) -> &L {
+    pub fn parent_location(&self) -> &L {
         &self.l
+    }
+
+    /// Use [`Self::parent_location`] instead.
+    #[deprecated(note = "use `.parent_location()` instead")]
+    pub fn outer(&self) -> &L {
+        self.parent_location()
     }
 
     /// Creates a bounded stream of `()` values inside this tick, with a fixed batch size.


### PR DESCRIPTION
Remake of #3154 which was accidentally merged

Also renames `Tick::outer()` to `parent_location()`, making the original
a deprecated alias for the new method.

The `*_atomic` batch/snapshot methods accepted any tick without
validating
that it lives on the same location as the atomic section, unlike their
non-atomic counterparts (`Stream::batch`, `Singleton::snapshot`, etc.)
which
assert location equality. A mismatched tick (e.g. one created on a
different
process) would only be caught later, if at all, by downstream clock
unification.

Add the analogous assertion to all six atomic variants:

- `Stream::batch_atomic`
- `KeyedStream::batch_atomic`
- `Singleton::snapshot_atomic`
- `Optional::snapshot_atomic`
- `KeyedSingleton::snapshot_atomic`
- `KeyedSingleton::batch_atomic`

Each now asserts that `Location::id(tick.outer())` equals
`Location::id(self.location.tick.outer())`, i.e. the passed tick must
live on
the atomic's underlying location. This cannot be expressed in the type
system
since the `L2: Location<'a, DropConsistency = L::DropConsistency>` bound
only
pins the location *type*, not the instance.

The assertion deliberately does not require the tick to be the atomic's
own
tick: independently created ticks on the same location are a supported
pattern (their clocks are unified with the atomic's clock by
`unify_atomic_ticks`), as used by `hydro_std::request_response`.

Verified: full workspace `cargo check --all-targets` passes; hydro_lang
atomic/sliced sim tests, hydro_std request_response tests, and
hydro_test
tutorial tests all pass.

---------