### PR TITLE
feat(hydro_lang)!: add InitNone boundedness variant for Optional

### DIFF
--- a/docs/docs/hydro/reference/correctness/nondet.md
+++ b/docs/docs/hydro/reference/correctness/nondet.md
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 fn singleton_with_delay<T, L>(
   singleton: Singleton<T, Process<L>, Unbounded>
-) -> Optional<T, Process<L>, Unbounded> {
+) -> Optional<T, Process<L>, InitNone> {
   singleton
     .sample_every(q!(Duration::from_secs(1)), nondet!(
       /// which intermediate values are sampled is non-deterministic, but `.last()`

--- a/hydro_lang/src/compile/ir/mod.rs
+++ b/hydro_lang/src/compile/ir/mod.rs
@@ -2316,6 +2316,15 @@ pub enum BoundKind {
 }
 
 #[derive(serde::Serialize, Clone, PartialEq, Eq, Debug)]
+pub enum OptionalBoundKind {
+    Unbounded,
+    /// The optional starts out null, but once it becomes non-null it will remain non-null
+    /// forever (though the non-null value may change arbitrarily). Erases to [`BoundKind::Unbounded`].
+    InitNone,
+    Bounded,
+}
+
+#[derive(serde::Serialize, Clone, PartialEq, Eq, Debug)]
 pub enum StreamOrder {
     NoOrder,
     TotalOrder,
@@ -2356,7 +2365,7 @@ pub enum CollectionKind {
         element_type: DebugType,
     },
     Optional {
-        bound: BoundKind,
+        bound: OptionalBoundKind,
         element_type: DebugType,
     },
     KeyedStream {
@@ -2384,7 +2393,7 @@ impl CollectionKind {
                 bound: SingletonBoundKind::Bounded,
                 ..
             } | CollectionKind::Optional {
-                bound: BoundKind::Bounded,
+                bound: OptionalBoundKind::Bounded,
                 ..
             } | CollectionKind::KeyedStream {
                 bound: BoundKind::Bounded,

--- a/hydro_lang/src/lib.rs
+++ b/hydro_lang/src/lib.rs
@@ -55,7 +55,7 @@ pub mod prelude {
     pub use crate::live_collections::boundedness::{Bounded, Unbounded};
     pub use crate::live_collections::keyed_singleton::{KeyedSingleton, MonotonicKeys};
     pub use crate::live_collections::keyed_stream::KeyedStream;
-    pub use crate::live_collections::optional::Optional;
+    pub use crate::live_collections::optional::{InitNone, Optional};
     pub use crate::live_collections::singleton::Singleton;
     pub use crate::live_collections::sliced::sliced;
     pub use crate::live_collections::stream::Stream;

--- a/hydro_lang/src/live_collections/batch_atomic.rs
+++ b/hydro_lang/src/live_collections/batch_atomic.rs
@@ -1,5 +1,6 @@
 use super::boundedness::{Bounded, Unbounded};
 use crate::live_collections::keyed_singleton::KeyedSingletonBound;
+use crate::live_collections::optional::OptionalBound;
 use crate::live_collections::singleton::SingletonBound;
 use crate::live_collections::stream::{Ordering, Retries};
 use crate::location::tick::Tick;
@@ -38,7 +39,9 @@ impl<'a, L: Location<'a>, T, B: SingletonBound> BatchAtomic<'a>
     }
 }
 
-impl<'a, L: Location<'a>, T> BatchAtomic<'a> for super::Optional<T, Atomic<L>, Unbounded> {
+impl<'a, L: Location<'a>, T, B: OptionalBound> BatchAtomic<'a>
+    for super::Optional<T, Atomic<L>, B>
+{
     type Batched = super::Optional<T, Tick<L::DropConsistency>, Bounded>;
 
     fn batched_atomic(self) -> Self::Batched {

--- a/hydro_lang/src/live_collections/boundedness.rs
+++ b/hydro_lang/src/live_collections/boundedness.rs
@@ -4,7 +4,7 @@
 use sealed::sealed;
 
 use super::keyed_singleton::KeyedSingletonBound;
-use super::optional::OptionalBound;
+use super::optional::{InitNone, OptionalBound};
 use crate::compile::ir::BoundKind;
 use crate::live_collections::singleton::SingletonBound;
 
@@ -27,6 +27,15 @@ pub trait Boundedness:
         BoundKind::Unbounded
     };
 
+    /// The [`OptionalBound`] of an optional produced by aggregating a stream with this
+    /// boundedness (e.g. `reduce`/`max`/`min`/`first`/`last`).
+    ///
+    /// A [`Bounded`] stream yields a [`Bounded`] optional. An [`Unbounded`] stream yields an
+    /// [`InitNone`] optional: such an aggregation is materialized at a top-level location where
+    /// its state persists across ticks, so once the first element arrives the result becomes
+    /// non-null and stays non-null (its value may still change).
+    type AggregatedOptional: OptionalBound<UnderlyingBound = Self>;
+
     /// Determines the output ordering of a join based on this (right/build) side's boundedness.
     ///
     /// When this side is [`Bounded`], the join accumulates this side first and then
@@ -42,6 +51,7 @@ pub enum Unbounded {}
 #[sealed]
 impl Boundedness for Unbounded {
     const BOUNDED: bool = false;
+    type AggregatedOptional = InitNone;
     type PreserveOrderIfBounded<InO: crate::live_collections::stream::Ordering> =
         crate::live_collections::stream::NoOrder;
 }
@@ -53,6 +63,7 @@ pub enum Bounded {}
 #[sealed]
 impl Boundedness for Bounded {
     const BOUNDED: bool = true;
+    type AggregatedOptional = Bounded;
     type PreserveOrderIfBounded<InO: crate::live_collections::stream::Ordering> = InO;
 }
 

--- a/hydro_lang/src/live_collections/boundedness.rs
+++ b/hydro_lang/src/live_collections/boundedness.rs
@@ -4,6 +4,7 @@
 use sealed::sealed;
 
 use super::keyed_singleton::KeyedSingletonBound;
+use super::optional::OptionalBound;
 use crate::compile::ir::BoundKind;
 use crate::live_collections::singleton::SingletonBound;
 
@@ -12,7 +13,9 @@ use crate::live_collections::singleton::SingletonBound;
 /// Implementors of this trait use it to signal the boundedness property of a stream.
 #[sealed]
 pub trait Boundedness:
-    SingletonBound<UnderlyingBound = Self> + KeyedSingletonBound<UnderlyingBound = Self>
+    SingletonBound<UnderlyingBound = Self>
+    + KeyedSingletonBound<UnderlyingBound = Self>
+    + OptionalBound<UnderlyingBound = Self>
 {
     /// `true` if the bound is [`Bounded`], `false` if it is [`Unbounded`].
     const BOUNDED: bool;

--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -1594,6 +1594,7 @@ impl<'a, K, V, L: Location<'a>, B: KeyedSingletonBound<ValueBound = Bounded>>
                 },
                 idempotent = manual_proof!(/** repeated elements are ignored */)
             ))
+            .ignore_init_none()
     }
 
     /// Converts this keyed singleton into a [`KeyedStream`] with each group having a single

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -37,8 +37,8 @@ use crate::properties::{StreamMapFuncAlgebra, ValidMutCommutativityFor, ValidMut
 /// becoming null again), this also includes additional variants that constrain how the
 /// optional's *presence* (whether it is null) and value evolve over time.
 ///
-/// The currently defined variants form a hierarchy of increasing strength, all of which erase
-/// to [`Unbounded`]:
+/// The currently defined variants form a hierarchy of increasing strength; variants other than
+/// [`Bounded`] erase to [`Unbounded`]:
 /// - [`Unbounded`]: the optional may become null and non-null arbitrarily, with an arbitrary
 ///   value whenever it is non-null.
 /// - [`InitNone`]: the optional starts null, but once it becomes non-null it stays
@@ -71,7 +71,7 @@ impl OptionalBound for Bounded {
 /// non-null forever, although the non-null value may still change arbitrarily over time.
 ///
 /// This erases to [`Unbounded`], since the value (when present) is still asynchronously changing.
-pub struct InitNone;
+pub enum InitNone {}
 
 impl OptionalBound for InitNone {
     type UnderlyingBound = Unbounded;
@@ -111,7 +111,8 @@ impl<B: IsBounded> IsInitNone for B {}
 /// Type Parameters:
 /// - `Type`: the type of the value in this optional (when it is not null)
 /// - `Loc`: the [`Location`] where the optional is materialized
-/// - `Bound`: tracks whether the value is [`Bounded`] (fixed) or [`Unbounded`] (changing asynchronously)
+/// - `Bound`: tracks whether the value is [`Bounded`] (fixed) or [`Unbounded`] (changing
+///   asynchronously) or something in between (see [`OptionalBoundKind`]).
 pub struct Optional<Type, Loc, Bound: OptionalBound> {
     pub(crate) location: Loc,
     pub(crate) ir_node: Rc<RefCell<HydroNode>>,
@@ -140,6 +141,15 @@ where
     fn from(value: Optional<T, L, Bounded>) -> Self {
         let tick = value.location().tick();
         value.clone_into_tick(&tick).latest()
+    }
+}
+
+impl<'a, T, L> From<Optional<T, L, InitNone>> for Optional<T, L, Unbounded>
+where
+    L: Location<'a>,
+{
+    fn from(value: Optional<T, L, InitNone>) -> Self {
+        value.ignore_init_none()
     }
 }
 

--- a/hydro_lang/src/live_collections/optional.rs
+++ b/hydro_lang/src/live_collections/optional.rs
@@ -5,6 +5,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::rc::Rc;
 
+use sealed::sealed;
 use stageleft::{IntoQuotedMut, QuotedWithContext, q};
 use syn::parse_quote;
 
@@ -13,7 +14,9 @@ use super::boundedness::{Bounded, Boundedness, IsBounded, Unbounded};
 use super::singleton::Singleton;
 use super::stream::{AtLeastOnce, ExactlyOnce, NoOrder, Stream, TotalOrder};
 use crate::compile::builder::{CycleId, FlowState};
-use crate::compile::ir::{CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, SharedNode};
+use crate::compile::ir::{
+    CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, OptionalBoundKind, SharedNode,
+};
 #[cfg(stageleft_runtime)]
 use crate::forward_handle::{CycleCollection, CycleCollectionWithInitial, ReceiverComplete};
 use crate::forward_handle::{ForwardRef, TickCycle};
@@ -28,6 +31,74 @@ use crate::nondet::{NonDet, nondet};
 use crate::prelude::KeyedSingleton;
 use crate::properties::{StreamMapFuncAlgebra, ValidMutCommutativityFor, ValidMutIdempotenceFor};
 
+/// A marker trait indicating the boundedness of an [`Optional`].
+///
+/// In addition to [`Bounded`] (immutable) and [`Unbounded`] (arbitrarily mutable, including
+/// becoming null again), this also includes additional variants that constrain how the
+/// optional's *presence* (whether it is null) and value evolve over time.
+///
+/// The currently defined variants form a hierarchy of increasing strength, all of which erase
+/// to [`Unbounded`]:
+/// - [`Unbounded`]: the optional may become null and non-null arbitrarily, with an arbitrary
+///   value whenever it is non-null.
+/// - [`InitNone`]: the optional starts null, but once it becomes non-null it stays
+///   non-null forever; the non-null value may still change arbitrarily.
+pub trait OptionalBound {
+    /// The [`Boundedness`] that this [`Optional`] would be erased to.
+    type UnderlyingBound: Boundedness;
+
+    /// Returns the [`OptionalBoundKind`] corresponding to this type.
+    fn bound_kind() -> OptionalBoundKind;
+}
+
+impl OptionalBound for Unbounded {
+    type UnderlyingBound = Unbounded;
+
+    fn bound_kind() -> OptionalBoundKind {
+        OptionalBoundKind::Unbounded
+    }
+}
+
+impl OptionalBound for Bounded {
+    type UnderlyingBound = Bounded;
+
+    fn bound_kind() -> OptionalBoundKind {
+        OptionalBoundKind::Bounded
+    }
+}
+
+/// Marks that the [`Optional`] is null only initially: once it becomes non-null it will remain
+/// non-null forever, although the non-null value may still change arbitrarily over time.
+///
+/// This erases to [`Unbounded`], since the value (when present) is still asynchronously changing.
+pub struct InitNone;
+
+impl OptionalBound for InitNone {
+    type UnderlyingBound = Unbounded;
+
+    fn bound_kind() -> OptionalBoundKind {
+        OptionalBoundKind::InitNone
+    }
+}
+
+#[sealed]
+#[diagnostic::on_unimplemented(
+    message = "The optional must be null-only-initially (`InitNone`) or bounded (`Bounded`), but has bound `{Self}`. Strengthen the guarantee upstream or consider a different API.",
+    label = "required here",
+    note = "To intentionally process a non-deterministic snapshot or batch, you may want to use a `sliced!` region. This introduces non-determinism so avoid unless necessary."
+)]
+/// Marker trait that is implemented for [`OptionalBound`] types that are null only initially:
+/// once the optional becomes non-null it remains non-null (or it is [`Bounded`]).
+pub trait IsInitNone: OptionalBound {}
+
+#[sealed]
+#[diagnostic::do_not_recommend]
+impl IsInitNone for InitNone {}
+
+#[sealed]
+#[diagnostic::do_not_recommend]
+impl<B: IsBounded> IsInitNone for B {}
+
 /// A *nullable* Rust value that can asynchronously change over time.
 ///
 /// Optionals are the live collection equivalent of [`Option`]. If the optional is [`Bounded`],
@@ -41,7 +112,7 @@ use crate::properties::{StreamMapFuncAlgebra, ValidMutCommutativityFor, ValidMut
 /// - `Type`: the type of the value in this optional (when it is not null)
 /// - `Loc`: the [`Location`] where the optional is materialized
 /// - `Bound`: tracks whether the value is [`Bounded`] (fixed) or [`Unbounded`] (changing asynchronously)
-pub struct Optional<Type, Loc, Bound: Boundedness> {
+pub struct Optional<Type, Loc, Bound: OptionalBound> {
     pub(crate) location: Loc,
     pub(crate) ir_node: Rc<RefCell<HydroNode>>,
     pub(crate) flow_state: FlowState,
@@ -49,7 +120,7 @@ pub struct Optional<Type, Loc, Bound: Boundedness> {
     _phantom: PhantomData<(Type, Loc, Bound)>,
 }
 
-impl<T, L, B: Boundedness> Drop for Optional<T, L, B> {
+impl<T, L, B: OptionalBound> Drop for Optional<T, L, B> {
     fn drop(&mut self) {
         let ir_node = self.ir_node.replace(HydroNode::Placeholder);
         if !matches!(ir_node, HydroNode::Placeholder) && !ir_node.is_shared_with_others() {
@@ -146,7 +217,7 @@ where
     }
 }
 
-impl<'a, T, L, B: Boundedness> CycleCollection<'a, ForwardRef> for Optional<T, L, B>
+impl<'a, T, L, B: OptionalBound> CycleCollection<'a, ForwardRef> for Optional<T, L, B>
 where
     L: Location<'a>,
 {
@@ -163,7 +234,7 @@ where
     }
 }
 
-impl<'a, T, L, B: Boundedness> ReceiverComplete<'a, ForwardRef> for Optional<T, L, B>
+impl<'a, T, L, B: OptionalBound> ReceiverComplete<'a, ForwardRef> for Optional<T, L, B>
 where
     L: Location<'a>,
 {
@@ -239,7 +310,7 @@ fn or_inside_tick<'a, T, L: Location<'a>, B: Boundedness>(
     )
 }
 
-impl<'a, T, L, B: Boundedness> Clone for Optional<T, L, B>
+impl<'a, T, L, B: OptionalBound> Clone for Optional<T, L, B>
 where
     T: Clone,
     L: Location<'a>,
@@ -272,7 +343,7 @@ where
     }
 }
 
-impl<'a, T, L, B: Boundedness> Optional<T, L, B>
+impl<'a, T, L, B: OptionalBound> Optional<T, L, B>
 where
     L: Location<'a>,
 {
@@ -291,7 +362,7 @@ where
 
     pub(crate) fn collection_kind() -> CollectionKind {
         CollectionKind::Optional {
-            bound: B::BOUND_KIND,
+            bound: <B as OptionalBound>::bound_kind(),
             element_type: stageleft::quote_type::<T>().into(),
         }
     }
@@ -404,12 +475,17 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn map<U, F>(self, f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>>) -> Optional<U, L, B>
+    pub fn map<U, F>(
+        self,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B::UnderlyingBound>>,
+    ) -> Optional<U, L, B>
     where
         F: Fn(T) -> U + 'a,
     {
         let f = f
-            .splice_fn1_ctx(&OperatorContext::<L, B>::new(&self.location))
+            .splice_fn1_ctx(&OperatorContext::<L, B::UnderlyingBound>::new(
+                &self.location,
+            ))
             .into();
         Optional::new(
             self.location.clone(),
@@ -605,19 +681,26 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn filter<F>(self, f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>>) -> Optional<T, L, B>
+    pub fn filter<F>(
+        self,
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B::UnderlyingBound>>,
+    ) -> Optional<T, L, B::UnderlyingBound>
     where
         F: Fn(&T) -> bool + 'a,
     {
         let f = f
-            .splice_fn1_borrow_ctx(&OperatorContext::<L, B>::new(&self.location))
+            .splice_fn1_borrow_ctx(&OperatorContext::<L, B::UnderlyingBound>::new(
+                &self.location,
+            ))
             .into();
         Optional::new(
             self.location.clone(),
             HydroNode::Filter {
                 f,
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                metadata: self.location.new_node_metadata(Self::collection_kind()),
+                metadata: self
+                    .location
+                    .new_node_metadata(Optional::<T, L, B::UnderlyingBound>::collection_kind()),
             },
         )
     }
@@ -648,13 +731,15 @@ where
     /// ```
     pub fn filter_map<U, F>(
         self,
-        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B>>,
-    ) -> Optional<U, L, B>
+        f: impl IntoQuotedMut<'a, F, OperatorContext<L, B::UnderlyingBound>>,
+    ) -> Optional<U, L, B::UnderlyingBound>
     where
         F: Fn(T) -> Option<U> + 'a,
     {
         let f = f
-            .splice_fn1_ctx(&OperatorContext::<L, B>::new(&self.location))
+            .splice_fn1_ctx(&OperatorContext::<L, B::UnderlyingBound>::new(
+                &self.location,
+            ))
             .into();
         Optional::new(
             self.location.clone(),
@@ -663,7 +748,7 @@ where
                 input: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                 metadata: self
                     .location
-                    .new_node_metadata(Optional::<U, L, B>::collection_kind()),
+                    .new_node_metadata(Optional::<U, L, B::UnderlyingBound>::collection_kind()),
             },
         )
     }
@@ -747,16 +832,20 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn or(self, other: Optional<T, L, B>) -> Optional<T, L, B> {
-        check_matching_location(&self.location, &other.location);
+    pub fn or(
+        self,
+        other: Optional<T, L, B::UnderlyingBound>,
+    ) -> Optional<T, L, B::UnderlyingBound> {
+        let me = self.ignore_init_none();
+        check_matching_location(&me.location, &other.location);
 
         if L::is_top_level()
-            && !B::BOUNDED // only if unbounded we need to use a tick
-            && let Some(tick) = self.location.try_tick()
+            && !<B::UnderlyingBound as Boundedness>::BOUNDED // only if unbounded we need to use a tick
+            && let Some(tick) = me.location.try_tick()
         {
-            let self_location = self.location().clone();
+            let self_location = me.location().clone();
             let out = or_inside_tick(
-                self.snapshot(&tick, nondet!(/** eventually stabilizes */)),
+                me.snapshot(&tick, nondet!(/** eventually stabilizes */)),
                 other.snapshot(&tick, nondet!(/** eventually stabilizes */)),
             )
             .latest();
@@ -764,11 +853,13 @@ where
             Optional::new(self_location, out.ir_node.replace(HydroNode::Placeholder))
         } else {
             Optional::new(
-                self.location.clone(),
+                me.location.clone(),
                 HydroNode::ChainFirst {
-                    first: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    first: Box::new(me.ir_node.replace(HydroNode::Placeholder)),
                     second: Box::new(other.ir_node.replace(HydroNode::Placeholder)),
-                    metadata: self.location.new_node_metadata(Self::collection_kind()),
+                    metadata: me
+                        .location
+                        .new_node_metadata(Optional::<T, L, B::UnderlyingBound>::collection_kind()),
                 },
             )
         }
@@ -804,15 +895,21 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn unwrap_or(self, other: Singleton<T, L, B>) -> Singleton<T, L, B> {
+    pub fn unwrap_or(
+        self,
+        other: Singleton<T, L, B::UnderlyingBound>,
+    ) -> Singleton<T, L, B::UnderlyingBound> {
         let res_option = self.or(other.into());
         Singleton::new(
             res_option.location.clone(),
             HydroNode::Cast {
                 inner: Box::new(res_option.ir_node.replace(HydroNode::Placeholder)),
-                metadata: res_option
-                    .location
-                    .new_node_metadata(Singleton::<T, L, B>::collection_kind()),
+                metadata: res_option.location.new_node_metadata(Singleton::<
+                    T,
+                    L,
+                    B::UnderlyingBound,
+                >::collection_kind(
+                )),
             },
         )
     }
@@ -842,7 +939,7 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn unwrap_or_default(self) -> Singleton<T, L, B>
+    pub fn unwrap_or_default(self) -> Singleton<T, L, B::UnderlyingBound>
     where
         T: Default + Clone,
     {
@@ -875,7 +972,7 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn into_singleton(self) -> Singleton<Option<T>, L, B>
+    pub fn into_singleton(self) -> Singleton<Option<T>, L, B::UnderlyingBound>
     where
         T: Clone,
     {
@@ -886,9 +983,11 @@ where
             HydroNode::SingletonSource {
                 value: none.into(),
                 first_tick_only: false,
-                metadata: self
-                    .location
-                    .new_node_metadata(Singleton::<Option<T>, L, B>::collection_kind()),
+                metadata: self.location.new_node_metadata(Singleton::<
+                    Option<T>,
+                    L,
+                    B::UnderlyingBound,
+                >::collection_kind()),
             },
         );
 
@@ -918,7 +1017,7 @@ where
     /// # }
     /// ```
     #[expect(clippy::wrong_self_convention, reason = "Stream naming")]
-    pub fn is_some(self) -> Singleton<bool, L, B> {
+    pub fn is_some(self) -> Singleton<bool, L, B::UnderlyingBound> {
         self.map(q!(|_| ()))
             .into_singleton()
             .map(q!(|o| o.is_some()))
@@ -947,7 +1046,7 @@ where
     /// # }
     /// ```
     #[expect(clippy::wrong_self_convention, reason = "Stream naming")]
-    pub fn is_none(self) -> Singleton<bool, L, B> {
+    pub fn is_none(self) -> Singleton<bool, L, B::UnderlyingBound> {
         self.map(q!(|_| ()))
             .into_singleton()
             .map(q!(|o| o.is_none()))
@@ -997,6 +1096,28 @@ where
             metadata.tag = Some(name.to_owned());
         }
         self
+    }
+
+    /// Drops the [`InitNone`] guarantee of the [`Optional`], erasing it to its
+    /// [`OptionalBound::UnderlyingBound`] (i.e. [`Unbounded`] for [`InitNone`]).
+    pub fn ignore_init_none(self) -> Optional<T, L, B::UnderlyingBound> {
+        if <B as OptionalBound>::bound_kind() == <B::UnderlyingBound as OptionalBound>::bound_kind()
+        {
+            Optional::new(
+                self.location.clone(),
+                self.ir_node.replace(HydroNode::Placeholder),
+            )
+        } else {
+            Optional::new(
+                self.location.clone(),
+                HydroNode::Cast {
+                    inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
+                    metadata: self
+                        .location
+                        .new_node_metadata(Optional::<T, L, B::UnderlyingBound>::collection_kind()),
+                },
+            )
+        }
     }
 
     /// Strengthens the boundedness guarantee to `Bounded`, given that `B: IsBounded`, which
@@ -1246,7 +1367,7 @@ where
     }
 }
 
-impl<'a, K, V, L, B: Boundedness> Optional<(K, V), L, B>
+impl<'a, K, V, L, B: OptionalBound> Optional<(K, V), L, B>
 where
     L: Location<'a>,
 {
@@ -1257,20 +1378,23 @@ where
     /// if it is [`Unbounded`], the [`KeyedSingleton`] will be [`Unbounded`], which means that
     /// the entry will be updated and appear / disappear according to the state of the
     /// [`Optional`].
-    pub fn into_keyed_singleton(self) -> KeyedSingleton<K, V, L, B> {
+    pub fn into_keyed_singleton(self) -> KeyedSingleton<K, V, L, B::UnderlyingBound> {
         KeyedSingleton::new(
             self.location.clone(),
             HydroNode::Cast {
                 inner: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
-                metadata: self
-                    .location
-                    .new_node_metadata(KeyedSingleton::<K, V, L, B>::collection_kind()),
+                metadata: self.location.new_node_metadata(KeyedSingleton::<
+                    K,
+                    V,
+                    L,
+                    B::UnderlyingBound,
+                >::collection_kind()),
             },
         )
     }
 }
 
-impl<'a, T, L, B: Boundedness> Optional<T, Atomic<L>, B>
+impl<'a, T, L, B: OptionalBound> Optional<T, Atomic<L>, B>
 where
     L: Location<'a>,
 {
@@ -1300,7 +1424,7 @@ where
     }
 }
 
-impl<'a, T, L, B: Boundedness> Optional<T, L, B>
+impl<'a, T, L, B: OptionalBound> Optional<T, L, B>
 where
     L: Location<'a>,
 {

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -15,7 +15,8 @@ use super::sliced::sliced;
 use super::stream::{AtLeastOnce, ExactlyOnce, NoOrder, Stream, TotalOrder};
 use crate::compile::builder::{CycleId, FlowState};
 use crate::compile::ir::{
-    CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, SharedNode, SingletonBoundKind,
+    CollectionKind, HydroIrOpMetadata, HydroNode, HydroRoot, OptionalBoundKind, SharedNode,
+    SingletonBoundKind,
 };
 #[cfg(stageleft_runtime)]
 use crate::forward_handle::{CycleCollection, CycleCollectionWithInitial, ReceiverComplete};
@@ -854,7 +855,7 @@ where
                     left: Box::new(self.ir_node.replace(HydroNode::Placeholder)),
                     right: Box::new(Self::other_ir_node(other)),
                     metadata: self.location.new_node_metadata(CollectionKind::Optional {
-                        bound: B::BOUND_KIND,
+                        bound: OptionalBoundKind::Bounded,
                         element_type: stageleft::quote_type::<
                             <Self as ZipResult<'a, O>>::ElementType,
                         >()

--- a/hydro_lang/src/live_collections/stream/mod.rs
+++ b/hydro_lang/src/live_collections/stream/mod.rs
@@ -1504,7 +1504,7 @@ where
     pub fn reduce<F, C, Idemp>(
         self,
         comb: impl IntoQuotedMut<'a, F, OperatorContext<L, B>, AggFuncAlgebra<C, Idemp>>,
-    ) -> Optional<T, L, B>
+    ) -> Optional<T, L, B::AggregatedOptional>
     where
         F: Fn(&mut T, T) + 'a,
         C: ValidCommutativityFor<O>,
@@ -1521,9 +1521,11 @@ where
         let core = HydroNode::Reduce {
             f: f.into(),
             input: Box::new(ordered_etc.ir_node.replace(HydroNode::Placeholder)),
-            metadata: ordered_etc
-                .location
-                .new_node_metadata(Optional::<T, L::DropConsistency, B>::collection_kind()),
+            metadata: ordered_etc.location.new_node_metadata(Optional::<
+                T,
+                L::DropConsistency,
+                B::AggregatedOptional,
+            >::collection_kind()),
         };
 
         Optional::new(ordered_etc.location.clone(), core)
@@ -1549,7 +1551,7 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn max(self) -> Optional<T, L, B>
+    pub fn max(self) -> Optional<T, L, B::AggregatedOptional>
     where
         T: Ord,
     {
@@ -1583,7 +1585,7 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn min(self) -> Optional<T, L, B>
+    pub fn min(self) -> Optional<T, L, B::AggregatedOptional>
     where
         T: Ord,
     {
@@ -1620,7 +1622,7 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn first(self) -> Optional<T, L, B>
+    pub fn first(self) -> Optional<T, L, B::AggregatedOptional>
     where
         O: IsOrdered,
     {
@@ -1652,7 +1654,7 @@ where
     /// # }));
     /// # }
     /// ```
-    pub fn last(self) -> Optional<T, L, B>
+    pub fn last(self) -> Optional<T, L, B::AggregatedOptional>
     where
         O: IsOrdered,
     {

--- a/hydro_lang/src/nondet.rs
+++ b/hydro_lang/src/nondet.rs
@@ -43,7 +43,7 @@ pub use crate::__nondet__ as nondet;
 /// # #[cfg(feature = "tokio")]
 /// fn singleton_with_delay<T, L>(
 ///   singleton: Singleton<T, Process<L>, Unbounded>
-/// ) -> Optional<T, Process<L>, Unbounded> {
+/// ) -> Optional<T, Process<L>, InitNone> {
 ///   singleton
 ///     .sample_every(q!(Duration::from_secs(1)), nondet!(/**
 ///         non-deterministic samples will eventually resolve to stable result

--- a/hydro_lang/src/viz/render.rs
+++ b/hydro_lang/src/viz/render.rs
@@ -385,7 +385,7 @@ pub fn extract_edge_properties_from_collection_kind(
         }
         CollectionKind::Optional { bound, .. } => {
             properties.insert(HydroEdgeProp::Optional);
-            add_bound_property(&mut properties, bound);
+            add_optional_bound_property(&mut properties, bound);
             // Optionals have implicit TotalOrder
             properties.insert(HydroEdgeProp::TotalOrder);
         }
@@ -413,6 +413,23 @@ fn add_bound_property(
             properties.insert(HydroEdgeProp::Bounded);
         }
         BoundKind::Unbounded => {
+            properties.insert(HydroEdgeProp::Unbounded);
+        }
+    }
+}
+
+/// Helper function to add bound property for Optional based on OptionalBoundKind.
+fn add_optional_bound_property(
+    properties: &mut HashSet<HydroEdgeProp>,
+    bound: &crate::compile::ir::OptionalBoundKind,
+) {
+    use crate::compile::ir::OptionalBoundKind;
+
+    match bound {
+        OptionalBoundKind::Bounded => {
+            properties.insert(HydroEdgeProp::Bounded);
+        }
+        OptionalBoundKind::InitNone | OptionalBoundKind::Unbounded => {
             properties.insert(HydroEdgeProp::Unbounded);
         }
     }

--- a/hydro_test/src/cluster/paxos_with_client.rs
+++ b/hydro_test/src/cluster/paxos_with_client.rs
@@ -63,7 +63,8 @@ pub trait PaxosLike<'a>: Sized {
                             "Client notified that leader was elected: {:?}",
                             ballot
                         )))
-                        .max(),
+                        .max()
+                        .into(),
                 );
 
                 let payloads_at_proposer = sliced! {

--- a/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
+++ b/hydro_test/src/cluster/snapshots/compute_pi_ir.snap
@@ -195,7 +195,7 @@ expression: built.ir()
                                         metadata: HydroIrMetadata {
                                             location_id: Process(loc2v1),
                                             collection_kind: Optional {
-                                                bound: Unbounded,
+                                                bound: InitNone,
                                                 element_type: (u64 , u64),
                                             },
                                         },

--- a/hydro_test/src/cluster/snapshots/paxos_ir.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir.snap
@@ -277,18 +277,43 @@ expression: built.ir()
                                             inner: YieldConcat {
                                                 inner: ChainFirst {
                                                     first: Batch {
-                                                        inner: Map {
-                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_LINE_COL ! ([] [| v | Some (v)]) }),
-                                                            input: Reduce {
-                                                                f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
-                                                                input: ObserveNonDet {
-                                                                    inner: ObserveNonDet {
-                                                                        inner: Chain {
-                                                                            first: Chain {
-                                                                                first: CycleSource {
-                                                                                    cycle_id: CycleId(
-                                                                                        5,
-                                                                                    ),
+                                                        inner: Cast {
+                                                            inner: Map {
+                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_LINE_COL ! ([] [| v | Some (v)]) }),
+                                                                input: Reduce {
+                                                                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
+                                                                    input: ObserveNonDet {
+                                                                        inner: ObserveNonDet {
+                                                                            inner: Chain {
+                                                                                first: Chain {
+                                                                                    first: CycleSource {
+                                                                                        cycle_id: CycleId(
+                                                                                            5,
+                                                                                        ),
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_id: Cluster(loc1v1),
+                                                                                            collection_kind: Stream {
+                                                                                                bound: Unbounded,
+                                                                                                order: NoOrder,
+                                                                                                retry: ExactlyOnce,
+                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                            },
+                                                                                        },
+                                                                                    },
+                                                                                    second: CycleSource {
+                                                                                        cycle_id: CycleId(
+                                                                                            3,
+                                                                                        ),
+                                                                                        metadata: HydroIrMetadata {
+                                                                                            location_id: Cluster(loc1v1),
+                                                                                            collection_kind: Stream {
+                                                                                                bound: Unbounded,
+                                                                                                order: NoOrder,
+                                                                                                retry: ExactlyOnce,
+                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                            },
+                                                                                        },
+                                                                                    },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Cluster(loc1v1),
                                                                                         collection_kind: Stream {
@@ -301,32 +326,18 @@ expression: built.ir()
                                                                                 },
                                                                                 second: CycleSource {
                                                                                     cycle_id: CycleId(
-                                                                                        3,
+                                                                                        6,
                                                                                     ),
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Cluster(loc1v1),
                                                                                         collection_kind: Stream {
                                                                                             bound: Unbounded,
                                                                                             order: NoOrder,
-                                                                                            retry: ExactlyOnce,
+                                                                                            retry: AtLeastOnce,
                                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                         },
                                                                                     },
                                                                                 },
-                                                                                metadata: HydroIrMetadata {
-                                                                                    location_id: Cluster(loc1v1),
-                                                                                    collection_kind: Stream {
-                                                                                        bound: Unbounded,
-                                                                                        order: NoOrder,
-                                                                                        retry: ExactlyOnce,
-                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                    },
-                                                                                },
-                                                                            },
-                                                                            second: CycleSource {
-                                                                                cycle_id: CycleId(
-                                                                                    6,
-                                                                                ),
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Cluster(loc1v1),
                                                                                     collection_kind: Stream {
@@ -337,34 +348,32 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                             },
+                                                                            trusted: true,
                                                                             metadata: HydroIrMetadata {
                                                                                 location_id: Cluster(loc1v1),
                                                                                 collection_kind: Stream {
                                                                                     bound: Unbounded,
                                                                                     order: NoOrder,
-                                                                                    retry: AtLeastOnce,
+                                                                                    retry: ExactlyOnce,
                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                 },
                                                                             },
                                                                         },
-                                                                        trusted: true,
+                                                                        trusted: false,
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Cluster(loc1v1),
                                                                             collection_kind: Stream {
                                                                                 bound: Unbounded,
-                                                                                order: NoOrder,
+                                                                                order: TotalOrder,
                                                                                 retry: ExactlyOnce,
                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                             },
                                                                         },
                                                                     },
-                                                                    trusted: false,
                                                                     metadata: HydroIrMetadata {
                                                                         location_id: Cluster(loc1v1),
-                                                                        collection_kind: Stream {
-                                                                            bound: Unbounded,
-                                                                            order: TotalOrder,
-                                                                            retry: ExactlyOnce,
+                                                                        collection_kind: Optional {
+                                                                            bound: InitNone,
                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                         },
                                                                     },
@@ -372,8 +381,8 @@ expression: built.ir()
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Cluster(loc1v1),
                                                                     collection_kind: Optional {
-                                                                        bound: Unbounded,
-                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                        bound: InitNone,
+                                                                        element_type: core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot >,
                                                                     },
                                                                 },
                                                             },
@@ -1892,7 +1901,7 @@ expression: built.ir()
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Atomic(Tick(2, Cluster(loc2v1))),
                                                                                                 collection_kind: Optional {
-                                                                                                    bound: Unbounded,
+                                                                                                    bound: InitNone,
                                                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                                 },
                                                                                             },
@@ -2341,44 +2350,54 @@ expression: built.ir()
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < ((hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) , hydro_test :: __staged :: cluster :: paxos :: Ballot) , core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [move | ((quorum_ballot , quorum_accepted) , my_ballot) | if quorum_ballot == my_ballot { Some (quorum_accepted) } else { None }]) }),
                                                     input: CrossSingleton {
                                                         left: Batch {
-                                                            inner: Reduce {
-                                                                f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL ! ([] [move | curr , new | { if new . 0 > curr . 0 { * curr = new ; } }]) }),
-                                                                input: ObserveNonDet {
-                                                                    inner: Cast {
+                                                            inner: Cast {
+                                                                inner: Reduce {
+                                                                    f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) , (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL ! ([] [move | curr , new | { if new . 0 > curr . 0 { * curr = new ; } }]) }),
+                                                                    input: ObserveNonDet {
                                                                         inner: Cast {
                                                                             inner: Cast {
-                                                                                inner: FlatMap {
-                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) > , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([] [| d | d]) }),
-                                                                                    input: Scan {
-                                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < std :: collections :: hash_map :: HashMap < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([] [| | HashMap :: new ()]) }),
-                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , core :: option :: Option < core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: __deps :: hydro_lang :: live_collections :: keyed_stream :: Generate < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([quorum_size__free = 2usize ,] [move | logs , log | { logs . push (log) ; logs . len () >= quorum_size__free }]) }) ,] [move | key_state , v | { if let Some (key_state_value) = key_state . as_mut () { if f__free (key_state_value , v) { Generate :: Return (key_state . take () . unwrap ()) } else { Generate :: Continue } } else { unreachable ! () } }]) }) , init__free = stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([init__free = stageleft :: runtime_support :: fn0_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| | vec ! []]) }) ,] [move | | Some (init__free ())]) }) ,] [move | acc : & mut HashMap < _ , _ > , (k , v) | { let existing_state = acc . entry (Clone :: clone (& k)) . or_insert_with (| | Some (init__free ())) ; if let Some (existing_state_value) = existing_state { match f__free (existing_state_value , v) { Generate :: Yield (out) => Some (Some ((k , out))) , Generate :: Return (out) => { let _ = existing_state . take () ; Some (Some ((k , out))) } Generate :: Break => { let _ = existing_state . take () ; Some (None) } Generate :: Continue => Some (None) , } } else { Some (None) } }]) }),
-                                                                                        input: ObserveNonDet {
-                                                                                            inner: Cast {
-                                                                                                inner: YieldConcat {
-                                                                                                    inner: FilterMap {
-                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([] [move | (key , res) | match res { Ok (v) => Some ((key , v)) , Err (_) => None , }]) }),
-                                                                                                        input: AntiJoin {
-                                                                                                            pos: AntiJoin {
-                                                                                                                pos: Tee {
-                                                                                                                    inner: <shared 7>,
-                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(9, Cluster(loc1v1)),
-                                                                                                                        collection_kind: Stream {
-                                                                                                                            bound: Bounded,
-                                                                                                                            order: NoOrder,
-                                                                                                                            retry: ExactlyOnce,
-                                                                                                                            element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
+                                                                                inner: Cast {
+                                                                                    inner: FlatMap {
+                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) > , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([] [| d | d]) }),
+                                                                                        input: Scan {
+                                                                                            init: stageleft :: runtime_support :: fn0_type_hint :: < std :: collections :: hash_map :: HashMap < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([] [| | HashMap :: new ()]) }),
+                                                                                            acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: collections :: hash_map :: HashMap < hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: option :: Option < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > > , (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) , core :: option :: Option < core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , hydro_test :: __staged :: __deps :: hydro_lang :: live_collections :: keyed_stream :: Generate < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([f__free = stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , bool > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([quorum_size__free = 2usize ,] [move | logs , log | { logs . push (log) ; logs . len () >= quorum_size__free }]) }) ,] [move | key_state , v | { if let Some (key_state_value) = key_state . as_mut () { if f__free (key_state_value , v) { Generate :: Return (key_state . take () . unwrap ()) } else { Generate :: Continue } } else { unreachable ! () } }]) }) , init__free = stageleft :: runtime_support :: fn0_type_hint :: < core :: option :: Option < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([init__free = stageleft :: runtime_support :: fn0_type_hint :: < std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| | vec ! []]) }) ,] [move | | Some (init__free ())]) }) ,] [move | acc : & mut HashMap < _ , _ > , (k , v) | { let existing_state = acc . entry (Clone :: clone (& k)) . or_insert_with (| | Some (init__free ())) ; if let Some (existing_state_value) = existing_state { match f__free (existing_state_value , v) { Generate :: Yield (out) => Some (Some ((k , out))) , Generate :: Return (out) => { let _ = existing_state . take () ; Some (Some ((k , out))) } Generate :: Break => { let _ = existing_state . take () ; Some (None) } Generate :: Continue => Some (None) , } } else { Some (None) } }]) }),
+                                                                                            input: ObserveNonDet {
+                                                                                                inner: Cast {
+                                                                                                    inner: YieldConcat {
+                                                                                                        inner: FilterMap {
+                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >) , core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)) > > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([] [move | (key , res) | match res { Ok (v) => Some ((key , v)) , Err (_) => None , }]) }),
+                                                                                                            input: AntiJoin {
+                                                                                                                pos: AntiJoin {
+                                                                                                                    pos: Tee {
+                                                                                                                        inner: <shared 7>,
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                            collection_kind: Stream {
+                                                                                                                                bound: Bounded,
+                                                                                                                                order: NoOrder,
+                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
+                                                                                                                            },
                                                                                                                         },
                                                                                                                     },
-                                                                                                                },
-                                                                                                                neg: Map {
-                                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL ! ([] [| (k , _) | k]) }),
-                                                                                                                    input: Cast {
-                                                                                                                        inner: Cast {
-                                                                                                                            inner: Filter {
-                                                                                                                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([min__free = 2usize ,] [move | (success , _error) | success < & min__free]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
-                                                                                                                                input: Tee {
-                                                                                                                                    inner: <shared 12>,
+                                                                                                                    neg: Map {
+                                                                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL ! ([] [| (k , _) | k]) }),
+                                                                                                                        input: Cast {
+                                                                                                                            inner: Cast {
+                                                                                                                                inner: Filter {
+                                                                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < (usize , usize) , bool > ({ use hydro_std :: __staged :: __deps :: * ; use hydro_std :: __staged :: quorum :: * ; hydro_std :: __stageleft_quote_src_quorum_rs_LINE_COL ! ([min__free = 2usize ,] [move | (success , _error) | success < & min__free]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
+                                                                                                                                    input: Tee {
+                                                                                                                                        inner: <shared 12>,
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                                            collection_kind: KeyedSingleton {
+                                                                                                                                                bound: Bounded,
+                                                                                                                                                key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                                                value_type: (usize , usize),
+                                                                                                                                            },
+                                                                                                                                        },
+                                                                                                                                    },
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(9, Cluster(loc1v1)),
                                                                                                                                         collection_kind: KeyedSingleton {
@@ -2390,8 +2409,10 @@ expression: built.ir()
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_id: Tick(9, Cluster(loc1v1)),
-                                                                                                                                    collection_kind: KeyedSingleton {
+                                                                                                                                    collection_kind: KeyedStream {
                                                                                                                                         bound: Bounded,
+                                                                                                                                        value_order: TotalOrder,
+                                                                                                                                        value_retry: ExactlyOnce,
                                                                                                                                         key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                                                                         value_type: (usize , usize),
                                                                                                                                     },
@@ -2399,12 +2420,11 @@ expression: built.ir()
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_id: Tick(9, Cluster(loc1v1)),
-                                                                                                                                collection_kind: KeyedStream {
+                                                                                                                                collection_kind: Stream {
                                                                                                                                     bound: Bounded,
-                                                                                                                                    value_order: TotalOrder,
-                                                                                                                                    value_retry: ExactlyOnce,
-                                                                                                                                    key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                                    value_type: (usize , usize),
+                                                                                                                                    order: NoOrder,
+                                                                                                                                    retry: ExactlyOnce,
+                                                                                                                                    element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)),
                                                                                                                                 },
                                                                                                                             },
                                                                                                                         },
@@ -2414,7 +2434,32 @@ expression: built.ir()
                                                                                                                                 bound: Bounded,
                                                                                                                                 order: NoOrder,
                                                                                                                                 retry: ExactlyOnce,
-                                                                                                                                element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , (usize , usize)),
+                                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                        location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                        collection_kind: Stream {
+                                                                                                                            bound: Bounded,
+                                                                                                                            order: NoOrder,
+                                                                                                                            retry: ExactlyOnce,
+                                                                                                                            element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
+                                                                                                                        },
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                neg: DeferTick {
+                                                                                                                    input: CycleSource {
+                                                                                                                        cycle_id: CycleId(
+                                                                                                                            10,
+                                                                                                                        ),
+                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                            location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                                            collection_kind: Stream {
+                                                                                                                                bound: Bounded,
+                                                                                                                                order: NoOrder,
+                                                                                                                                retry: ExactlyOnce,
+                                                                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                                                             },
                                                                                                                         },
                                                                                                                     },
@@ -2438,45 +2483,20 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                 },
                                                                                                             },
-                                                                                                            neg: DeferTick {
-                                                                                                                input: CycleSource {
-                                                                                                                    cycle_id: CycleId(
-                                                                                                                        10,
-                                                                                                                    ),
-                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                        location_id: Tick(9, Cluster(loc1v1)),
-                                                                                                                        collection_kind: Stream {
-                                                                                                                            bound: Bounded,
-                                                                                                                            order: NoOrder,
-                                                                                                                            retry: ExactlyOnce,
-                                                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                        },
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(9, Cluster(loc1v1)),
-                                                                                                                    collection_kind: Stream {
-                                                                                                                        bound: Bounded,
-                                                                                                                        order: NoOrder,
-                                                                                                                        retry: ExactlyOnce,
-                                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                                    },
-                                                                                                                },
-                                                                                                            },
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_id: Tick(9, Cluster(loc1v1)),
                                                                                                                 collection_kind: Stream {
                                                                                                                     bound: Bounded,
                                                                                                                     order: NoOrder,
                                                                                                                     retry: ExactlyOnce,
-                                                                                                                    element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , core :: result :: Result < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) , core :: option :: Option < hydro_test :: __staged :: cluster :: paxos :: Ballot > >),
+                                                                                                                    element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)),
                                                                                                                 },
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
-                                                                                                            location_id: Tick(9, Cluster(loc1v1)),
+                                                                                                            location_id: Cluster(loc1v1),
                                                                                                             collection_kind: Stream {
-                                                                                                                bound: Bounded,
+                                                                                                                bound: Unbounded,
                                                                                                                 order: NoOrder,
                                                                                                                 retry: ExactlyOnce,
                                                                                                                 element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)),
