### PR TITLE
fix(hydro_lang): convert type-level marker structs to uninhabitable enums

### DIFF
--- a/hydro_lang/src/live_collections/keyed_singleton.rs
+++ b/hydro_lang/src/live_collections/keyed_singleton.rs
@@ -97,7 +97,7 @@ impl KeyedSingletonBound for Bounded {
 
 /// A variation of boundedness specific to [`KeyedSingleton`], which indicates that once a key appears,
 /// its value is bounded and will never change, but new entries may appear asynchronously
-pub struct BoundedValue;
+pub enum BoundedValue {}
 
 impl KeyedSingletonBound for BoundedValue {
     type UnderlyingBound = Unbounded;
@@ -114,7 +114,7 @@ impl KeyedSingletonBound for BoundedValue {
 
 /// A variation of boundedness specific to [`KeyedSingleton`], which indicates that once a key appears,
 /// it will never be removed, and the corresponding value will only increase monotonically.
-pub struct MonotonicValue;
+pub enum MonotonicValue {}
 
 impl KeyedSingletonBound for MonotonicValue {
     type UnderlyingBound = Unbounded;
@@ -131,7 +131,7 @@ impl KeyedSingletonBound for MonotonicValue {
 
 /// A variation of boundedness specific to [`KeyedSingleton`], which indicates that once a key
 /// appears, it will never be removed, but the corresponding value may change arbitrarily.
-pub struct MonotonicKeys;
+pub enum MonotonicKeys {}
 
 impl KeyedSingletonBound for MonotonicKeys {
     type UnderlyingBound = Unbounded;

--- a/hydro_lang/src/live_collections/singleton.rs
+++ b/hydro_lang/src/live_collections/singleton.rs
@@ -68,7 +68,7 @@ impl SingletonBound for Bounded {
 }
 
 /// Marks that the [`Singleton`] is monotonic, which means that its value will only grow over time.
-pub struct Monotonic;
+pub enum Monotonic {}
 
 impl SingletonBound for Monotonic {
     type UnderlyingBound = Unbounded;


### PR DESCRIPTION
The hydro_lang codebase uses uninhabitable enums (`pub enum Marker {}`) for
type-level markers such as `Bounded`, `Unbounded`, `TotalOrder`, `NoOrder`,
`ExactlyOnce`, and `AtLeastOnce`. Four boundedness markers were instead declared
as unit structs (`pub struct Marker;`), which are inhabitable and inconsistent
with the rest of the codebase.

These markers are only ever used at the type level (as generic parameters,
associated types, and trait impl targets) and are never instantiated as values,
so converting them to zero-variant enums makes them uninhabitable without
affecting behavior:

- `Monotonic` in live_collections/singleton.rs
- `BoundedValue` in live_collections/keyed_singleton.rs
- `MonotonicValue` in live_collections/keyed_singleton.rs
- `MonotonicKeys` in live_collections/keyed_singleton.rs

Verified the full workspace still compiles.