### PR TITLE
fix(hydro_lang): propagate coverage instrumentation to trybuild dylib builds

### DIFF
--- a/docs/docs/hydro/reference/simulation/index.mdx
+++ b/docs/docs/hydro/reference/simulation/index.mdx
@@ -18,3 +18,8 @@ The simulator uses the exact same Hydro code you will run in production, and req
 | Batching / Snapshotting             | Partial             | Supported on all live collections except `Optional` |
 | Unordered Reductions                        | Full             | Built-in operators like `count` are accelerated, but not arbitrary `{fold/reduce}` |
 | Non-Deterministic Observations | Limited             | `assume_ordering::<TotalOrder>` is supported, `assume_retries::<ExactlyOnce>` is not supported |
+
+## Code Coverage
+Simulation tests execute your Hydro code inside a dynamic library that is compiled on the fly when the test runs, rather than inside the test binary itself. The simulator makes sure code-coverage instrumentation carries over to that library: if it detects a coverage run (the `LLVM_PROFILE_FILE` environment variable, which coverage harnesses set for the test process, or an explicit `instrument-coverage` flag in `RUSTFLAGS`), it compiles the library with `-C instrument-coverage` as well, so lines exercised only through the simulator are attributed to your source files like any other test coverage.
+
+One note for custom coverage pipelines: the coverage mapping for simulator-executed code lives in the compiled library itself, not in the test binary. During a coverage run the simulator keeps a copy of each compiled library under `target/debug/deps/hydro-coverage/`, so tools like `grcov` or `llvm-cov` that take explicit binary paths will find these mappings whether they are pointed at `target/debug` or `target/debug/deps` alongside the test binaries when generating reports.

--- a/hydro_lang/src/compile/trybuild/generate.rs
+++ b/hydro_lang/src/compile/trybuild/generate.rs
@@ -375,15 +375,57 @@ fn rustc_target_libdir() -> Option<String> {
         .clone()
 }
 
+/// The built artifact returned by [`compile_trybuild_example`].
+///
+/// Outside coverage runs this is a delete-on-drop temporary copy: every build
+/// reuses the same example artifact path in the shared target dir (e.g. the
+/// simulator always builds `sim-dylib`, varying only `TRYBUILD_LIB_NAME`), so
+/// the caller gets a private copy that a later build cannot clobber.
+///
+/// In coverage runs the copy is instead persisted (keyed by the generated
+/// source's hash, which `bin_name` embeds) under the main target dir's
+/// `debug/deps`, and must outlive the process: the coverage mapping needed to
+/// resolve profile data lives in the artifact itself, and report-time tools
+/// (e.g. `grcov --binary-path target/debug` or `target/debug/deps`, both
+/// scanned recursively) run only after all test processes have exited.
+pub enum BuiltArtifact {
+    /// A delete-on-drop temporary copy of the artifact.
+    Temp(tempfile::TempPath),
+    /// A persistent copy that survives process exit, for coverage reporters.
+    Persisted(PathBuf),
+}
+
+impl std::ops::Deref for BuiltArtifact {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        match self {
+            BuiltArtifact::Temp(path) => path,
+            BuiltArtifact::Persisted(path) => path,
+        }
+    }
+}
+
+impl BuiltArtifact {
+    /// Persist the artifact at its current path, returning that path (the
+    /// temporary copy is kept rather than deleted on drop).
+    pub fn keep(self) -> Result<PathBuf, std::io::Error> {
+        match self {
+            BuiltArtifact::Temp(path) => path.keep().map_err(|e| e.error),
+            BuiltArtifact::Persisted(path) => Ok(path),
+        }
+    }
+}
+
 /// Compiles a generated trybuild example against the prebuilt dylib crate,
 /// using the shared parallel-compilation machinery (per-job target dirs with
 /// symlinked shared artifacts, plus a prebuild of the dylib dependencies).
 ///
-/// Returns the path to a temporary copy of the built artifact (a `cdylib` for
-/// the simulator, or an executable for Maelstrom). The copy allows the caller
-/// to hold onto the artifact independently of the shared target directory.
+/// Returns a [`BuiltArtifact`] handle to a copy of the built artifact (a
+/// `cdylib` for the simulator, or an executable for Maelstrom), which the
+/// caller can hold onto independently of the shared target directory.
 #[cfg(any(feature = "sim", feature = "maelstrom"))]
-pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfile::TempPath, ()> {
+pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<BuiltArtifact, ()> {
     use std::process::{Command, Stdio};
 
     let ExampleBuildConfig {
@@ -399,7 +441,36 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
     let is_fuzz = allow_fuzz && std::env::var("BOLERO_FUZZER").is_ok();
     // When RUSTFLAGS is set, our prebuild fingerprint doesn't account for it, so skip the
     // parallel build machinery entirely and build directly into the shared target dir.
-    let has_custom_rustflags = std::env::var("RUSTFLAGS").is_ok();
+    //
+    // Coverage instrumentation needs the same treatment, but the host's
+    // `-C instrument-coverage` often never reaches this child build: pipelines that inject
+    // it via cargo CLI config (`--config build.rustflags=[...]`) or a
+    // `RUSTC_WORKSPACE_WRAPPER` leave the test process's environment untouched, so code
+    // exercised only through the compiled dylib would silently report zero coverage. The
+    // coverage *runtime* does leave a reliable footprint, though: `LLVM_PROFILE_FILE` is
+    // set for the test process and inherited here. When present, synthesize
+    // `-C instrument-coverage` into the child build's RUSTFLAGS (unless the inherited
+    // RUSTFLAGS already carries an instrument-coverage flag, as with `cargo llvm-cov`).
+    // Skipping the prebuild machinery keeps this simple, but coverage builds must also
+    // be isolated from the shared target dir (see below), and the covmap-bearing
+    // artifact is copied to a stable location where coverage reporters can find it.
+    // See https://github.com/hydro-project/hydro/issues/3160.
+    let mut custom_rustflags = std::env::var("RUSTFLAGS").ok();
+    if std::env::var_os("LLVM_PROFILE_FILE").is_some()
+        && !custom_rustflags
+            .as_deref()
+            .is_some_and(|flags| flags.contains("instrument-coverage"))
+    {
+        let flags = custom_rustflags.get_or_insert_default();
+        if !flags.is_empty() {
+            flags.push(' ');
+        }
+        flags.push_str("-Cinstrument-coverage");
+    }
+    let has_custom_rustflags = custom_rustflags.is_some();
+    let coverage_enabled = custom_rustflags
+        .as_deref()
+        .is_some_and(|flags| flags.contains("instrument-coverage"));
 
     // Run from dylib-examples crate which has the dylib as a dev-dependency (only if not fuzzing)
     let crate_to_compile = if is_fuzz {
@@ -473,7 +544,16 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
         drop(prebuild_span);
         (per_job, Some(guard), Some(cargo_lock))
     } else {
-        (trybuild.target_dir.clone(), None, None)
+        // Coverage builds get an isolated target dir: flags differ from prebuild-mode
+        // builds, so building into the shared target dir would clobber the shared
+        // artifacts that prebuild-mode builds symlink against, breaking interleaved
+        // non-coverage runs (and forcing full rebuilds in both directions).
+        let target_dir = if coverage_enabled {
+            path!(trybuild.target_dir / "coverage")
+        } else {
+            trybuild.target_dir.clone()
+        };
+        (target_dir, None, None)
     };
 
     // Populate per-job build/ dir right before final build. Hold guard for entire build.
@@ -527,6 +607,14 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
             .join(","),
     ]);
     command.args(["--config", "build.incremental = false"]);
+    if let Some(flags) = &custom_rustflags {
+        // Covers both inherited RUSTFLAGS (a no-op re-set) and the synthesized
+        // instrument-coverage case, where the flag must apply to the whole child build
+        // graph — in particular the crate under test, which the generated project pulls
+        // in as a path dependency at its real source location (so coverage regions map
+        // back to the original files).
+        command.env("RUSTFLAGS", flags);
+    }
     if let Some(crate_type) = crate_type {
         command.args(["--crate-type", crate_type]);
     }
@@ -571,6 +659,16 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
                 // https://github.com/rust-lang/rust/issues/91979
                 "-Clink-args=-Wl,-z,nodelete",
             );
+        }
+
+        if coverage_enabled && cfg!(target_os = "linux") {
+            // The dynamic loader resolves the example's trybuild-dylib dependency by
+            // soname, and cargo puts the *host* target dir's deps/ on LD_LIBRARY_PATH
+            // when running tests — which outranks DT_RUNPATH and would shadow the
+            // isolated coverage build's dylib with the same-soname uninstrumented one.
+            // Emit legacy DT_RPATH, which outranks LD_LIBRARY_PATH, so the rpath baked
+            // above (pointing into the coverage target dir) wins.
+            command.arg("-Clink-arg=-Wl,--disable-new-dtags");
         }
     }
 
@@ -675,9 +773,32 @@ pub fn compile_trybuild_example(config: ExampleBuildConfig<'_>) -> Result<tempfi
         panic!("final build failed to produce binary.\nstderr:\n{stderr_output}");
     }
 