@@ -2485,53 +2505,52 @@ expression: built.ir()
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
                                                                                                         location_id: Cluster(loc1v1),
-                                                                                                        collection_kind: Stream {
+                                                                                                        collection_kind: KeyedStream {
                                                                                                             bound: Unbounded,
-                                                                                                            order: NoOrder,
-                                                                                                            retry: ExactlyOnce,
-                                                                                                            element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >)),
+                                                                                                            value_order: NoOrder,
+                                                                                                            value_retry: ExactlyOnce,
+                                                                                                            key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                            value_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
                                                                                                         },
                                                                                                     },
                                                                                                 },
+                                                                                                trusted: false,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Cluster(loc1v1),
                                                                                                     collection_kind: KeyedStream {
                                                                                                         bound: Unbounded,
-                                                                                                        value_order: NoOrder,
+                                                                                                        value_order: TotalOrder,
                                                                                                         value_retry: ExactlyOnce,
                                                                                                         key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                                         value_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
                                                                                                     },
                                                                                                 },
                                                                                             },
-                                                                                            trusted: false,
                                                                                             metadata: HydroIrMetadata {
                                                                                                 location_id: Cluster(loc1v1),
-                                                                                                collection_kind: KeyedStream {
+                                                                                                collection_kind: Stream {
                                                                                                     bound: Unbounded,
-                                                                                                    value_order: TotalOrder,
-                                                                                                    value_retry: ExactlyOnce,
-                                                                                                    key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                                    value_type: (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >),
+                                                                                                    order: TotalOrder,
+                                                                                                    retry: ExactlyOnce,
+                                                                                                    element_type: core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) >,
                                                                                                 },
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_id: Cluster(loc1v1),
-                                                                                            collection_kind: Stream {
+                                                                                            collection_kind: KeyedStream {
                                                                                                 bound: Unbounded,
-                                                                                                order: TotalOrder,
-                                                                                                retry: ExactlyOnce,
-                                                                                                element_type: core :: option :: Option < (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >) >,
+                                                                                                value_order: TotalOrder,
+                                                                                                value_retry: ExactlyOnce,
+                                                                                                key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                value_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
                                                                                             },
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
                                                                                         location_id: Cluster(loc1v1),
-                                                                                        collection_kind: KeyedStream {
-                                                                                            bound: Unbounded,
-                                                                                            value_order: TotalOrder,
-                                                                                            value_retry: ExactlyOnce,
+                                                                                        collection_kind: KeyedSingleton {
+                                                                                            bound: BoundedValue,
                                                                                             key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                             value_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
                                                                                         },
@@ -2539,8 +2558,10 @@ expression: built.ir()
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
                                                                                     location_id: Cluster(loc1v1),
-                                                                                    collection_kind: KeyedSingleton {
-                                                                                        bound: BoundedValue,
+                                                                                    collection_kind: KeyedStream {
+                                                                                        bound: Unbounded,
+                                                                                        value_order: TotalOrder,
+                                                                                        value_retry: ExactlyOnce,
                                                                                         key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                         value_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
                                                                                     },
@@ -2548,32 +2569,29 @@ expression: built.ir()
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_id: Cluster(loc1v1),
-                                                                                collection_kind: KeyedStream {
+                                                                                collection_kind: Stream {
                                                                                     bound: Unbounded,
-                                                                                    value_order: TotalOrder,
-                                                                                    value_retry: ExactlyOnce,
-                                                                                    key_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
-                                                                                    value_type: std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >,
+                                                                                    order: NoOrder,
+                                                                                    retry: ExactlyOnce,
+                                                                                    element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >),
                                                                                 },
                                                                             },
                                                                         },
+                                                                        trusted: true,
                                                                         metadata: HydroIrMetadata {
                                                                             location_id: Cluster(loc1v1),
                                                                             collection_kind: Stream {
                                                                                 bound: Unbounded,
-                                                                                order: NoOrder,
+                                                                                order: TotalOrder,
                                                                                 retry: ExactlyOnce,
                                                                                 element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >),
                                                                             },
                                                                         },
                                                                     },
-                                                                    trusted: true,
                                                                     metadata: HydroIrMetadata {
                                                                         location_id: Cluster(loc1v1),
-                                                                        collection_kind: Stream {
-                                                                            bound: Unbounded,
-                                                                            order: TotalOrder,
-                                                                            retry: ExactlyOnce,
+                                                                        collection_kind: Optional {
+                                                                            bound: InitNone,
                                                                             element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , std :: vec :: Vec < (core :: option :: Option < usize > , std :: collections :: hash_map :: HashMap < usize , hydro_test :: __staged :: cluster :: paxos :: LogValue < (u32 , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , i32)) > >) >),
                                                                         },
                                                                     },
@@ -3063,87 +3081,97 @@ expression: built.ir()
                                             inner: <shared 17>: Batch {
                                                 inner: Map {
                                                     f: stageleft :: runtime_support :: fn1_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| ballot | ballot . proposer_id]) }),
-                                                    input: Reduce {
-                                                        f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
-                                                        input: ObserveNonDet {
-                                                            inner: Inspect {
-                                                                f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_with_client_rs_LINE_COL ! ([] [| ballot | println ! ("Client notified that leader was elected: {:?}" , ballot)]) }),
-                                                                input: Map {
-                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([] [| (_ , v) | v]) }),
-                                                                    input: Cast {
-                                                                        inner: Network {
-                                                                            name: None,
-                                                                            networking_info: Tcp {
-                                                                                fault: FailStop,
-                                                                            },
-                                                                            serialize: Custom {
-                                                                                serialize_fn: Some(
-                                                                                    hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
-                                                                                ),
-                                                                            },
-                                                                            deserialize: Custom {
-                                                                                deserialize_fn: Some(
-                                                                                    | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: Ballot > (& b) . unwrap ()) },
-                                                                                ),
-                                                                            },
-                                                                            instantiate_fn: <network instantiate>,
-                                                                            input: YieldConcat {
-                                                                                inner: Cast {
-                                                                                    inner: CrossProduct {
-                                                                                        left: ObserveNonDet {
-                                                                                            inner: Map {
-                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL ! ([] [| (k , _) | k]) }),
-                                                                                                input: Cast {
-                                                                                                    inner: Cast {
-                                                                                                        inner: Filter {
-                                                                                                            f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL ! ([] [| b | * b]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
-                                                                                                            input: Batch {
-                                                                                                                inner: FoldKeyed {
-                                                                                                                    init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL ! ([] [| | false]) }),
-                                                                                                                    acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL ! ([] [| present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } }]) }),
-                                                                                                                    input: Cast {
-                                                                                                                        inner: Map {
-                                                                                                                            f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; hydro_lang :: __stageleft_quote_src_location_mod_rs_LINE_COL ! ([] [| (k , v) | (MemberId :: from_tagless (k) , v)]) }),
-                                                                                                                            input: Source {
-                                                                                                                                source: ClusterMembers(
-                                                                                                                                    Cluster(loc3v1),
-                                                                                                                                    Uninit,
-                                                                                                                                ),
+                                                    input: Cast {
+                                                        inner: Reduce {
+                                                            f: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_mod_rs_LINE_COL ! ([] [| curr , new | { if new > * curr { * curr = new ; } }]) }),
+                                                            input: ObserveNonDet {
+                                                                inner: Inspect {
+                                                                    f: stageleft :: runtime_support :: fnmut1_borrow_type_hint :: < hydro_test :: __staged :: cluster :: paxos :: Ballot , () > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos_with_client :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_with_client_rs_LINE_COL ! ([] [| ballot | println ! ("Client notified that leader was elected: {:?}" , ballot)]) }),
+                                                                    input: Map {
+                                                                        f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_stream :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_stream_mod_rs_LINE_COL ! ([] [| (_ , v) | v]) }),
+                                                                        input: Cast {
+                                                                            inner: Network {
+                                                                                name: None,
+                                                                                networking_info: Tcp {
+                                                                                    fault: FailStop,
+                                                                                },
+                                                                                serialize: Custom {
+                                                                                    serialize_fn: Some(
+                                                                                        hydro_lang :: runtime_support :: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_lang :: __staged :: location :: MemberId < _ > , hydro_test :: __staged :: cluster :: paxos :: Ballot) , _ > (| (id , data) | { (id . into_tagless () , hydro_lang :: runtime_support :: bincode :: serialize (& data) . unwrap () . into ()) }),
+                                                                                    ),
+                                                                                },
+                                                                                deserialize: Custom {
+                                                                                    deserialize_fn: Some(
+                                                                                        | res | { let (id , b) = res . unwrap () ; (hydro_lang :: __staged :: location :: MemberId :: < hydro_test :: __staged :: cluster :: paxos :: Proposer > :: from_tagless (id as hydro_lang :: __staged :: location :: TaglessMemberId) , hydro_lang :: runtime_support :: bincode :: deserialize :: < hydro_test :: __staged :: cluster :: paxos :: Ballot > (& b) . unwrap ()) },
+                                                                                    ),
+                                                                                },
+                                                                                instantiate_fn: <network instantiate>,
+                                                                                input: YieldConcat {
+                                                                                    inner: Cast {
+                                                                                        inner: CrossProduct {
+                                                                                            left: ObserveNonDet {
+                                                                                                inner: Map {
+                                                                                                    f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , bool) , hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL ! ([] [| (k , _) | k]) }),
+                                                                                                    input: Cast {
+                                                                                                        inner: Cast {
+                                                                                                            inner: Filter {
+                                                                                                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: keyed_singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_keyed_singleton_rs_LINE_COL ! ([f__free = stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL ! ([] [| b | * b]) }) ,] [{ let orig = f__free ; move | t : & (_ , _) | orig (& t . 1) }]) }),
+                                                                                                                input: Batch {
+                                                                                                                    inner: FoldKeyed {
+                                                                                                                        init: stageleft :: runtime_support :: fn0_type_hint :: < bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL ! ([] [| | false]) }),
+                                                                                                                        acc: stageleft :: runtime_support :: fn2_borrow_mut_type_hint :: < bool , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: stream :: networking :: * ; hydro_lang :: __stageleft_quote_src_live_collections_stream_networking_rs_LINE_COL ! ([] [| present , event | { match event { MembershipEvent :: Joined => * present = true , MembershipEvent :: Left => * present = false , } }]) }),
+                                                                                                                        input: Cast {
+                                                                                                                            inner: Map {
+                                                                                                                                f: stageleft :: runtime_support :: fnmut1_type_hint :: < (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) , (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent) > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: location :: * ; hydro_lang :: __stageleft_quote_src_location_mod_rs_LINE_COL ! ([] [| (k , v) | (MemberId :: from_tagless (k) , v)]) }),
+                                                                                                                                input: Source {
+                                                                                                                                    source: ClusterMembers(
+                                                                                                                                        Cluster(loc3v1),
+                                                                                                                                        Uninit,
+                                                                                                                                    ),
+                                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                                        location_id: Cluster(loc1v1),
+                                                                                                                                        collection_kind: Stream {
+                                                                                                                                            bound: Unbounded,
+                                                                                                                                            order: TotalOrder,
+                                                                                                                                            retry: ExactlyOnce,
+                                                                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                                                                        },
+                                                                                                                                    },
+                                                                                                                                },
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_id: Cluster(loc1v1),
                                                                                                                                     collection_kind: Stream {
                                                                                                                                         bound: Unbounded,
                                                                                                                                         order: TotalOrder,
                                                                                                                                         retry: ExactlyOnce,
-                                                                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: TaglessMemberId , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                                                                        element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                             },
                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                 location_id: Cluster(loc1v1),
-                                                                                                                                collection_kind: Stream {
+                                                                                                                                collection_kind: KeyedStream {
                                                                                                                                     bound: Unbounded,
-                                                                                                                                    order: TotalOrder,
-                                                                                                                                    retry: ExactlyOnce,
-                                                                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent),
+                                                                                                                                    value_order: TotalOrder,
+                                                                                                                                    value_retry: ExactlyOnce,
+                                                                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
+                                                                                                                                    value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
                                                                                                                                 },
                                                                                                                             },
                                                                                                                         },
                                                                                                                         metadata: HydroIrMetadata {
                                                                                                                             location_id: Cluster(loc1v1),
-                                                                                                                            collection_kind: KeyedStream {
-                                                                                                                                bound: Unbounded,
-                                                                                                                                value_order: TotalOrder,
-                                                                                                                                value_retry: ExactlyOnce,
+                                                                                                                            collection_kind: KeyedSingleton {
+                                                                                                                                bound: MonotonicKeys,
                                                                                                                                 key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
-                                                                                                                                value_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: MembershipEvent,
+                                                                                                                                value_type: bool,
                                                                                                                             },
                                                                                                                         },
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
-                                                                                                                        location_id: Cluster(loc1v1),
+                                                                                                                        location_id: Tick(10, Cluster(loc1v1)),
                                                                                                                         collection_kind: KeyedSingleton {
-                                                                                                                            bound: MonotonicKeys,
+                                                                                                                            bound: Bounded,
                                                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
                                                                                                                             value_type: bool,
                                                                                                                         },
@@ -3160,8 +3188,10 @@ expression: built.ir()
                                                                                                             },
                                                                                                             metadata: HydroIrMetadata {
                                                                                                                 location_id: Tick(10, Cluster(loc1v1)),
-                                                                                                                collection_kind: KeyedSingleton {
+                                                                                                                collection_kind: KeyedStream {
                                                                                                                     bound: Bounded,
+                                                                                                                    value_order: TotalOrder,
+                                                                                                                    value_retry: ExactlyOnce,
                                                                                                                     key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
                                                                                                                     value_type: bool,
                                                                                                                 },
@@ -3169,12 +3199,11 @@ expression: built.ir()
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_id: Tick(10, Cluster(loc1v1)),
-                                                                                                            collection_kind: KeyedStream {
+                                                                                                            collection_kind: Stream {
                                                                                                                 bound: Bounded,
-                                                                                                                value_order: TotalOrder,
-                                                                                                                value_retry: ExactlyOnce,
-                                                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
-                                                                                                                value_type: bool,
+                                                                                                                order: NoOrder,
+                                                                                                                retry: ExactlyOnce,
+                                                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , bool),
                                                                                                             },
                                                                                                         },
                                                                                                     },