+    if coverage_enabled {
+        // The coverage mapping needed to resolve profile data at report time lives in
+        // the artifact itself, and reporters run only after all test processes have
+        // exited — so the copy must be persistent, not a delete-on-drop temp file.
+        // Persist it keyed by the generated source's hash (embedded in `bin_name`;
+        // the shared artifact path itself is reused by every build and would be
+        // clobbered), under the main target dir's `debug/deps` so reporters find
+        // every mapping whether they scan `target/debug` or the narrower
+        // `target/debug/deps` (both are common `grcov --binary-path` conventions,
+        // and both are scanned recursively). This persisted copy doubles as the
+        // artifact handed to the caller.
+        let coverage_dir = path!(trybuild.target_dir / "debug" / "deps" / "hydro-coverage");
+        fs::create_dir_all(&coverage_dir).unwrap();
+        let artifact_name = out.as_ref().unwrap().file_name().unwrap().to_str().unwrap();
+        let persisted = path!(coverage_dir / format!("{bin_name}-{artifact_name}"));
+        // Write via a unique temp file + rename so concurrent test processes
+        // building the same flow never observe a partially-copied artifact.
+        let staging = tempfile::NamedTempFile::new_in(&coverage_dir).unwrap();
+        fs::copy(out.as_ref().unwrap(), staging.path()).unwrap();
+        staging.persist(&persisted).unwrap();
+        return Ok(BuiltArtifact::Persisted(persisted));
+    }
+
     let out_file = tempfile::NamedTempFile::new().unwrap().into_temp_path();
     fs::copy(out.as_ref().unwrap(), &out_file).unwrap();
-    Ok(out_file)
+    Ok(BuiltArtifact::Temp(out_file))
 }
 
 /// Generates the inlined `__staged.rs` source for the source crate and writes it into the

--- a/hydro_lang/src/sim/compiled.rs
+++ b/hydro_lang/src/sim/compiled.rs
@@ -93,12 +93,12 @@ use futures::StreamExt;
 use libloading::Library;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use tempfile::TempPath;
 use tokio::sync::{Mutex, Notify};
 
 use super::runtime::{Hooks, InlineHooks};
 use super::{SimClusterReceiver, SimClusterSender, SimReceiver, SimSender};
 use crate::compile::builder::ExternalPortId;
+use crate::compile::trybuild::generate::BuiltArtifact;
 use crate::live_collections::stream::{ExactlyOnce, NoOrder, Ordering, Retries, TotalOrder};
 use crate::location::dynamic::LocationId;
 use crate::sim::graph::{SimExternalPort, SimExternalPortRegistry};