@@ -3184,92 +3213,90 @@ expression: built.ir()
                                                                                                             bound: Bounded,
                                                                                                             order: NoOrder,
                                                                                                             retry: ExactlyOnce,
-                                                                                                            element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , bool),
+                                                                                                            element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
                                                                                                         },
                                                                                                     },
                                                                                                 },
+                                                                                                trusted: true,
                                                                                                 metadata: HydroIrMetadata {
                                                                                                     location_id: Tick(10, Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
                                                                                                         bound: Bounded,
-                                                                                                        order: NoOrder,
+                                                                                                        order: TotalOrder,
                                                                                                         retry: ExactlyOnce,
                                                                                                         element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
                                                                                                     },
                                                                                                 },
                                                                                             },
-                                                                                            trusted: true,
-                                                                                            metadata: HydroIrMetadata {
-                                                                                                location_id: Tick(10, Cluster(loc1v1)),
-                                                                                                collection_kind: Stream {
-                                                                                                    bound: Bounded,
-                                                                                                    order: TotalOrder,
-                                                                                                    retry: ExactlyOnce,
-                                                                                                    element_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
-                                                                                                },
-                                                                                            },
-                                                                                        },
-                                                                                        right: Batch {
-                                                                                            inner: YieldConcat {
-                                                                                                inner: Cast {
-                                                                                                    inner: Map {
-                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_LINE_COL ! ([] [| (d , _) | d]) }),
-                                                                                                        input: CrossSingleton {
-                                                                                                            left: Tee {
-                                                                                                                inner: <shared 4>,
-                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                    collection_kind: Singleton {
-                                                                                                                        bound: Bounded,
-                                                                                                                        element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                            right: Batch {
+                                                                                                inner: YieldConcat {
+                                                                                                    inner: Cast {
+                                                                                                        inner: Map {
+                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool) , hydro_test :: __staged :: cluster :: paxos :: Ballot > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_LINE_COL ! ([] [| (d , _) | d]) }),
+                                                                                                            input: CrossSingleton {
+                                                                                                                left: Tee {
+                                                                                                                    inner: <shared 4>,
+                                                                                                                    metadata: HydroIrMetadata {
+                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                        collection_kind: Singleton {
+                                                                                                                            bound: Bounded,
+                                                                                                                            element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                                        },
                                                                                                                     },
                                                                                                                 },
-                                                                                                            },
-                                                                                                            right: Filter {
-                                                                                                                f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_LINE_COL ! ([] [| b | * b]) }),
-                                                                                                                input: Tee {
-                                                                                                                    inner: <shared 18>: Map {
-                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_LINE_COL ! ([] [| (a , b) | a && b]) }),
-                                                                                                                        input: Cast {
-                                                                                                                            inner: CrossSingleton {
-                                                                                                                                left: Tee {
-                                                                                                                                    inner: <shared 13>,
-                                                                                                                                    metadata: HydroIrMetadata {
-                                                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                        collection_kind: Singleton {
-                                                                                                                                            bound: Bounded,
-                                                                                                                                            element_type: bool,
+                                                                                                                right: Filter {
+                                                                                                                    f: stageleft :: runtime_support :: fn1_borrow_type_hint :: < bool , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_LINE_COL ! ([] [| b | * b]) }),
+                                                                                                                    input: Tee {
+                                                                                                                        inner: <shared 18>: Map {
+                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < (bool , bool) , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_LINE_COL ! ([] [| (a , b) | a && b]) }),
+                                                                                                                            input: Cast {
+                                                                                                                                inner: CrossSingleton {
+                                                                                                                                    left: Tee {
+                                                                                                                                        inner: <shared 13>,
+                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                            collection_kind: Singleton {
+                                                                                                                                                bound: Bounded,
+                                                                                                                                                element_type: bool,
+                                                                                                                                            },
                                                                                                                                         },
                                                                                                                                     },
-                                                                                                                                },
-                                                                                                                                right: Map {
-                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_LINE_COL ! ([] [| o | o . is_none ()]) }),
-                                                                                                                                    input: Cast {
-                                                                                                                                        inner: ChainFirst {
-                                                                                                                                            first: Map {
-                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_LINE_COL ! ([] [| v | Some (v)]) }),
-                                                                                                                                                input: Map {
-                                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_LINE_COL ! ([] [| _ | ()]) }),
-                                                                                                                                                    input: DeferTick {
-                                                                                                                                                        input: FilterMap {
-                                                                                                                                                            f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_LINE_COL ! ([] [| v | v]) }),
-                                                                                                                                                            input: Map {
-                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| is_leader | is_leader . then_some (())]) }),
-                                                                                                                                                                input: Tee {
-                                                                                                                                                                    inner: <shared 13>,
+                                                                                                                                    right: Map {
+                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , bool > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_LINE_COL ! ([] [| o | o . is_none ()]) }),
+                                                                                                                                        input: Cast {
+                                                                                                                                            inner: ChainFirst {
+                                                                                                                                                first: Map {
+                                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < () , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_LINE_COL ! ([] [| v | Some (v)]) }),
+                                                                                                                                                    input: Map {
+                                                                                                                                                        f: stageleft :: runtime_support :: fn1_type_hint :: < () , () > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: optional :: * ; hydro_lang :: __stageleft_quote_src_live_collections_optional_rs_LINE_COL ! ([] [| _ | ()]) }),
+                                                                                                                                                        input: DeferTick {
+                                                                                                                                                            input: FilterMap {
+                                                                                                                                                                f: stageleft :: runtime_support :: fn1_type_hint :: < core :: option :: Option < () > , core :: option :: Option < () > > ({ use hydro_lang :: __staged :: __deps :: * ; use hydro_lang :: __staged :: live_collections :: singleton :: * ; hydro_lang :: __stageleft_quote_src_live_collections_singleton_rs_LINE_COL ! ([] [| v | v]) }),
+                                                                                                                                                                input: Map {
+                                                                                                                                                                    f: stageleft :: runtime_support :: fn1_type_hint :: < bool , core :: option :: Option < () > > ({ use crate :: __staged :: __deps :: * ; use crate :: __staged :: cluster :: paxos :: * ; crate :: __staged :: __stageleft_quote_src_cluster_paxos_rs_LINE_COL ! ([] [| is_leader | is_leader . then_some (())]) }),
+                                                                                                                                                                    input: Tee {
+                                                                                                                                                                        inner: <shared 13>,
+                                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                                            collection_kind: Singleton {
+                                                                                                                                                                                bound: Bounded,
+                                                                                                                                                                                element_type: bool,
+                                                                                                                                                                            },
+                                                                                                                                                                        },
+                                                                                                                                                                    },
                                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                                                         collection_kind: Singleton {
                                                                                                                                                                             bound: Bounded,
-                                                                                                                                                                            element_type: bool,
+                                                                                                                                                                            element_type: core :: option :: Option < () >,
                                                                                                                                                                         },
                                                                                                                                                                     },
                                                                                                                                                                 },
                                                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                                                     location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                                    collection_kind: Singleton {
+                                                                                                                                                                    collection_kind: Optional {
                                                                                                                                                                         bound: Bounded,
-                                                                                                                                                                        element_type: core :: option :: Option < () >,
+                                                                                                                                                                        element_type: (),
                                                                                                                                                                     },
                                                                                                                                                                 },
                                                                                                                                                             },
@@ -3293,25 +3320,25 @@ expression: built.ir()
                                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                                         collection_kind: Optional {
                                                                                                                                                             bound: Bounded,
-                                                                                                                                                            element_type: (),
+                                                                                                                                                            element_type: core :: option :: Option < () >,
                                                                                                                                                         },
                                                                                                                                                     },
                                                                                                                                                 },
-                                                                                                                                                metadata: HydroIrMetadata {
-                                                                                                                                                    location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                    collection_kind: Optional {
-                                                                                                                                                        bound: Bounded,
-                                                                                                                                                        element_type: core :: option :: Option < () >,
+                                                                                                                                                second: Cast {
+                                                                                                                                                    inner: SingletonSource {
+                                                                                                                                                        value: :: std :: option :: Option :: None,
+                                                                                                                                                        first_tick_only: false,
+                                                                                                                                                        metadata: HydroIrMetadata {
+                                                                                                                                                            location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                                                                            collection_kind: Singleton {
+                                                                                                                                                                bound: Bounded,
+                                                                                                                                                                element_type: core :: option :: Option < () >,
+                                                                                                                                                            },
+                                                                                                                                                        },
                                                                                                                                                     },
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            second: Cast {
-                                                                                                                                                inner: SingletonSource {
-                                                                                                                                                    value: :: std :: option :: Option :: None,
-                                                                                                                                                    first_tick_only: false,
                                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                        collection_kind: Singleton {
+                                                                                                                                                        collection_kind: Optional {
                                                                                                                                                             bound: Bounded,
                                                                                                                                                             element_type: core :: option :: Option < () >,
                                                                                                                                                         },
@@ -3327,7 +3354,7 @@ expression: built.ir()
                                                                                                                                             },
                                                                                                                                             metadata: HydroIrMetadata {
                                                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                                collection_kind: Optional {
+                                                                                                                                                collection_kind: Singleton {
                                                                                                                                                     bound: Bounded,
                                                                                                                                                     element_type: core :: option :: Option < () >,
                                                                                                                                                 },
@@ -3337,21 +3364,21 @@ expression: built.ir()
                                                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                             collection_kind: Singleton {
                                                                                                                                                 bound: Bounded,
-                                                                                                                                                element_type: core :: option :: Option < () >,
+                                                                                                                                                element_type: bool,
                                                                                                                                             },
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                        collection_kind: Singleton {
+                                                                                                                                        collection_kind: Optional {
                                                                                                                                             bound: Bounded,
-                                                                                                                                            element_type: bool,
+                                                                                                                                            element_type: (bool , bool),
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 },
                                                                                                                                 metadata: HydroIrMetadata {
                                                                                                                                     location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                                    collection_kind: Optional {
+                                                                                                                                    collection_kind: Singleton {
                                                                                                                                         bound: Bounded,
                                                                                                                                         element_type: (bool , bool),
                                                                                                                                     },
@@ -3361,7 +3388,7 @@ expression: built.ir()
                                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                                 collection_kind: Singleton {
                                                                                                                                     bound: Bounded,
-                                                                                                                                    element_type: (bool , bool),
+                                                                                                                                    element_type: bool,
                                                                                                                                 },
                                                                                                                             },
                                                                                                                         },
@@ -3375,7 +3402,7 @@ expression: built.ir()
                                                                                                                     },
                                                                                                                     metadata: HydroIrMetadata {
                                                                                                                         location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                                        collection_kind: Singleton {
+                                                                                                                        collection_kind: Optional {
                                                                                                                             bound: Bounded,
                                                                                                                             element_type: bool,
                                                                                                                         },
@@ -3385,7 +3412,7 @@ expression: built.ir()
                                                                                                                     location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                     collection_kind: Optional {
                                                                                                                         bound: Bounded,
-                                                                                                                        element_type: bool,
+                                                                                                                        element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool),
                                                                                                                     },
                                                                                                                 },
                                                                                                             },
@@ -3393,22 +3420,24 @@ expression: built.ir()
                                                                                                                 location_id: Tick(15, Cluster(loc1v1)),
                                                                                                                 collection_kind: Optional {
                                                                                                                     bound: Bounded,
-                                                                                                                    element_type: (hydro_test :: __staged :: cluster :: paxos :: Ballot , bool),
+                                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                                                 },
                                                                                                             },
                                                                                                         },
                                                                                                         metadata: HydroIrMetadata {
                                                                                                             location_id: Tick(15, Cluster(loc1v1)),
-                                                                                                            collection_kind: Optional {
+                                                                                                            collection_kind: Stream {
                                                                                                                 bound: Bounded,
+                                                                                                                order: TotalOrder,
+                                                                                                                retry: ExactlyOnce,
                                                                                                                 element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                                             },
                                                                                                         },
                                                                                                     },
                                                                                                     metadata: HydroIrMetadata {
-                                                                                                        location_id: Tick(15, Cluster(loc1v1)),
+                                                                                                        location_id: Cluster(loc1v1),
                                                                                                         collection_kind: Stream {
-                                                                                                            bound: Bounded,
+                                                                                                            bound: Unbounded,
                                                                                                             order: TotalOrder,
                                                                                                             retry: ExactlyOnce,
                                                                                                             element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -3416,9 +3445,9 @@ expression: built.ir()
                                                                                                     },
                                                                                                 },
                                                                                                 metadata: HydroIrMetadata {
-                                                                                                    location_id: Cluster(loc1v1),
+                                                                                                    location_id: Tick(10, Cluster(loc1v1)),
                                                                                                     collection_kind: Stream {
-                                                                                                        bound: Unbounded,
+                                                                                                        bound: Bounded,
                                                                                                         order: TotalOrder,
                                                                                                         retry: ExactlyOnce,
                                                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
@@ -3431,24 +3460,25 @@ expression: built.ir()
                                                                                                     bound: Bounded,
                                                                                                     order: TotalOrder,
                                                                                                     retry: ExactlyOnce,
-                                                                                                    element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
                                                                                                 },
                                                                                             },
                                                                                         },
                                                                                         metadata: HydroIrMetadata {
                                                                                             location_id: Tick(10, Cluster(loc1v1)),
-                                                                                            collection_kind: Stream {
+                                                                                            collection_kind: KeyedStream {
                                                                                                 bound: Bounded,
-                                                                                                order: TotalOrder,
-                                                                                                retry: ExactlyOnce,
-                                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                                value_order: TotalOrder,
+                                                                                                value_retry: ExactlyOnce,
+                                                                                                key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
+                                                                                                value_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                             },
                                                                                         },
                                                                                     },
                                                                                     metadata: HydroIrMetadata {
-                                                                                        location_id: Tick(10, Cluster(loc1v1)),
+                                                                                        location_id: Cluster(loc1v1),
                                                                                         collection_kind: KeyedStream {
-                                                                                            bound: Bounded,
+                                                                                            bound: Unbounded,
                                                                                             value_order: TotalOrder,
                                                                                             value_retry: ExactlyOnce,
                                                                                             key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
@@ -3457,24 +3487,23 @@ expression: built.ir()
                                                                                     },
                                                                                 },
                                                                                 metadata: HydroIrMetadata {
-                                                                                    location_id: Cluster(loc1v1),
+                                                                                    location_id: Cluster(loc3v1),
                                                                                     collection_kind: KeyedStream {
                                                                                         bound: Unbounded,
                                                                                         value_order: TotalOrder,
                                                                                         value_retry: ExactlyOnce,
-                                                                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos_bench :: Client >,
+                                                                                        key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
                                                                                         value_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                                     },
                                                                                 },
                                                                             },
                                                                             metadata: HydroIrMetadata {
                                                                                 location_id: Cluster(loc3v1),
-                                                                                collection_kind: KeyedStream {
+                                                                                collection_kind: Stream {
                                                                                     bound: Unbounded,
-                                                                                    value_order: TotalOrder,
-                                                                                    value_retry: ExactlyOnce,
-                                                                                    key_type: hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer >,
-                                                                                    value_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
+                                                                                    order: NoOrder,
+                                                                                    retry: ExactlyOnce,
+                                                                                    element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
                                                                                 },
                                                                             },
                                                                         },
@@ -3484,7 +3513,7 @@ expression: built.ir()
                                                                                 bound: Unbounded,
                                                                                 order: NoOrder,
                                                                                 retry: ExactlyOnce,
-                                                                                element_type: (hydro_test :: __staged :: __deps :: hydro_lang :: location :: member_id :: MemberId < hydro_test :: __staged :: cluster :: paxos :: Proposer > , hydro_test :: __staged :: cluster :: paxos :: Ballot),
+                                                                                element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                             },
                                                                         },
                                                                     },
@@ -3498,23 +3527,21 @@ expression: built.ir()
                                                                         },
                                                                     },
                                                                 },
+                                                                trusted: false,
                                                                 metadata: HydroIrMetadata {
                                                                     location_id: Cluster(loc3v1),
                                                                     collection_kind: Stream {
                                                                         bound: Unbounded,
-                                                                        order: NoOrder,
+                                                                        order: TotalOrder,
                                                                         retry: ExactlyOnce,
                                                                         element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                     },
                                                                 },
                                                             },
-                                                            trusted: false,
                                                             metadata: HydroIrMetadata {
                                                                 location_id: Cluster(loc3v1),
-                                                                collection_kind: Stream {
-                                                                    bound: Unbounded,
-                                                                    order: TotalOrder,
-                                                                    retry: ExactlyOnce,
+                                                                collection_kind: Optional {
+                                                                    bound: InitNone,
                                                                     element_type: hydro_test :: __staged :: cluster :: paxos :: Ballot,
                                                                 },
                                                             },
@@ -6769,7 +6796,7 @@ expression: built.ir()
                                             metadata: HydroIrMetadata {
                                                 location_id: Atomic(Tick(17, Cluster(loc5v1))),
                                                 collection_kind: Optional {
-                                                    bound: Unbounded,
+                                                    bound: InitNone,
                                                     element_type: usize,
                                                 },
                                             },

--- a/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@acceptor_mermaid.snap
@@ -1,6 +1,6 @@
 ---
 source: hydro_test/src/cluster/paxos_bench.rs
-expression: "preview.dfir_for(&acceptors).to_mermaid(&WriteConfig\n{\n    no_subgraphs: true, no_pull_push: true, no_handoffs: true,\n    op_text_no_imports: true, ..WriteConfig::default()\n})"
+expression: "preview.dfir_for(&acceptors).unwrap().to_mermaid(&WriteConfig\n{\n    no_subgraphs: true, no_pull_push: true, no_handoffs: true,\n    op_text_no_imports: true, ..WriteConfig::default()\n})"
 ---
 %%{init:{'theme':'base','themeVariables':{'clusterBkg':'#ddd','clusterBorder':'#888'}}}%%
 flowchart TD
@@ -132,161 +132,161 @@ subgraph var_cycle_4 ["var <tt>cycle_4</tt>"]
     style var_cycle_4 fill:transparent
     41v1
 end
-subgraph var_reduce_keyed_watermark_chain_525 ["var <tt>reduce_keyed_watermark_chain_525</tt>"]
-    style var_reduce_keyed_watermark_chain_525 fill:transparent
+subgraph var_reduce_keyed_watermark_chain_528 ["var <tt>reduce_keyed_watermark_chain_528</tt>"]
+    style var_reduce_keyed_watermark_chain_528 fill:transparent
     34v1
 end
-subgraph var_stream_162 ["var <tt>stream_162</tt>"]
-    style var_stream_162 fill:transparent
+subgraph var_stream_163 ["var <tt>stream_163</tt>"]
+    style var_stream_163 fill:transparent
     3v1
     4v1
 end
-subgraph var_stream_164 ["var <tt>stream_164</tt>"]
-    style var_stream_164 fill:transparent
+subgraph var_stream_165 ["var <tt>stream_165</tt>"]
+    style var_stream_165 fill:transparent
     5v1
 end
-subgraph var_stream_166 ["var <tt>stream_166</tt>"]
-    style var_stream_166 fill:transparent
+subgraph var_stream_167 ["var <tt>stream_167</tt>"]
+    style var_stream_167 fill:transparent
     6v1
 end
-subgraph var_stream_168 ["var <tt>stream_168</tt>"]
-    style var_stream_168 fill:transparent
+subgraph var_stream_169 ["var <tt>stream_169</tt>"]
+    style var_stream_169 fill:transparent
     7v1
 end
-subgraph var_stream_171 ["var <tt>stream_171</tt>"]
-    style var_stream_171 fill:transparent
+subgraph var_stream_172 ["var <tt>stream_172</tt>"]
+    style var_stream_172 fill:transparent
     8v1
-end
-subgraph var_stream_173 ["var <tt>stream_173</tt>"]
-    style var_stream_173 fill:transparent
-    9v1
 end
 subgraph var_stream_174 ["var <tt>stream_174</tt>"]
     style var_stream_174 fill:transparent
+    9v1
+end
+subgraph var_stream_175 ["var <tt>stream_175</tt>"]
+    style var_stream_175 fill:transparent
     10v1
     11v1
 end
-subgraph var_stream_176 ["var <tt>stream_176</tt>"]
-    style var_stream_176 fill:transparent
+subgraph var_stream_177 ["var <tt>stream_177</tt>"]
+    style var_stream_177 fill:transparent
     12v1
 end
-subgraph var_stream_178 ["var <tt>stream_178</tt>"]
-    style var_stream_178 fill:transparent
+subgraph var_stream_179 ["var <tt>stream_179</tt>"]
+    style var_stream_179 fill:transparent
     13v1
 end
-subgraph var_stream_180 ["var <tt>stream_180</tt>"]
-    style var_stream_180 fill:transparent
+subgraph var_stream_181 ["var <tt>stream_181</tt>"]
+    style var_stream_181 fill:transparent
     14v1
-end
-subgraph var_stream_183 ["var <tt>stream_183</tt>"]
-    style var_stream_183 fill:transparent
-    15v1
 end
 subgraph var_stream_184 ["var <tt>stream_184</tt>"]
     style var_stream_184 fill:transparent
+    15v1
+end
+subgraph var_stream_185 ["var <tt>stream_185</tt>"]
+    style var_stream_185 fill:transparent
     16v1
 end
 subgraph var_stream_24 ["var <tt>stream_24</tt>"]
     style var_stream_24 fill:transparent
     1v1
 end
-subgraph var_stream_455 ["var <tt>stream_455</tt>"]
-    style var_stream_455 fill:transparent
+subgraph var_stream_458 ["var <tt>stream_458</tt>"]
+    style var_stream_458 fill:transparent
     19v1
     20v1
 end
-subgraph var_stream_457 ["var <tt>stream_457</tt>"]
-    style var_stream_457 fill:transparent
+subgraph var_stream_460 ["var <tt>stream_460</tt>"]
+    style var_stream_460 fill:transparent
     21v1
-end
-subgraph var_stream_459 ["var <tt>stream_459</tt>"]
-    style var_stream_459 fill:transparent
-    22v1
 end
 subgraph var_stream_462 ["var <tt>stream_462</tt>"]
     style var_stream_462 fill:transparent
+    22v1
+end
+subgraph var_stream_465 ["var <tt>stream_465</tt>"]
+    style var_stream_465 fill:transparent
     23v1
 end
-subgraph var_stream_463 ["var <tt>stream_463</tt>"]
-    style var_stream_463 fill:transparent
+subgraph var_stream_466 ["var <tt>stream_466</tt>"]
+    style var_stream_466 fill:transparent
     24v1
 end
-subgraph var_stream_510 ["var <tt>stream_510</tt>"]
-    style var_stream_510 fill:transparent
+subgraph var_stream_513 ["var <tt>stream_513</tt>"]
+    style var_stream_513 fill:transparent
     27v1
-end
-subgraph var_stream_511 ["var <tt>stream_511</tt>"]
-    style var_stream_511 fill:transparent
-    28v1
-end
-subgraph var_stream_512 ["var <tt>stream_512</tt>"]
-    style var_stream_512 fill:transparent
-    29v1
-    30v1
 end
 subgraph var_stream_514 ["var <tt>stream_514</tt>"]
     style var_stream_514 fill:transparent
+    28v1
+end
+subgraph var_stream_515 ["var <tt>stream_515</tt>"]
+    style var_stream_515 fill:transparent
+    29v1
+    30v1
+end
+subgraph var_stream_517 ["var <tt>stream_517</tt>"]
+    style var_stream_517 fill:transparent
     31v1
 end
-subgraph var_stream_519 ["var <tt>stream_519</tt>"]
-    style var_stream_519 fill:transparent
+subgraph var_stream_522 ["var <tt>stream_522</tt>"]
+    style var_stream_522 fill:transparent
     32v1
 end
-subgraph var_stream_520 ["var <tt>stream_520</tt>"]
-    style var_stream_520 fill:transparent
+subgraph var_stream_523 ["var <tt>stream_523</tt>"]
+    style var_stream_523 fill:transparent
     33v1
 end
-subgraph var_stream_525 ["var <tt>stream_525</tt>"]
-    style var_stream_525 fill:transparent
+subgraph var_stream_528 ["var <tt>stream_528</tt>"]
+    style var_stream_528 fill:transparent
     37v1
     38v1
 end
-subgraph var_stream_529 ["var <tt>stream_529</tt>"]
-    style var_stream_529 fill:transparent
+subgraph var_stream_532 ["var <tt>stream_532</tt>"]
+    style var_stream_532 fill:transparent
     39v1
 end
-subgraph var_stream_530 ["var <tt>stream_530</tt>"]
-    style var_stream_530 fill:transparent
+subgraph var_stream_533 ["var <tt>stream_533</tt>"]
+    style var_stream_533 fill:transparent
     40v1
-end
-subgraph var_stream_642 ["var <tt>stream_642</tt>"]
-    style var_stream_642 fill:transparent
-    42v1
-    43v1
-end
-subgraph var_stream_643 ["var <tt>stream_643</tt>"]
-    style var_stream_643 fill:transparent
-    44v1
 end
 subgraph var_stream_645 ["var <tt>stream_645</tt>"]
     style var_stream_645 fill:transparent
+    42v1
+    43v1
+end
+subgraph var_stream_646 ["var <tt>stream_646</tt>"]
+    style var_stream_646 fill:transparent
+    44v1
+end
+subgraph var_stream_648 ["var <tt>stream_648</tt>"]
+    style var_stream_648 fill:transparent
     45v1
-end
-subgraph var_stream_652 ["var <tt>stream_652</tt>"]
-    style var_stream_652 fill:transparent
-    46v1
-end
-subgraph var_stream_653 ["var <tt>stream_653</tt>"]
-    style var_stream_653 fill:transparent
-    47v1
-end
-subgraph var_stream_654 ["var <tt>stream_654</tt>"]
-    style var_stream_654 fill:transparent
-    48v1
 end
 subgraph var_stream_655 ["var <tt>stream_655</tt>"]
     style var_stream_655 fill:transparent
-    49v1
+    46v1
 end
 subgraph var_stream_656 ["var <tt>stream_656</tt>"]
     style var_stream_656 fill:transparent
-    50v1
+    47v1
 end
 subgraph var_stream_657 ["var <tt>stream_657</tt>"]
     style var_stream_657 fill:transparent
-    51v1
+    48v1
+end
+subgraph var_stream_658 ["var <tt>stream_658</tt>"]
+    style var_stream_658 fill:transparent
+    49v1
 end
 subgraph var_stream_659 ["var <tt>stream_659</tt>"]
     style var_stream_659 fill:transparent
+    50v1
+end
+subgraph var_stream_660 ["var <tt>stream_660</tt>"]
+    style var_stream_660 fill:transparent
+    51v1
+end
+subgraph var_stream_662 ["var <tt>stream_662</tt>"]
+    style var_stream_662 fill:transparent
     52v1
 end

--- a/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
+++ b/hydro_test/src/cluster/snapshots/paxos_ir@proposer_mermaid.snap
@@ -1,6 +1,6 @@
 ---
 source: hydro_test/src/cluster/paxos_bench.rs
-expression: "preview.dfir_for(&proposers).to_mermaid(&WriteConfig\n{\n    no_subgraphs: true, no_pull_push: true, no_handoffs: true,\n    op_text_no_imports: true, ..WriteConfig::default()\n})"
+expression: "preview.dfir_for(&proposers).unwrap().to_mermaid(&WriteConfig\n{\n    no_subgraphs: true, no_pull_push: true, no_handoffs: true,\n    op_text_no_imports: true, ..WriteConfig::default()\n})"
 ---
 %%{init:{'theme':'base','themeVariables':{'clusterBkg':'#ddd','clusterBorder':'#888'}}}%%
 flowchart TD
@@ -628,322 +628,318 @@ subgraph var_cycle_9 ["var <tt>cycle_9</tt>"]
     style var_cycle_9 fill:transparent
     102v1
 end
-subgraph var_stream_101 ["var <tt>stream_101</tt>"]
-    style var_stream_101 fill:transparent
+subgraph var_stream_102 ["var <tt>stream_102</tt>"]
+    style var_stream_102 fill:transparent
     47v1
     48v1
 end
-subgraph var_stream_103 ["var <tt>stream_103</tt>"]
-    style var_stream_103 fill:transparent
-    49v1
-end
 subgraph var_stream_104 ["var <tt>stream_104</tt>"]
     style var_stream_104 fill:transparent
-    50v1
+    49v1
 end
-subgraph var_stream_106 ["var <tt>stream_106</tt>"]
-    style var_stream_106 fill:transparent
-    52v1
+subgraph var_stream_105 ["var <tt>stream_105</tt>"]
+    style var_stream_105 fill:transparent
+    50v1
 end
 subgraph var_stream_107 ["var <tt>stream_107</tt>"]
     style var_stream_107 fill:transparent
-    53v1
+    52v1
 end
 subgraph var_stream_108 ["var <tt>stream_108</tt>"]
     style var_stream_108 fill:transparent
+    53v1
+end
+subgraph var_stream_109 ["var <tt>stream_109</tt>"]
+    style var_stream_109 fill:transparent
     54v1
 end
-subgraph var_stream_110 ["var <tt>stream_110</tt>"]
-    style var_stream_110 fill:transparent
+subgraph var_stream_111 ["var <tt>stream_111</tt>"]
+    style var_stream_111 fill:transparent
     55v1
 end
-subgraph var_stream_112 ["var <tt>stream_112</tt>"]
-    style var_stream_112 fill:transparent
+subgraph var_stream_113 ["var <tt>stream_113</tt>"]
+    style var_stream_113 fill:transparent
     56v1
 end
-subgraph var_stream_115 ["var <tt>stream_115</tt>"]
-    style var_stream_115 fill:transparent
+subgraph var_stream_116 ["var <tt>stream_116</tt>"]
+    style var_stream_116 fill:transparent
     57v1
 end
-subgraph var_stream_120 ["var <tt>stream_120</tt>"]
-    style var_stream_120 fill:transparent
+subgraph var_stream_121 ["var <tt>stream_121</tt>"]
+    style var_stream_121 fill:transparent
     58v1
 end
-subgraph var_stream_122 ["var <tt>stream_122</tt>"]
-    style var_stream_122 fill:transparent
+subgraph var_stream_123 ["var <tt>stream_123</tt>"]
+    style var_stream_123 fill:transparent
     59v1
-end
-subgraph var_stream_126 ["var <tt>stream_126</tt>"]
-    style var_stream_126 fill:transparent
-    60v1
 end
 subgraph var_stream_127 ["var <tt>stream_127</tt>"]
     style var_stream_127 fill:transparent
-    61v1
+    60v1
 end
 subgraph var_stream_128 ["var <tt>stream_128</tt>"]
     style var_stream_128 fill:transparent
-    62v1
+    61v1
 end
 subgraph var_stream_129 ["var <tt>stream_129</tt>"]
     style var_stream_129 fill:transparent
-    63v1
+    62v1
 end
 subgraph var_stream_130 ["var <tt>stream_130</tt>"]
     style var_stream_130 fill:transparent
-    64v1
+    63v1
 end
 subgraph var_stream_131 ["var <tt>stream_131</tt>"]
     style var_stream_131 fill:transparent
-    65v1
+    64v1
 end
 subgraph var_stream_132 ["var <tt>stream_132</tt>"]
     style var_stream_132 fill:transparent
+    65v1
+end
+subgraph var_stream_133 ["var <tt>stream_133</tt>"]
+    style var_stream_133 fill:transparent
     66v1
     67v1
 end
-subgraph var_stream_134 ["var <tt>stream_134</tt>"]
-    style var_stream_134 fill:transparent
+subgraph var_stream_135 ["var <tt>stream_135</tt>"]
+    style var_stream_135 fill:transparent
     68v1
-end
-subgraph var_stream_136 ["var <tt>stream_136</tt>"]
-    style var_stream_136 fill:transparent
-    69v1
 end
 subgraph var_stream_137 ["var <tt>stream_137</tt>"]
     style var_stream_137 fill:transparent
-    70v1
+    69v1
 end
-subgraph var_stream_139 ["var <tt>stream_139</tt>"]
-    style var_stream_139 fill:transparent
-    71v1
+subgraph var_stream_138 ["var <tt>stream_138</tt>"]
+    style var_stream_138 fill:transparent
+    70v1
 end
 subgraph var_stream_140 ["var <tt>stream_140</tt>"]
     style var_stream_140 fill:transparent
-    72v1
+    71v1
 end
 subgraph var_stream_141 ["var <tt>stream_141</tt>"]
     style var_stream_141 fill:transparent
-    73v1
+    72v1
 end
 subgraph var_stream_142 ["var <tt>stream_142</tt>"]
     style var_stream_142 fill:transparent
-    74v1
+    73v1
 end
 subgraph var_stream_143 ["var <tt>stream_143</tt>"]
     style var_stream_143 fill:transparent
-    75v1
+    74v1
 end
 subgraph var_stream_144 ["var <tt>stream_144</tt>"]
     style var_stream_144 fill:transparent
+    75v1
+end
+subgraph var_stream_145 ["var <tt>stream_145</tt>"]
+    style var_stream_145 fill:transparent
     76v1
     77v1
 end
-subgraph var_stream_146 ["var <tt>stream_146</tt>"]
-    style var_stream_146 fill:transparent
+subgraph var_stream_147 ["var <tt>stream_147</tt>"]
+    style var_stream_147 fill:transparent
     78v1
-end
-subgraph var_stream_148 ["var <tt>stream_148</tt>"]
-    style var_stream_148 fill:transparent
-    79v1
 end
 subgraph var_stream_149 ["var <tt>stream_149</tt>"]
     style var_stream_149 fill:transparent
-    80v1
+    79v1
 end
-subgraph var_stream_151 ["var <tt>stream_151</tt>"]
-    style var_stream_151 fill:transparent
-    81v1
+subgraph var_stream_150 ["var <tt>stream_150</tt>"]
+    style var_stream_150 fill:transparent
+    80v1
 end
 subgraph var_stream_152 ["var <tt>stream_152</tt>"]
     style var_stream_152 fill:transparent
-    82v1
+    81v1
 end
 subgraph var_stream_153 ["var <tt>stream_153</tt>"]
     style var_stream_153 fill:transparent
-    83v1
+    82v1
 end
 subgraph var_stream_154 ["var <tt>stream_154</tt>"]
     style var_stream_154 fill:transparent
+    83v1
+end
+subgraph var_stream_155 ["var <tt>stream_155</tt>"]
+    style var_stream_155 fill:transparent
     84v1
 end
-subgraph var_stream_157 ["var <tt>stream_157</tt>"]
-    style var_stream_157 fill:transparent
+subgraph var_stream_158 ["var <tt>stream_158</tt>"]
+    style var_stream_158 fill:transparent
     85v1
 end
-subgraph var_stream_159 ["var <tt>stream_159</tt>"]
-    style var_stream_159 fill:transparent
+subgraph var_stream_160 ["var <tt>stream_160</tt>"]
+    style var_stream_160 fill:transparent
     86v1
 end
-subgraph var_stream_187 ["var <tt>stream_187</tt>"]
-    style var_stream_187 fill:transparent
+subgraph var_stream_188 ["var <tt>stream_188</tt>"]
+    style var_stream_188 fill:transparent
     89v1
     90v1
 end
-subgraph var_stream_189 ["var <tt>stream_189</tt>"]
-    style var_stream_189 fill:transparent
-    91v1
-end
 subgraph var_stream_190 ["var <tt>stream_190</tt>"]
     style var_stream_190 fill:transparent
-    92v1
+    91v1
 end
 subgraph var_stream_191 ["var <tt>stream_191</tt>"]
     style var_stream_191 fill:transparent
-    93v1
+    92v1
 end
-subgraph var_stream_193 ["var <tt>stream_193</tt>"]
-    style var_stream_193 fill:transparent
-    94v1
+subgraph var_stream_192 ["var <tt>stream_192</tt>"]
+    style var_stream_192 fill:transparent
+    93v1
 end
 subgraph var_stream_194 ["var <tt>stream_194</tt>"]
     style var_stream_194 fill:transparent
-    95v1
+    94v1
 end
-subgraph var_stream_197 ["var <tt>stream_197</tt>"]
-    style var_stream_197 fill:transparent
-    96v1
+subgraph var_stream_195 ["var <tt>stream_195</tt>"]
+    style var_stream_195 fill:transparent
+    95v1
 end
 subgraph var_stream_198 ["var <tt>stream_198</tt>"]
     style var_stream_198 fill:transparent
-    97v1
+    96v1
 end
 subgraph var_stream_199 ["var <tt>stream_199</tt>"]
     style var_stream_199 fill:transparent
-    98v1
+    97v1
 end
-subgraph var_stream_202 ["var <tt>stream_202</tt>"]
-    style var_stream_202 fill:transparent
-    99v1
+subgraph var_stream_200 ["var <tt>stream_200</tt>"]
+    style var_stream_200 fill:transparent
+    98v1
 end
 subgraph var_stream_203 ["var <tt>stream_203</tt>"]
     style var_stream_203 fill:transparent
-    100v1
+    99v1
 end
 subgraph var_stream_204 ["var <tt>stream_204</tt>"]
     style var_stream_204 fill:transparent
+    100v1
+end
+subgraph var_stream_205 ["var <tt>stream_205</tt>"]
+    style var_stream_205 fill:transparent
     101v1
 end
-subgraph var_stream_206 ["var <tt>stream_206</tt>"]
-    style var_stream_206 fill:transparent
+subgraph var_stream_207 ["var <tt>stream_207</tt>"]
+    style var_stream_207 fill:transparent
     103v1
 end
-subgraph var_stream_209 ["var <tt>stream_209</tt>"]
-    style var_stream_209 fill:transparent
+subgraph var_stream_210 ["var <tt>stream_210</tt>"]
+    style var_stream_210 fill:transparent
     104v1
 end
-subgraph var_stream_211 ["var <tt>stream_211</tt>"]
-    style var_stream_211 fill:transparent
+subgraph var_stream_212 ["var <tt>stream_212</tt>"]
+    style var_stream_212 fill:transparent
     105v1
 end
-subgraph var_stream_214 ["var <tt>stream_214</tt>"]
-    style var_stream_214 fill:transparent
+subgraph var_stream_215 ["var <tt>stream_215</tt>"]
+    style var_stream_215 fill:transparent
     107v1
-end
-subgraph var_stream_217 ["var <tt>stream_217</tt>"]
-    style var_stream_217 fill:transparent
-    108v1
 end
 subgraph var_stream_218 ["var <tt>stream_218</tt>"]
     style var_stream_218 fill:transparent
+    108v1
+end
+subgraph var_stream_219 ["var <tt>stream_219</tt>"]
+    style var_stream_219 fill:transparent
     109v1
 end
 subgraph var_stream_22 ["var <tt>stream_22</tt>"]
     style var_stream_22 fill:transparent
     1v1
 end
-subgraph var_stream_220 ["var <tt>stream_220</tt>"]
-    style var_stream_220 fill:transparent
-    110v1
-end
 subgraph var_stream_221 ["var <tt>stream_221</tt>"]
     style var_stream_221 fill:transparent
-    111v1
+    110v1
 end
 subgraph var_stream_222 ["var <tt>stream_222</tt>"]
     style var_stream_222 fill:transparent
-    112v1
+    111v1
 end
-subgraph var_stream_226 ["var <tt>stream_226</tt>"]
-    style var_stream_226 fill:transparent
-    113v1
+subgraph var_stream_223 ["var <tt>stream_223</tt>"]
+    style var_stream_223 fill:transparent
+    112v1
 end
 subgraph var_stream_227 ["var <tt>stream_227</tt>"]
     style var_stream_227 fill:transparent
+    113v1
+end
+subgraph var_stream_228 ["var <tt>stream_228</tt>"]
+    style var_stream_228 fill:transparent
     114v1
 end
-subgraph var_stream_232 ["var <tt>stream_232</tt>"]
-    style var_stream_232 fill:transparent
+subgraph var_stream_233 ["var <tt>stream_233</tt>"]
+    style var_stream_233 fill:transparent
     115v1
-end
-subgraph var_stream_236 ["var <tt>stream_236</tt>"]
-    style var_stream_236 fill:transparent
-    116v1
-end
-subgraph var_stream_237 ["var <tt>stream_237</tt>"]
-    style var_stream_237 fill:transparent
-    117v1
 end
 subgraph var_stream_238 ["var <tt>stream_238</tt>"]
     style var_stream_238 fill:transparent
-    118v1
+    116v1
 end
 subgraph var_stream_239 ["var <tt>stream_239</tt>"]
     style var_stream_239 fill:transparent
-    119v1
+    117v1
 end
 subgraph var_stream_240 ["var <tt>stream_240</tt>"]
     style var_stream_240 fill:transparent
-    120v1
+    118v1
 end
 subgraph var_stream_241 ["var <tt>stream_241</tt>"]
     style var_stream_241 fill:transparent
-    121v1
-    122v1
+    119v1
+end
+subgraph var_stream_242 ["var <tt>stream_242</tt>"]
+    style var_stream_242 fill:transparent
+    120v1
 end
 subgraph var_stream_243 ["var <tt>stream_243</tt>"]
     style var_stream_243 fill:transparent
-    123v1
+    121v1
+    122v1
 end
 subgraph var_stream_245 ["var <tt>stream_245</tt>"]
     style var_stream_245 fill:transparent
-    124v1
+    123v1
 end
-subgraph var_stream_248 ["var <tt>stream_248</tt>"]
-    style var_stream_248 fill:transparent
-    125v1
+subgraph var_stream_247 ["var <tt>stream_247</tt>"]
+    style var_stream_247 fill:transparent
+    124v1
 end
 subgraph var_stream_250 ["var <tt>stream_250</tt>"]
     style var_stream_250 fill:transparent
-    126v1
+    125v1
 end
-subgraph var_stream_253 ["var <tt>stream_253</tt>"]
-    style var_stream_253 fill:transparent
-    127v1
+subgraph var_stream_252 ["var <tt>stream_252</tt>"]
+    style var_stream_252 fill:transparent
+    126v1
 end
 subgraph var_stream_255 ["var <tt>stream_255</tt>"]
     style var_stream_255 fill:transparent
-    128v1
+    127v1
 end
-subgraph var_stream_256 ["var <tt>stream_256</tt>"]
-    style var_stream_256 fill:transparent
-    129v1
+subgraph var_stream_257 ["var <tt>stream_257</tt>"]
+    style var_stream_257 fill:transparent
+    128v1
 end
 subgraph var_stream_258 ["var <tt>stream_258</tt>"]
     style var_stream_258 fill:transparent
+    129v1
+end
+subgraph var_stream_260 ["var <tt>stream_260</tt>"]
+    style var_stream_260 fill:transparent
     131v1
 end
-subgraph var_stream_259 ["var <tt>stream_259</tt>"]
-    style var_stream_259 fill:transparent
+subgraph var_stream_261 ["var <tt>stream_261</tt>"]
+    style var_stream_261 fill:transparent
     132v1
 end
-subgraph var_stream_277 ["var <tt>stream_277</tt>"]
-    style var_stream_277 fill:transparent
+subgraph var_stream_279 ["var <tt>stream_279</tt>"]
+    style var_stream_279 fill:transparent
     134v1
-end
-subgraph var_stream_278 ["var <tt>stream_278</tt>"]
-    style var_stream_278 fill:transparent
-    135v1
 end
 subgraph var_stream_28 ["var <tt>stream_28</tt>"]
     style var_stream_28 fill:transparent
@@ -951,613 +947,617 @@ subgraph var_stream_28 ["var <tt>stream_28</tt>"]
 end
 subgraph var_stream_280 ["var <tt>stream_280</tt>"]
     style var_stream_280 fill:transparent
-    136v1
+    135v1
 end
 subgraph var_stream_282 ["var <tt>stream_282</tt>"]
     style var_stream_282 fill:transparent
+    136v1
+end
+subgraph var_stream_284 ["var <tt>stream_284</tt>"]
+    style var_stream_284 fill:transparent
     137v1
 end
-subgraph var_stream_285 ["var <tt>stream_285</tt>"]
-    style var_stream_285 fill:transparent
+subgraph var_stream_287 ["var <tt>stream_287</tt>"]
+    style var_stream_287 fill:transparent
     138v1
-end
-subgraph var_stream_290 ["var <tt>stream_290</tt>"]
-    style var_stream_290 fill:transparent
-    139v1
-end
-subgraph var_stream_291 ["var <tt>stream_291</tt>"]
-    style var_stream_291 fill:transparent
-    140v1
 end
 subgraph var_stream_292 ["var <tt>stream_292</tt>"]
     style var_stream_292 fill:transparent
-    141v1
+    139v1
 end
 subgraph var_stream_293 ["var <tt>stream_293</tt>"]
     style var_stream_293 fill:transparent
-    142v1
+    140v1
 end
 subgraph var_stream_294 ["var <tt>stream_294</tt>"]
     style var_stream_294 fill:transparent
-    143v1
+    141v1
 end
 subgraph var_stream_295 ["var <tt>stream_295</tt>"]
     style var_stream_295 fill:transparent
-    144v1
-    145v1
+    142v1
+end
+subgraph var_stream_296 ["var <tt>stream_296</tt>"]
+    style var_stream_296 fill:transparent
+    143v1
 end
 subgraph var_stream_297 ["var <tt>stream_297</tt>"]
     style var_stream_297 fill:transparent
-    146v1
+    144v1
+    145v1
 end
 subgraph var_stream_299 ["var <tt>stream_299</tt>"]
     style var_stream_299 fill:transparent
-    147v1
+    146v1
 end
 subgraph var_stream_30 ["var <tt>stream_30</tt>"]
     style var_stream_30 fill:transparent
     4v1
 end
-subgraph var_stream_300 ["var <tt>stream_300</tt>"]
-    style var_stream_300 fill:transparent
-    148v1
+subgraph var_stream_301 ["var <tt>stream_301</tt>"]
+    style var_stream_301 fill:transparent
+    147v1
 end
 subgraph var_stream_302 ["var <tt>stream_302</tt>"]
     style var_stream_302 fill:transparent
-    149v1
-end
-subgraph var_stream_303 ["var <tt>stream_303</tt>"]
-    style var_stream_303 fill:transparent
-    150v1
+    148v1
 end
 subgraph var_stream_304 ["var <tt>stream_304</tt>"]
     style var_stream_304 fill:transparent
-    151v1
+    149v1
 end
 subgraph var_stream_305 ["var <tt>stream_305</tt>"]
     style var_stream_305 fill:transparent
-    152v1
+    150v1
 end
 subgraph var_stream_306 ["var <tt>stream_306</tt>"]
     style var_stream_306 fill:transparent
+    151v1
+end
+subgraph var_stream_307 ["var <tt>stream_307</tt>"]
+    style var_stream_307 fill:transparent
+    152v1
+end
+subgraph var_stream_308 ["var <tt>stream_308</tt>"]
+    style var_stream_308 fill:transparent
     153v1
 end
-subgraph var_stream_310 ["var <tt>stream_310</tt>"]
-    style var_stream_310 fill:transparent
+subgraph var_stream_312 ["var <tt>stream_312</tt>"]
+    style var_stream_312 fill:transparent
     154v1
 end
 subgraph var_stream_33 ["var <tt>stream_33</tt>"]
     style var_stream_33 fill:transparent
     5v1
 end
-subgraph var_stream_338 ["var <tt>stream_338</tt>"]
-    style var_stream_338 fill:transparent
-    157v1
-    158v1
-end
 subgraph var_stream_34 ["var <tt>stream_34</tt>"]
     style var_stream_34 fill:transparent
     6v1
 end
-subgraph var_stream_340 ["var <tt>stream_340</tt>"]
-    style var_stream_340 fill:transparent
+subgraph var_stream_341 ["var <tt>stream_341</tt>"]
+    style var_stream_341 fill:transparent
+    157v1
+    158v1
+end
+subgraph var_stream_343 ["var <tt>stream_343</tt>"]
+    style var_stream_343 fill:transparent
     159v1
 end
-subgraph var_stream_344 ["var <tt>stream_344</tt>"]
-    style var_stream_344 fill:transparent
+subgraph var_stream_347 ["var <tt>stream_347</tt>"]
+    style var_stream_347 fill:transparent
     160v1
 end
-subgraph var_stream_345 ["var <tt>stream_345</tt>"]
-    style var_stream_345 fill:transparent
+subgraph var_stream_348 ["var <tt>stream_348</tt>"]
+    style var_stream_348 fill:transparent
     161v1
-end
-subgraph var_stream_346 ["var <tt>stream_346</tt>"]
-    style var_stream_346 fill:transparent
-    162v1
 end
 subgraph var_stream_349 ["var <tt>stream_349</tt>"]
     style var_stream_349 fill:transparent
-    163v1
+    162v1
 end
 subgraph var_stream_352 ["var <tt>stream_352</tt>"]
     style var_stream_352 fill:transparent
-    164v1
-end
-subgraph var_stream_353 ["var <tt>stream_353</tt>"]
-    style var_stream_353 fill:transparent
-    165v1
-end
-subgraph var_stream_354 ["var <tt>stream_354</tt>"]
-    style var_stream_354 fill:transparent
-    166v1
+    163v1
 end
 subgraph var_stream_355 ["var <tt>stream_355</tt>"]
     style var_stream_355 fill:transparent
-    167v1
+    164v1
+end
+subgraph var_stream_356 ["var <tt>stream_356</tt>"]
+    style var_stream_356 fill:transparent
+    165v1
 end
 subgraph var_stream_357 ["var <tt>stream_357</tt>"]
     style var_stream_357 fill:transparent
-    168v1
+    166v1
 end
 subgraph var_stream_358 ["var <tt>stream_358</tt>"]
     style var_stream_358 fill:transparent
+    167v1
+end
+subgraph var_stream_360 ["var <tt>stream_360</tt>"]
+    style var_stream_360 fill:transparent
+    168v1
+end
+subgraph var_stream_361 ["var <tt>stream_361</tt>"]
+    style var_stream_361 fill:transparent
     169v1
-end
-subgraph var_stream_359 ["var <tt>stream_359</tt>"]
-    style var_stream_359 fill:transparent
-    170v1
-end
-subgraph var_stream_36 ["var <tt>stream_36</tt>"]
-    style var_stream_36 fill:transparent
-    7v1
-    8v1
 end
 subgraph var_stream_362 ["var <tt>stream_362</tt>"]
     style var_stream_362 fill:transparent
-    171v1
-end
-subgraph var_stream_364 ["var <tt>stream_364</tt>"]
-    style var_stream_364 fill:transparent
-    172v1
+    170v1
 end
 subgraph var_stream_365 ["var <tt>stream_365</tt>"]
     style var_stream_365 fill:transparent
-    173v1
+    171v1
+end
+subgraph var_stream_367 ["var <tt>stream_367</tt>"]
+    style var_stream_367 fill:transparent
+    172v1
 end
 subgraph var_stream_368 ["var <tt>stream_368</tt>"]
     style var_stream_368 fill:transparent
-    174v1
+    173v1
 end
-subgraph var_stream_370 ["var <tt>stream_370</tt>"]
-    style var_stream_370 fill:transparent
-    175v1
+subgraph var_stream_37 ["var <tt>stream_37</tt>"]
+    style var_stream_37 fill:transparent
+    7v1
+    8v1
 end
 subgraph var_stream_371 ["var <tt>stream_371</tt>"]
     style var_stream_371 fill:transparent
-    176v1
-    177v1
+    174v1
 end
 subgraph var_stream_373 ["var <tt>stream_373</tt>"]
     style var_stream_373 fill:transparent
-    178v1
+    175v1
+end
+subgraph var_stream_374 ["var <tt>stream_374</tt>"]
+    style var_stream_374 fill:transparent
+    176v1
+    177v1
 end
 subgraph var_stream_376 ["var <tt>stream_376</tt>"]
     style var_stream_376 fill:transparent
+    178v1
+end
+subgraph var_stream_379 ["var <tt>stream_379</tt>"]
+    style var_stream_379 fill:transparent
     179v1
-end
-subgraph var_stream_378 ["var <tt>stream_378</tt>"]
-    style var_stream_378 fill:transparent
-    180v1
-end
-subgraph var_stream_380 ["var <tt>stream_380</tt>"]
-    style var_stream_380 fill:transparent
-    181v1
 end
 subgraph var_stream_381 ["var <tt>stream_381</tt>"]
     style var_stream_381 fill:transparent
-    182v1
-end
-subgraph var_stream_382 ["var <tt>stream_382</tt>"]
-    style var_stream_382 fill:transparent
-    183v1
+    180v1
 end
 subgraph var_stream_383 ["var <tt>stream_383</tt>"]
     style var_stream_383 fill:transparent
-    184v1
+    181v1
+end
+subgraph var_stream_384 ["var <tt>stream_384</tt>"]
+    style var_stream_384 fill:transparent
+    182v1
 end
 subgraph var_stream_385 ["var <tt>stream_385</tt>"]
     style var_stream_385 fill:transparent
+    183v1
+end
+subgraph var_stream_386 ["var <tt>stream_386</tt>"]
+    style var_stream_386 fill:transparent
+    184v1
+end
+subgraph var_stream_388 ["var <tt>stream_388</tt>"]
+    style var_stream_388 fill:transparent
     185v1
-end
-subgraph var_stream_387 ["var <tt>stream_387</tt>"]
-    style var_stream_387 fill:transparent
-    186v1
-end
-subgraph var_stream_389 ["var <tt>stream_389</tt>"]
-    style var_stream_389 fill:transparent
-    188v1
-end
-subgraph var_stream_39 ["var <tt>stream_39</tt>"]
-    style var_stream_39 fill:transparent
-    9v1
 end
 subgraph var_stream_390 ["var <tt>stream_390</tt>"]
     style var_stream_390 fill:transparent
-    189v1
+    186v1
 end
-subgraph var_stream_391 ["var <tt>stream_391</tt>"]
-    style var_stream_391 fill:transparent
-    190v1
+subgraph var_stream_392 ["var <tt>stream_392</tt>"]
+    style var_stream_392 fill:transparent
+    188v1
 end
 subgraph var_stream_393 ["var <tt>stream_393</tt>"]
     style var_stream_393 fill:transparent
-    191v1
+    189v1
 end
-subgraph var_stream_395 ["var <tt>stream_395</tt>"]
-    style var_stream_395 fill:transparent
-    192v1
+subgraph var_stream_394 ["var <tt>stream_394</tt>"]
+    style var_stream_394 fill:transparent
+    190v1
+end
+subgraph var_stream_396 ["var <tt>stream_396</tt>"]
+    style var_stream_396 fill:transparent
+    191v1
 end
 subgraph var_stream_398 ["var <tt>stream_398</tt>"]
     style var_stream_398 fill:transparent
+    192v1
+end
+subgraph var_stream_40 ["var <tt>stream_40</tt>"]
+    style var_stream_40 fill:transparent
+    9v1
+end
+subgraph var_stream_401 ["var <tt>stream_401</tt>"]
+    style var_stream_401 fill:transparent
     193v1
 end
-subgraph var_stream_405 ["var <tt>stream_405</tt>"]
-    style var_stream_405 fill:transparent
+subgraph var_stream_408 ["var <tt>stream_408</tt>"]
+    style var_stream_408 fill:transparent
     194v1
 end
-subgraph var_stream_406 ["var <tt>stream_406</tt>"]
-    style var_stream_406 fill:transparent
+subgraph var_stream_409 ["var <tt>stream_409</tt>"]
+    style var_stream_409 fill:transparent
     195v1
 end
-subgraph var_stream_412 ["var <tt>stream_412</tt>"]
-    style var_stream_412 fill:transparent
+subgraph var_stream_415 ["var <tt>stream_415</tt>"]
+    style var_stream_415 fill:transparent
     196v1
-end
-subgraph var_stream_414 ["var <tt>stream_414</tt>"]
-    style var_stream_414 fill:transparent
-    197v1
-end
-subgraph var_stream_416 ["var <tt>stream_416</tt>"]
-    style var_stream_416 fill:transparent
-    198v1
 end
 subgraph var_stream_417 ["var <tt>stream_417</tt>"]
     style var_stream_417 fill:transparent
-    199v1
+    197v1
 end
-subgraph var_stream_418 ["var <tt>stream_418</tt>"]
-    style var_stream_418 fill:transparent
-    200v1
-    201v1
+subgraph var_stream_419 ["var <tt>stream_419</tt>"]
+    style var_stream_419 fill:transparent
+    198v1
 end
 subgraph var_stream_420 ["var <tt>stream_420</tt>"]
     style var_stream_420 fill:transparent
+    199v1
+end
+subgraph var_stream_421 ["var <tt>stream_421</tt>"]
+    style var_stream_421 fill:transparent
+    200v1
+    201v1
+end
+subgraph var_stream_423 ["var <tt>stream_423</tt>"]
+    style var_stream_423 fill:transparent
     202v1
-end
-subgraph var_stream_422 ["var <tt>stream_422</tt>"]
-    style var_stream_422 fill:transparent
-    203v1
-end
-subgraph var_stream_424 ["var <tt>stream_424</tt>"]
-    style var_stream_424 fill:transparent
-    204v1
 end
 subgraph var_stream_425 ["var <tt>stream_425</tt>"]
     style var_stream_425 fill:transparent
+    203v1
+end
+subgraph var_stream_427 ["var <tt>stream_427</tt>"]
+    style var_stream_427 fill:transparent
+    204v1
+end
+subgraph var_stream_428 ["var <tt>stream_428</tt>"]
+    style var_stream_428 fill:transparent
     205v1
 end
-subgraph var_stream_429 ["var <tt>stream_429</tt>"]
-    style var_stream_429 fill:transparent
+subgraph var_stream_432 ["var <tt>stream_432</tt>"]
+    style var_stream_432 fill:transparent
     206v1
 end
-subgraph var_stream_431 ["var <tt>stream_431</tt>"]
-    style var_stream_431 fill:transparent
+subgraph var_stream_434 ["var <tt>stream_434</tt>"]
+    style var_stream_434 fill:transparent
     207v1
 end
-subgraph var_stream_435 ["var <tt>stream_435</tt>"]
-    style var_stream_435 fill:transparent
+subgraph var_stream_438 ["var <tt>stream_438</tt>"]
+    style var_stream_438 fill:transparent
     208v1
-end
-subgraph var_stream_436 ["var <tt>stream_436</tt>"]
-    style var_stream_436 fill:transparent
-    209v1
 end
 subgraph var_stream_439 ["var <tt>stream_439</tt>"]
     style var_stream_439 fill:transparent
-    210v1
-end
-subgraph var_stream_440 ["var <tt>stream_440</tt>"]
-    style var_stream_440 fill:transparent
-    211v1
-end
-subgraph var_stream_441 ["var <tt>stream_441</tt>"]
-    style var_stream_441 fill:transparent
-    212v1
+    209v1
 end
 subgraph var_stream_442 ["var <tt>stream_442</tt>"]
     style var_stream_442 fill:transparent
-    213v1
+    210v1
+end
+subgraph var_stream_443 ["var <tt>stream_443</tt>"]
+    style var_stream_443 fill:transparent
+    211v1
 end
 subgraph var_stream_444 ["var <tt>stream_444</tt>"]
     style var_stream_444 fill:transparent
-    214v1
+    212v1
 end
 subgraph var_stream_445 ["var <tt>stream_445</tt>"]
     style var_stream_445 fill:transparent
-    215v1
+    213v1
 end
-subgraph var_stream_446 ["var <tt>stream_446</tt>"]
-    style var_stream_446 fill:transparent
-    216v1
+subgraph var_stream_447 ["var <tt>stream_447</tt>"]
+    style var_stream_447 fill:transparent
+    214v1
 end
 subgraph var_stream_448 ["var <tt>stream_448</tt>"]
     style var_stream_448 fill:transparent
+    215v1
+end
+subgraph var_stream_449 ["var <tt>stream_449</tt>"]
+    style var_stream_449 fill:transparent
+    216v1
+end
+subgraph var_stream_451 ["var <tt>stream_451</tt>"]
+    style var_stream_451 fill:transparent
     217v1
 end
-subgraph var_stream_45 ["var <tt>stream_45</tt>"]
-    style var_stream_45 fill:transparent
-    10v1
-end
-subgraph var_stream_450 ["var <tt>stream_450</tt>"]
-    style var_stream_450 fill:transparent
+subgraph var_stream_453 ["var <tt>stream_453</tt>"]
+    style var_stream_453 fill:transparent
     218v1
 end
-subgraph var_stream_452 ["var <tt>stream_452</tt>"]
-    style var_stream_452 fill:transparent
+subgraph var_stream_455 ["var <tt>stream_455</tt>"]
+    style var_stream_455 fill:transparent
     219v1
 end
-subgraph var_stream_466 ["var <tt>stream_466</tt>"]
-    style var_stream_466 fill:transparent
-    222v1
-    223v1
-end
-subgraph var_stream_468 ["var <tt>stream_468</tt>"]
-    style var_stream_468 fill:transparent
-    224v1
+subgraph var_stream_46 ["var <tt>stream_46</tt>"]
+    style var_stream_46 fill:transparent
+    10v1
 end
 subgraph var_stream_469 ["var <tt>stream_469</tt>"]
     style var_stream_469 fill:transparent
-    225v1
-end
-subgraph var_stream_47 ["var <tt>stream_47</tt>"]
-    style var_stream_47 fill:transparent
-    11v1
+    222v1
+    223v1
 end
 subgraph var_stream_471 ["var <tt>stream_471</tt>"]
     style var_stream_471 fill:transparent
-    226v1
+    224v1
 end
 subgraph var_stream_472 ["var <tt>stream_472</tt>"]
     style var_stream_472 fill:transparent
-    227v1
+    225v1
+end
+subgraph var_stream_474 ["var <tt>stream_474</tt>"]
+    style var_stream_474 fill:transparent
+    226v1
 end
 subgraph var_stream_475 ["var <tt>stream_475</tt>"]
     style var_stream_475 fill:transparent
+    227v1
+end
+subgraph var_stream_478 ["var <tt>stream_478</tt>"]
+    style var_stream_478 fill:transparent
     228v1
 end
-subgraph var_stream_476 ["var <tt>stream_476</tt>"]
-    style var_stream_476 fill:transparent
+subgraph var_stream_479 ["var <tt>stream_479</tt>"]
+    style var_stream_479 fill:transparent
     229v1
-end
-subgraph var_stream_477 ["var <tt>stream_477</tt>"]
-    style var_stream_477 fill:transparent
-    230v1
 end
 subgraph var_stream_48 ["var <tt>stream_48</tt>"]
     style var_stream_48 fill:transparent
-    12v1
-    13v1
+    11v1
 end
 subgraph var_stream_480 ["var <tt>stream_480</tt>"]
     style var_stream_480 fill:transparent
+    230v1
+end
+subgraph var_stream_483 ["var <tt>stream_483</tt>"]
+    style var_stream_483 fill:transparent
     231v1
 end
-subgraph var_stream_481 ["var <tt>stream_481</tt>"]
-    style var_stream_481 fill:transparent
+subgraph var_stream_484 ["var <tt>stream_484</tt>"]
+    style var_stream_484 fill:transparent
     232v1
 end
-subgraph var_stream_482 ["var <tt>stream_482</tt>"]
-    style var_stream_482 fill:transparent
+subgraph var_stream_485 ["var <tt>stream_485</tt>"]
+    style var_stream_485 fill:transparent
     233v1
-end
-subgraph var_stream_486 ["var <tt>stream_486</tt>"]
-    style var_stream_486 fill:transparent
-    235v1
-end
-subgraph var_stream_487 ["var <tt>stream_487</tt>"]
-    style var_stream_487 fill:transparent
-    236v1
 end
 subgraph var_stream_489 ["var <tt>stream_489</tt>"]
     style var_stream_489 fill:transparent
+    235v1
+end
+subgraph var_stream_49 ["var <tt>stream_49</tt>"]
+    style var_stream_49 fill:transparent
+    12v1
+    13v1
+end
+subgraph var_stream_490 ["var <tt>stream_490</tt>"]
+    style var_stream_490 fill:transparent
+    236v1
+end
+subgraph var_stream_492 ["var <tt>stream_492</tt>"]
+    style var_stream_492 fill:transparent
     237v1
 end
-subgraph var_stream_491 ["var <tt>stream_491</tt>"]
-    style var_stream_491 fill:transparent
+subgraph var_stream_494 ["var <tt>stream_494</tt>"]
+    style var_stream_494 fill:transparent
     239v1
 end
-subgraph var_stream_496 ["var <tt>stream_496</tt>"]
-    style var_stream_496 fill:transparent
+subgraph var_stream_499 ["var <tt>stream_499</tt>"]
+    style var_stream_499 fill:transparent
     240v1
-end
-subgraph var_stream_497 ["var <tt>stream_497</tt>"]
-    style var_stream_497 fill:transparent
-    241v1
-end
-subgraph var_stream_50 ["var <tt>stream_50</tt>"]
-    style var_stream_50 fill:transparent
-    14v1
 end
 subgraph var_stream_500 ["var <tt>stream_500</tt>"]
     style var_stream_500 fill:transparent
-    242v1
-end
-subgraph var_stream_501 ["var <tt>stream_501</tt>"]
-    style var_stream_501 fill:transparent
-    243v1
+    241v1
 end
 subgraph var_stream_503 ["var <tt>stream_503</tt>"]
     style var_stream_503 fill:transparent
-    244v1
+    242v1
 end
-subgraph var_stream_505 ["var <tt>stream_505</tt>"]
-    style var_stream_505 fill:transparent
-    245v1
+subgraph var_stream_504 ["var <tt>stream_504</tt>"]
+    style var_stream_504 fill:transparent
+    243v1
 end
 subgraph var_stream_506 ["var <tt>stream_506</tt>"]
     style var_stream_506 fill:transparent
+    244v1
+end
+subgraph var_stream_508 ["var <tt>stream_508</tt>"]
+    style var_stream_508 fill:transparent
+    245v1
+end
+subgraph var_stream_509 ["var <tt>stream_509</tt>"]
+    style var_stream_509 fill:transparent
     246v1
 end
-subgraph var_stream_507 ["var <tt>stream_507</tt>"]
-    style var_stream_507 fill:transparent
+subgraph var_stream_51 ["var <tt>stream_51</tt>"]
+    style var_stream_51 fill:transparent
+    14v1
+end
+subgraph var_stream_510 ["var <tt>stream_510</tt>"]
+    style var_stream_510 fill:transparent
     247v1
 end
-subgraph var_stream_52 ["var <tt>stream_52</tt>"]
-    style var_stream_52 fill:transparent
+subgraph var_stream_53 ["var <tt>stream_53</tt>"]
+    style var_stream_53 fill:transparent
     15v1
 end
-subgraph var_stream_535 ["var <tt>stream_535</tt>"]
-    style var_stream_535 fill:transparent
+subgraph var_stream_538 ["var <tt>stream_538</tt>"]
+    style var_stream_538 fill:transparent
     249v1
-end
-subgraph var_stream_536 ["var <tt>stream_536</tt>"]
-    style var_stream_536 fill:transparent
-    250v1
 end
 subgraph var_stream_539 ["var <tt>stream_539</tt>"]
     style var_stream_539 fill:transparent
+    250v1
+end
+subgraph var_stream_542 ["var <tt>stream_542</tt>"]
+    style var_stream_542 fill:transparent
     252v1
 end
-subgraph var_stream_54 ["var <tt>stream_54</tt>"]
-    style var_stream_54 fill:transparent
-    16v1
-end
-subgraph var_stream_540 ["var <tt>stream_540</tt>"]
-    style var_stream_540 fill:transparent
+subgraph var_stream_543 ["var <tt>stream_543</tt>"]
+    style var_stream_543 fill:transparent
     253v1
 end
-subgraph var_stream_541 ["var <tt>stream_541</tt>"]
-    style var_stream_541 fill:transparent
+subgraph var_stream_544 ["var <tt>stream_544</tt>"]
+    style var_stream_544 fill:transparent
     254v1
-end
-subgraph var_stream_545 ["var <tt>stream_545</tt>"]
-    style var_stream_545 fill:transparent
-    256v1
-end
-subgraph var_stream_546 ["var <tt>stream_546</tt>"]
-    style var_stream_546 fill:transparent
-    257v1
 end
 subgraph var_stream_548 ["var <tt>stream_548</tt>"]
     style var_stream_548 fill:transparent
-    258v1
+    256v1
+end
+subgraph var_stream_549 ["var <tt>stream_549</tt>"]
+    style var_stream_549 fill:transparent
+    257v1
 end
 subgraph var_stream_55 ["var <tt>stream_55</tt>"]
     style var_stream_55 fill:transparent
-    17v1
+    16v1
 end
-subgraph var_stream_550 ["var <tt>stream_550</tt>"]
-    style var_stream_550 fill:transparent
-    259v1
+subgraph var_stream_551 ["var <tt>stream_551</tt>"]
+    style var_stream_551 fill:transparent
+    258v1
 end
 subgraph var_stream_553 ["var <tt>stream_553</tt>"]
     style var_stream_553 fill:transparent
+    259v1
+end
+subgraph var_stream_556 ["var <tt>stream_556</tt>"]
+    style var_stream_556 fill:transparent
     260v1
-end
-subgraph var_stream_557 ["var <tt>stream_557</tt>"]
-    style var_stream_557 fill:transparent
-    261v1
-end
-subgraph var_stream_558 ["var <tt>stream_558</tt>"]
-    style var_stream_558 fill:transparent
-    262v1
 end
 subgraph var_stream_56 ["var <tt>stream_56</tt>"]
     style var_stream_56 fill:transparent
-    19v1
+    17v1
 end
 subgraph var_stream_560 ["var <tt>stream_560</tt>"]
     style var_stream_560 fill:transparent
+    261v1
+end
+subgraph var_stream_561 ["var <tt>stream_561</tt>"]
+    style var_stream_561 fill:transparent
+    262v1
+end
+subgraph var_stream_563 ["var <tt>stream_563</tt>"]
+    style var_stream_563 fill:transparent
     263v1
 end
-subgraph var_stream_562 ["var <tt>stream_562</tt>"]
-    style var_stream_562 fill:transparent
+subgraph var_stream_565 ["var <tt>stream_565</tt>"]
+    style var_stream_565 fill:transparent
     264v1
 end
 subgraph var_stream_57 ["var <tt>stream_57</tt>"]
     style var_stream_57 fill:transparent
+    19v1
+end
+subgraph var_stream_58 ["var <tt>stream_58</tt>"]
+    style var_stream_58 fill:transparent
     20v1
 end
-subgraph var_stream_59 ["var <tt>stream_59</tt>"]
-    style var_stream_59 fill:transparent
+subgraph var_stream_60 ["var <tt>stream_60</tt>"]
+    style var_stream_60 fill:transparent
     21v1
 end
-subgraph var_stream_61 ["var <tt>stream_61</tt>"]
-    style var_stream_61 fill:transparent
+subgraph var_stream_62 ["var <tt>stream_62</tt>"]
+    style var_stream_62 fill:transparent
     22v1
 end
-subgraph var_stream_64 ["var <tt>stream_64</tt>"]
-    style var_stream_64 fill:transparent
+subgraph var_stream_65 ["var <tt>stream_65</tt>"]
+    style var_stream_65 fill:transparent
     23v1
-end
-subgraph var_stream_67 ["var <tt>stream_67</tt>"]
-    style var_stream_67 fill:transparent
-    24v1
 end
 subgraph var_stream_68 ["var <tt>stream_68</tt>"]
     style var_stream_68 fill:transparent
+    24v1
+end
+subgraph var_stream_69 ["var <tt>stream_69</tt>"]
+    style var_stream_69 fill:transparent
     25v1
 end
-subgraph var_stream_71 ["var <tt>stream_71</tt>"]
-    style var_stream_71 fill:transparent
+subgraph var_stream_72 ["var <tt>stream_72</tt>"]
+    style var_stream_72 fill:transparent
     26v1
-end
-subgraph var_stream_73 ["var <tt>stream_73</tt>"]
-    style var_stream_73 fill:transparent
-    27v1
 end
 subgraph var_stream_74 ["var <tt>stream_74</tt>"]
     style var_stream_74 fill:transparent
-    28v1
+    27v1
 end
 subgraph var_stream_75 ["var <tt>stream_75</tt>"]
     style var_stream_75 fill:transparent
-    29v1
+    28v1
 end
 subgraph var_stream_76 ["var <tt>stream_76</tt>"]
     style var_stream_76 fill:transparent
+    29v1
+end
+subgraph var_stream_77 ["var <tt>stream_77</tt>"]
+    style var_stream_77 fill:transparent
     30v1
 end
-subgraph var_stream_79 ["var <tt>stream_79</tt>"]
-    style var_stream_79 fill:transparent
+subgraph var_stream_80 ["var <tt>stream_80</tt>"]
+    style var_stream_80 fill:transparent
     31v1
-end
-subgraph var_stream_81 ["var <tt>stream_81</tt>"]
-    style var_stream_81 fill:transparent
-    32v1
 end
 subgraph var_stream_82 ["var <tt>stream_82</tt>"]
     style var_stream_82 fill:transparent
-    33v1
+    32v1
 end
 subgraph var_stream_83 ["var <tt>stream_83</tt>"]
     style var_stream_83 fill:transparent
-    34v1
+    33v1
 end
 subgraph var_stream_84 ["var <tt>stream_84</tt>"]
     style var_stream_84 fill:transparent
-    35v1
+    34v1
 end
 subgraph var_stream_85 ["var <tt>stream_85</tt>"]
     style var_stream_85 fill:transparent
-    36v1
+    35v1
 end
 subgraph var_stream_86 ["var <tt>stream_86</tt>"]
     style var_stream_86 fill:transparent
+    36v1
+end
+subgraph var_stream_87 ["var <tt>stream_87</tt>"]
+    style var_stream_87 fill:transparent
     37v1
     38v1
 end
-subgraph var_stream_88 ["var <tt>stream_88</tt>"]
-    style var_stream_88 fill:transparent
+subgraph var_stream_89 ["var <tt>stream_89</tt>"]
+    style var_stream_89 fill:transparent
     39v1
-end
-subgraph var_stream_90 ["var <tt>stream_90</tt>"]
-    style var_stream_90 fill:transparent
-    40v1
 end
 subgraph var_stream_91 ["var <tt>stream_91</tt>"]
     style var_stream_91 fill:transparent
-    41v1
+    40v1
 end
 subgraph var_stream_92 ["var <tt>stream_92</tt>"]
     style var_stream_92 fill:transparent
-    42v1
+    41v1
 end
 subgraph var_stream_93 ["var <tt>stream_93</tt>"]
     style var_stream_93 fill:transparent
+    42v1
+end
+subgraph var_stream_94 ["var <tt>stream_94</tt>"]
+    style var_stream_94 fill:transparent
     43v1
 end
-subgraph var_stream_98 ["var <tt>stream_98</tt>"]
-    style var_stream_98 fill:transparent
+subgraph var_stream_99 ["var <tt>stream_99</tt>"]
+    style var_stream_99 fill:transparent
     44v1
 end


### PR DESCRIPTION
BREAKING CHANGE: `Optional<Type, Loc, Bound: OptionalBound>` instead of `Bound: Boundedness`. This should be fine in most cases since the types that implement `Boundedness` also implement the new `OptionalBound`.

Introduces the first of the planned "settling" boundedness variants for `Optional`, `InitNone`
`InitNone` means the optional is null only initially:
once it becomes non-null, it stays non-null forever; the non-null value may still change
arbitrarily. It erases to `Unbounded`, mirroring `Singleton`'s `Monotonic`.

`Optional` is now governed by a single trait, `OptionalBound` (like `Singleton`/`KeyedSingleton`
use `SingletonBound`/`KeyedSingletonBound`). This replaces the `B: Boundedness` on any
`Optional` method — methods instead project through `B::UnderlyingBound`, so `Boundedness` only
appears as an associated projection rather than a competing bound.

## Type-system machinery (`optional.rs`)
- New `OptionalBound` trait with `UnderlyingBound: Boundedness` and `bound_kind()`, implemented for
 `Unbounded`, `Bounded`, and the new `InitNone` marker.
- New sealed `IsInitNone` marker trait (analog of `IsMonotonic`), implemented for `InitNone` and
 blanket-implemented for `IsBounded`.
- `Optional<Type, Loc, Bound>` now bounds `Bound: OptionalBound`.
- `ignore_init_none()` erasure method (analog of `ignore_monotonic`).

## Method typing (single-trait cleanup)
- Presence-preserving `map` keeps `B` (its closure context now uses `B::UnderlyingBound`, matching
 `KeyedSingleton::map`).
- `filter`, `filter_map`, `or`, `unwrap_or`, `unwrap_or_default`, `into_singleton`, `is_some`,
 `is_none`, and `into_keyed_singleton` now return at `B::UnderlyingBound` (these can drop presence
 or produce a `Singleton`/`KeyedSingleton`). `or` erases its receiver first via `ignore_init_none`
 so its existing tick/snapshot logic runs entirely in `Boundedness`-land.
- `IsBounded`-gated methods are unchanged: `IsBounded ⟹ Boundedness ⟹ B::UnderlyingBound == B`,
 so they type-check with no edits and every existing `Bounded`/`Unbounded` call site is unchanged.
- `snapshot`, `snapshot_atomic`, `sample_*`, and the `ForwardRef` cycle impls generalized to
 `OptionalBound` (their results are already concrete, e.g. always-`Bounded` snapshots).

## IR (`compile/ir/mod.rs`)
- New `OptionalBoundKind { Unbounded, InitNone, Bounded }` enum; `CollectionKind::Optional` now
 carries it instead of the shared `BoundKind`. Existing serialized snapshots are unchanged because
 the `Unbounded`/`Bounded` variant names serialize identically.
- `is_bounded()` updated accordingly.

## Boundedness supertrait (`boundedness.rs`)
- `Boundedness` now additionally requires `OptionalBound<UnderlyingBound = Self>`, which is what
 makes `B::UnderlyingBound == B` hold for every `Bounded`/`Unbounded`/`IsBounded` context.

## Other
- `Singleton::zip` and `viz::render` updated for the new enum; a dedicated
 `add_optional_bound_property` helper renders `InitNone` as unbounded.

## Projection
- Added `Boundedness::AggregatedOptional: OptionalBound<UnderlyingBound = Self>`:
  `Bounded → Bounded`, `Unbounded → InitNone`.

## Retyped aggregations (`stream/mod.rs`)
- `reduce`, `max`, `min`, `first`, `last` now return `Optional<T, L, B::AggregatedOptional>`.
- For a bounded (in-tick) stream this is unchanged (`Bounded`). For an unbounded top-level
  stream the result is `InitNone`, which is *sound with zero codegen change*: such aggregations
  lower to `reduce::<'static>` (persisted across ticks), so once the first element arrives the
  optional is non-null forever. Per-tick aggregations stay `Bounded` (they lower to `reduce::<'tick>`).
  Verified the invariant that `Unbounded` streams only live at top-level locations.

## Ergonomics / downstream
- Added `From<Optional<T, L, InitNone>> for Optional<T, L, Unbounded>` (mirrors `From<Bounded>`).
- Generalized `BatchAtomic for Optional` from `Unbounded` to any `OptionalBound` (mirrors the
  existing `Singleton`/`Monotonic` impl), so `across_ticks(|s| s.max())` keeps working.
- `KeyedSingleton::get_max_key` erases its internal `reduce` result via `ignore_init_none()` to
  preserve its existing signature.
- hydro_test: `across_ticks(|s| s.max())` sites now compile unchanged (via the BatchAtomic
  generalization); one Paxos call site uses `.max().into()` to feed a `_, Unbounded>`-typed
  helper. Regenerated the `compute_pi_ir` and `paxos_ir` IR/mermaid snapshots (a single
  `Unbounded → InitNone` bound label on aggregation outputs, plus one passthrough `Cast` node
  from the `.into()` that shifts stmt-id numbering in the mermaids).

Codegen is byte-for-byte identical because optional codegen only branches on `is_bounded()`,
and `InitNone` reports the same as `Unbounded`.