@@ -466,7 +466,7 @@ tokio::task_local! {
 
 /// A handle to a compiled Hydro simulation, which can be instantiated and run.
 pub struct CompiledSim {
-    pub(super) _path: TempPath,
+    pub(super) _path: BuiltArtifact,
     pub(super) lib: Library,
     pub(super) externals_port_registry: SimExternalPortRegistry,
     pub(super) unit_test_fuzz_iterations: usize,

--- a/hydro_lang/src/sim/flow.rs
+++ b/hydro_lang/src/sim/flow.rs
@@ -248,7 +248,7 @@ impl<'a> SimFlow<'a> {
         let out = compile_sim(bin, trybuild).unwrap();
         let lib = {
             let _span = tracing::debug_span!(target: "hydro_build", "load_dylib").entered();
-            unsafe { Library::new(&out).unwrap() }
+            unsafe { Library::new(&*out).unwrap() }
         };
         drop(compiled_span);
 

--- a/hydro_lang/src/sim/graph.rs
+++ b/hydro_lang/src/sim/graph.rs
@@ -10,7 +10,6 @@ use quote::quote;
 use sha2::{Digest, Sha256};
 use slotmap::SparseSecondaryMap;
 use stageleft::QuotedWithContext;
-use tempfile::TempPath;
 use trybuild_internals_api::{cargo, dependencies, path};
 
 use crate::compile::builder::ExternalPortId;
@@ -18,8 +17,8 @@ use crate::compile::deploy_provider::{Deploy, DynSourceSink, Node, RegisterPort}
 #[cfg(any(feature = "deploy", feature = "maelstrom"))]
 use crate::compile::trybuild::generate::LinkingMode;
 use crate::compile::trybuild::generate::{
-    CONCURRENT_TEST_LOCK, ExampleBuildConfig, IS_TEST, TrybuildConfig, compile_trybuild_example,
-    create_trybuild, write_atomic, write_staged_source_cached,
+    BuiltArtifact, CONCURRENT_TEST_LOCK, ExampleBuildConfig, IS_TEST, TrybuildConfig,
+    compile_trybuild_example, create_trybuild, write_atomic, write_staged_source_cached,
 };
 use crate::deploy::deploy_runtime::cluster_membership_stream;
 use crate::location::dynamic::LocationId;
@@ -432,7 +431,7 @@ impl<'a> Deploy<'a> for SimDeploy {
     }
 }
 
-pub(super) fn compile_sim(bin: String, trybuild: TrybuildConfig) -> Result<TempPath, ()> {
+pub(super) fn compile_sim(bin: String, trybuild: TrybuildConfig) -> Result<BuiltArtifact, ()> {
     compile_trybuild_example(ExampleBuildConfig {
         trybuild,
         bin_name: bin,


### PR DESCRIPTION
Fixes #3160.

Code executed by the simulator was invisible to coverage instrumentation because the trybuild dylib is compiled by a child `cargo` invocation that never receives `-C instrument-coverage` when the flag is injected via cargo CLI config (`--config build.rustflags=[...]`) or a `RUSTC_WORKSPACE_WRAPPER`-based selective scheme — neither channel is visible in the test process's environment, so the existing `RUSTFLAGS` env passthrough never fires. (And even when `RUSTFLAGS` *is* a real env var, a workspace-wrapper scheme would still skip the crate under test, since it's an external path dependency of the generated project rather than a workspace member.)

### Changes (`hydro_lang/src/compile/trybuild/generate.rs`)

- **Detection**: treat `LLVM_PROFILE_FILE` being set in the env as the signal that the host build is coverage-instrumented (it is inherited by the test process regardless of how the rustc flag was injected), and synthesize `-C instrument-coverage` into the child build's `RUSTFLAGS` — merged with any inherited `RUSTFLAGS`, and skipped if it already carries the flag, so `cargo llvm-cov` behavior is unchanged.
- **Isolation**: coverage builds go to `<target>/coverage` instead of the shared trybuild target dir; instrumented artifacts previously clobbered the shared prebuild cache, breaking subsequent non-coverage runs with dlopen undefined-symbol errors.
- **Loader precedence** (Linux): link coverage builds with `--disable-new-dtags` so `DT_RPATH` outranks the `LD_LIBRARY_PATH` cargo sets for test processes, which otherwise shadowed the isolated instrumented dylib with the same-soname uninstrumented one from `target/debug/deps`.
- **Report-time discovery**: persist a per-build covmap-bearing copy of the dylib under `target/debug/deps/hydro-coverage/` (every sim build reuses the same `sim-dylib` artifact path, so later builds overwrite earlier coverage mappings). Coverage reporters (grcov / `llvm-cov report --object`) can point at these.
- Documented the coverage workflow in `docs/docs/hydro/reference/simulation/index.mdx`.

Because the generated project depends on the crate under test as a path dependency at its real source location, coverage regions map back to the original files with no path remapping.

### Validation

Linux, `hydro_lang`'s `sim_atomic_stream` test, with `LLVM_PROFILE_FILE` set and **no** `RUSTFLAGS` (the previously-broken scenario): profraws are emitted and `llvm-profdata merge` + `llvm-cov report --object <persisted dylib>` attributes coverage to real source files (e.g. dfir_pipes push/pull operators at ~90–100%). Interleaved coverage → non-coverage → coverage runs all pass with intact caches in both modes (second coverage run fully cached). `cargo check`/`clippy`/`fmt` clean for `hydro_lang` with `sim,maelstrom` features.

Caveat: the `--disable-new-dtags` linker arg is gated to Linux; on macOS `DYLD_FALLBACK_LIBRARY_PATH` has lower precedence than rpath, so the shadowing problem shouldn't arise there, but I couldn't verify on hardware.


### Update: validated against a real CI coverage pipeline

Tested end-to-end in a downstream CI pipeline that injects `-C instrument-coverage` via cargo CLI config plus selective workspace instrumentation (the exact scenario from #3160), reporting with `grcov --binary-path target/debug/deps`:

- sim-executed functions that previously reported 0% flipped to covered: the affected module went from ~49% to **99% line coverage**, and functions invoked only inside `q!()` closures now report hits;
- the `LLVM_PROFILE_FILE`-based detection fired as designed (profraws emitted for both the test binary and the dylib flush);
- one adjustment came out of it: the persisted covmap copies now live under `target/debug/deps/hydro-coverage/` instead of `target/debug/hydro-coverage/`, since `--binary-path` conventions vary between `target/debug` and `target/debug/deps` — the `deps` location is found recursively by both (and by `cargo llvm-cov`);
- overhead: the instrumented sim child builds (uncached by design) added ~1.6 min to that crate's coverage run, and the persisted dylib copies cost a few hundred MB per run.
