### PR TITLE
fix(hydro_lang): move demux serde bounds onto the serialization transport

### DIFF
--- a/hydro_lang/src/live_collections/keyed_stream/networking.rs
+++ b/hydro_lang/src/live_collections/keyed_stream/networking.rs
@@ -116,7 +116,6 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
         R,
     >
     where
-        T: Serialize + DeserializeOwned,
         O: MinOrder<N::OrderingGuarantee>,
     {
         let name = via.name();
@@ -263,8 +262,6 @@ impl<'a, K, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
         R,
     >
     where
-        K: Serialize + DeserializeOwned,
-        T: Serialize + DeserializeOwned,
         O: MinOrder<N::OrderingGuarantee>,
     {
         let name = via.name();
@@ -444,7 +441,6 @@ impl<'a, T, L, L2, B: Boundedness, C: Consistency, O: Ordering, R: Retries>
         R,
     >
     where
-        T: Serialize + DeserializeOwned,
         O: MinOrder<N::OrderingGuarantee>,
     {
         let name = via.name();
@@ -634,8 +630,6 @@ impl<'a, K, V, L, B: Boundedness, C: Consistency, O: Ordering, R: Retries>
         R,
     >
     where
-        K: Serialize + DeserializeOwned,
-        V: Serialize + DeserializeOwned,
         O: MinOrder<N::OrderingGuarantee>,
     {
         let name = via.name();

--- a/hydro_lang/src/live_collections/stream/networking.rs
+++ b/hydro_lang/src/live_collections/stream/networking.rs
@@ -167,7 +167,6 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
         via: N,
     ) -> Stream<T, Process<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, R>
     where
-        T: Serialize + DeserializeOwned,
         O: MinOrder<N::OrderingGuarantee>,
     {
         let name = via.name();
@@ -318,7 +317,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
         nondet_membership: NonDet,
     ) -> Stream<T, Cluster<'a, L2>, Unbounded, <O as MinOrder<N::OrderingGuarantee>>::Min, R>
     where
-        T: Clone + Serialize + DeserializeOwned,
+        T: Clone,
         O: MinOrder<N::OrderingGuarantee>,
     {
         let ids = track_membership(self.location.source_cluster_membership_stream(
@@ -393,7 +392,7 @@ impl<'a, T, L, B: Boundedness, O: Ordering, R: Retries> Stream<T, Process<'a, L>
         R,
     >
     where
-        T: Clone + Serialize + DeserializeOwned,
+        T: Clone,
         O: MinOrder<N::OrderingGuarantee>,
     {
         let cluster_ids = ClusterIds {
@@ -619,7 +618,6 @@ impl<'a, T, L, L2, B: Boundedness, O: Ordering, R: Retries>
         R,
     >
     where
-        T: Serialize + DeserializeOwned,
         O: MinOrder<N::OrderingGuarantee>,
     {
         self.into_keyed().demux(to, via)
@@ -734,10 +732,7 @@ impl<'a, T, L, B: Boundedness> Stream<T, Process<'a, L>, B, TotalOrder, ExactlyO
         to: &Cluster<'a, L2>,
         via: N,
         nondet_membership: NonDet,
-    ) -> Stream<T, Cluster<'a, L2>, Unbounded, N::OrderingGuarantee, ExactlyOnce>
-    where
-        T: Serialize + DeserializeOwned,
-    {
+    ) -> Stream<T, Cluster<'a, L2>, Unbounded, N::OrderingGuarantee, ExactlyOnce> {
         let ids = track_membership(self.location.source_cluster_membership_stream(
             to,
             nondet!(/** dropped prefixes don't affect broadcast */),
@@ -883,8 +878,6 @@ impl<'a, T, L, B: Boundedness, C: Consistency>
         via: N,
         nondet_membership: NonDet,
     ) -> KeyedStream<MemberId<L>, T, Cluster<'a, L2>, Unbounded, N::OrderingGuarantee, ExactlyOnce>
-    where
-        T: Serialize + DeserializeOwned,
     {
         let ids = track_membership(self.location.source_cluster_membership_stream(
             to,
@@ -1048,7 +1041,6 @@ impl<'a, T, L, B: Boundedness, C: Consistency, O: Ordering, R: Retries>
         R,
     >
     where
-        T: Serialize + DeserializeOwned,
         O: MinOrder<N::OrderingGuarantee>,
     {
         let name = via.name();
@@ -1228,7 +1220,7 @@ impl<'a, T, L, B: Boundedness, C: Consistency, O: Ordering, R: Retries>
         R,
     >
     where
-        T: Clone + Serialize + DeserializeOwned,
+        T: Clone,
         O: MinOrder<N::OrderingGuarantee>,
     {
         let ids = track_membership(self.location.source_cluster_membership_stream(
@@ -1276,7 +1268,7 @@ impl<'a, T, L, B: Boundedness, C: Consistency, O: Ordering, R: Retries>
         R,
     >
     where
-        T: Clone + Serialize + DeserializeOwned,
+        T: Clone,
         O: MinOrder<N::OrderingGuarantee>,
     {
         let cluster_ids = ClusterIds {
@@ -1471,7 +1463,6 @@ impl<'a, T, L, L2, B: Boundedness, C: Consistency, O: Ordering, R: Retries>
         R,
     >
     where
-        T: Serialize + DeserializeOwned,
         O: MinOrder<N::OrderingGuarantee>,
     {
         self.into_keyed().demux(to, via)

--- a/hydro_lang/tests/compile-fail/demux_bincode_requires_serde.rs
+++ b/hydro_lang/tests/compile-fail/demux_bincode_requires_serde.rs
@@ -1,0 +1,36 @@
+#![allow(unexpected_cfgs)]
+
+use hydro_lang::location::MemberId;
+use hydro_lang::prelude::*;
+
+struct P1 {}
+struct Workers {}
+
+// Deliberately does not implement `Serialize`.
+struct OpaquePayload {
+    text: String,
+}
+
+// A stub `Deserialize` impl, so that only the missing `Serialize` produces an
+// error: rustc's "the following other types implement ..." candidate list for
+// `Deserialize` includes concrete `&'a X` impls contributed by whatever
+// happens to be in the dependency graph (e.g. `&'a camino::Utf8Path` when
+// camino's serde feature is enabled), which makes its stderr snapshot vary
+// across environments. `Serialize`'s list is stable blanket/tuple impls.
+impl<'de> serde::Deserialize<'de> for OpaquePayload {
+    fn deserialize<D: serde::Deserializer<'de>>(_: D) -> Result<Self, D::Error> {
+        unreachable!()
+    }
+}
+
+fn test<'a>(p1: &Process<'a, P1>, workers: &Cluster<'a, Workers>) {
+    let payloads = p1
+        .source_iter(q!(vec!["hello".to_owned()]))
+        .map(q!(|s| (MemberId::from_raw_id(0), OpaquePayload { text: s })));
+
+    // `.bincode()` serializes items, so the payload must implement
+    // `Serialize` (and `DeserializeOwned`); `.embedded()` would accept it.
+    payloads.demux(workers, TCP.fail_stop().bincode());
+}
+
+fn main() {}

--- a/hydro_lang/tests/compile-fail/nightly/demux_bincode_requires_serde.stderr
+++ b/hydro_lang/tests/compile-fail/nightly/demux_bincode_requires_serde.stderr
@@ -1,0 +1,58 @@
+error[E0277]: the trait bound `OpaquePayload: serde::Serialize` is not satisfied
+  --> tests/compile-fail/nightly/demux_bincode_requires_serde.rs:33:29
+   |
+33 |     payloads.demux(workers, TCP.fail_stop().bincode());
+   |              -----          ^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |              |
+   |              required by a bound introduced by this call
+   |
+help: the trait `Serialize` is not implemented for `OpaquePayload`
+  --> tests/compile-fail/nightly/demux_bincode_requires_serde.rs:10:1
+   |
+10 | struct OpaquePayload {
+   | ^^^^^^^^^^^^^^^^^^^^
+   = note: for local types consider adding `#[derive(serde::Serialize)]` to your `OpaquePayload` type
+   = note: for types from other crates check whether the crate offers a `serde` feature flag
+   = help: the following other types implement trait `Serialize`:
+             &'a T
+             &'a mut T
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+           and $N others
+   = note: required for `Bincode` to implement `hydro_lang::networking::SerKind<OpaquePayload>`
+   = note: required for `NetworkingConfig<hydro_lang::networking::Tcp<hydro_lang::networking::FailStop>, Bincode>` to implement `NetworkFor<OpaquePayload>`
+note: required by a bound in `hydro_lang::live_collections::stream::networking::<impl hydro_lang::prelude::Stream<(MemberId<L2>, T), hydro_lang::prelude::Process<'a, L>, B, O, R>>::demux`
+  --> src/live_collections/stream/networking.rs
+   |
+   |     pub fn demux<N: NetworkFor<T>>(
+   |                     ^^^^^^^^^^^^^ required by this bound in `hydro_lang::live_collections::stream::networking::<impl Stream<(MemberId<L2>, T), Process<'a, L>, B, O, R>>::demux`
+
+error[E0277]: the trait bound `OpaquePayload: serde::Serialize` is not satisfied
+  --> tests/compile-fail/nightly/demux_bincode_requires_serde.rs:33:5
+   |
+33 |     payloads.demux(workers, TCP.fail_stop().bincode());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `Serialize` is not implemented for `OpaquePayload`
+  --> tests/compile-fail/nightly/demux_bincode_requires_serde.rs:10:1
+   |
+10 | struct OpaquePayload {
+   | ^^^^^^^^^^^^^^^^^^^^
+   = note: for local types consider adding `#[derive(serde::Serialize)]` to your `OpaquePayload` type
+   = note: for types from other crates check whether the crate offers a `serde` feature flag
+   = help: the following other types implement trait `Serialize`:
+             &'a T
+             &'a mut T
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+           and $N others
+   = note: required for `Bincode` to implement `hydro_lang::networking::SerKind<OpaquePayload>`
+   = note: required for `NetworkingConfig<hydro_lang::networking::Tcp<hydro_lang::networking::FailStop>, Bincode>` to implement `NetworkFor<OpaquePayload>`

--- a/hydro_lang/tests/compile-fail/stable/demux_bincode_requires_serde.stderr
+++ b/hydro_lang/tests/compile-fail/stable/demux_bincode_requires_serde.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `OpaquePayload: serde::Serialize` is not satisfied
+  --> tests/compile-fail/stable/demux_bincode_requires_serde.rs:33:14
+   |
+33 |     payloads.demux(workers, TCP.fail_stop().bincode());
+   |              ^^^^^ unsatisfied trait bound
+   |
+help: the trait `Serialize` is not implemented for `OpaquePayload`
+  --> tests/compile-fail/stable/demux_bincode_requires_serde.rs:10:1
+   |
+10 | struct OpaquePayload {
+   | ^^^^^^^^^^^^^^^^^^^^
+   = note: for local types consider adding `#[derive(serde::Serialize)]` to your `OpaquePayload` type
+   = note: for types from other crates check whether the crate offers a `serde` feature flag
+   = help: the following other types implement trait `Serialize`:
+             &'a T
+             &'a mut T
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+           and $N others
+   = note: required for `Bincode` to implement `hydro_lang::networking::SerKind<OpaquePayload>`
+   = note: required for `NetworkingConfig<hydro_lang::networking::Tcp<hydro_lang::networking::FailStop>, Bincode>` to implement `NetworkFor<OpaquePayload>`

--- a/hydro_test/src/embedded/mod.rs
+++ b/hydro_test/src/embedded/mod.rs
@@ -3,3 +3,4 @@ pub mod echo_network_embedded;
 pub mod m2m_broadcast;
 pub mod m2o_send;
 pub mod o2m_broadcast;
+pub mod o2m_demux_embedded;

--- a/hydro_test/src/embedded/o2m_demux_embedded.rs
+++ b/hydro_test/src/embedded/o2m_demux_embedded.rs
@@ -1,0 +1,28 @@
+use hydro_lang::location::MemberId;
+use hydro_lang::prelude::*;
+
+pub struct Src {}
+pub struct Dst {}
+
+/// A payload that deliberately does **not** implement `Serialize`/`DeserializeOwned`.
+///
+/// `.embedded()` channels move values in-process without ever serializing them, so demuxing
+/// this type must compile without serde impls (regression test for hydro-project/hydro#3158).
+pub struct OpaquePayload {
+    pub text: String,
+}
+
+/// Like [`super::o2m_broadcast::o2m_broadcast`], but demuxes to explicit members with
+/// `.embedded()` serialization and a payload type that has no serde derives.
+pub fn o2m_demux_embedded<'a>(
+    cluster: &Cluster<'a, Dst>,
+    input: Stream<String, Process<'a, Src>>,
+) -> Stream<String, Cluster<'a, Dst>> {
+    input
+        .map(q!(|s| (
+            MemberId::from_raw_id(0),
+            OpaquePayload { text: s }
+        )))
+        .demux(cluster, TCP.fail_stop().embedded().name("demux_data"))
+        .map(q!(|payload| payload.text.to_uppercase()))
+}

--- a/hydro_test_embedded/build.rs
+++ b/hydro_test_embedded/build.rs
@@ -116,6 +116,31 @@ fn generate_embedded() {
         .unwrap();
     }
 
+    // --- o2m_demux_embedded (process -> cluster demux, `.embedded()` serialization) ---
+    // The payload type has no serde derives; constructing this flow in a build script
+    // (a non-test context) is the regression scenario for hydro-project/hydro#3158.
+    {
+        let mut flow = hydro_lang::compile::builder::FlowBuilder::new();
+        let process = flow.process::<hydro_test::embedded::o2m_demux_embedded::Src>();
+        let cluster = flow.cluster::<hydro_test::embedded::o2m_demux_embedded::Dst>();
+        hydro_test::embedded::o2m_demux_embedded::o2m_demux_embedded(
+            &cluster,
+            process.embedded_input("input"),
+        )
+        .embedded_output("output");
+
+        let code = flow
+            .with_process(&process, "o2m_demux_sender")
+            .with_cluster(&cluster, "o2m_demux_receiver")
+            .generate_embedded("hydro_test");
+
+        std::fs::write(
+            format!("{out_dir}/o2m_demux_embedded.rs"),
+            prettyplease::unparse(&code),
+        )
+        .unwrap();
+    }
+
     // --- m2o_send (cluster -> process) ---
     {
         let mut flow = hydro_lang::compile::builder::FlowBuilder::new();

--- a/hydro_test_embedded/src/lib.rs
+++ b/hydro_test_embedded/src/lib.rs
@@ -60,6 +60,17 @@ pub mod o2m_broadcast {
     reason = "generated code"
 )]
 #[allow(unused_imports, unused_qualifications, missing_docs, non_snake_case)]
+pub mod o2m_demux_embedded {
+    include!(concat!(env!("OUT_DIR"), "/o2m_demux_embedded.rs"));
+}
+
+#[cfg(feature = "test_embedded")]
+#[expect(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason,
+    reason = "generated code"
+)]
+#[allow(unused_imports, unused_qualifications, missing_docs, non_snake_case)]
 pub mod m2o_send {
     include!(concat!(env!("OUT_DIR"), "/m2o_send.rs"));
 }
@@ -241,6 +252,52 @@ mod tests {
         };
         let mut flow_receiver =
             crate::o2m_broadcast::o2m_receiver(&member_id, &mut outputs, net_in);
+        run_flow(&mut flow_receiver).await;
+        drop(flow_receiver);
+        assert_eq!(received, vec!["HELLO", "WORLD"]);
+    }
+
+    // --- o2m_demux_embedded (process -> cluster demux, `.embedded()` serialization) ---
+    // The payload type has no serde derives; the embedded channel moves it in-process
+    // (regression test for hydro-project/hydro#3158).
+    // sender (process): (inputs, network_out)
+    // receiver (cluster): (self_id, outputs, network_in)
+    #[tokio::test]
+    async fn test_o2m_demux_embedded() {
+        use hydro_test::embedded::o2m_demux_embedded::OpaquePayload;
+
+        let member_id = TaglessMemberId::from_raw_id(0);
+        let (tx, mut rx) =
+            tokio::sync::mpsc::unbounded_channel::<(TaglessMemberId, OpaquePayload)>();
+
+        // Sender (process): (input, net_out); the channel carries the raw payload (not `Bytes`).
+        let input = stream::iter(vec!["hello".to_owned(), "world".to_owned()]);
+        let mut net_out = crate::o2m_demux_embedded::o2m_demux_sender::EmbeddedNetworkOut {
+            demux_data: move |item: (TaglessMemberId, OpaquePayload)| {
+                tx.send(item).unwrap();
+            },
+        };
+        let mut flow_sender = crate::o2m_demux_embedded::o2m_demux_sender(input, &mut net_out);
+        run_flow(&mut flow_sender).await;
+        drop(flow_sender);
+
+        let mut payloads = vec![];
+        while let Ok((id, payload)) = rx.try_recv() {
+            assert_eq!(id, member_id);
+            payloads.push(payload);
+        }
+        assert_eq!(payloads.len(), 2);
+
+        // Receiver (cluster): (self_id, outputs, network_in); raw payloads, no deserialization.
+        let net_in = crate::o2m_demux_embedded::o2m_demux_receiver::EmbeddedNetworkIn {
+            demux_data: stream::iter(payloads),
+        };
+        let mut received = vec![];
+        let mut outputs = crate::o2m_demux_embedded::o2m_demux_receiver::EmbeddedOutputs {
+            output: |s: String| received.push(s),
+        };
+        let mut flow_receiver =
+            crate::o2m_demux_embedded::o2m_demux_receiver(&member_id, &mut outputs, net_in);
         run_flow(&mut flow_receiver).await;
         drop(flow_receiver);
         assert_eq!(received, vec!["HELLO", "WORLD"]);


### PR DESCRIPTION
Fixes #3158.

`Stream::demux` and its sibling networking methods hardcoded `T: Serialize + DeserializeOwned`, but the serde requirement is really a property of the transport: `Embedded` channels pass values in-process and never serialize, yet payload types that only ever cross `.embedded()` edges were forced to carry serde derives in production builds (including `build.rs` flow construction, where test-gating the derives is impossible).

### Change

It turned out the trait machinery was already transport-correct — `Bincode`'s `SerKind<T>` impl carries `Serialize + DeserializeOwned` (flowing to `serialize_bincode`, where it's actually consumed), and `Embedded`'s impl is unbounded. The bug was 14 redundant explicit where-clauses on the `NetworkFor`-generic methods:

- removed `T: Serialize + DeserializeOwned` from `demux` (×5), `send` (×3), `broadcast` (×2), `broadcast_closed` (×2), and `round_robin` (×2) across `Stream` and `KeyedStream` — the transport's `SerKind` impl now decides;
- the `*_bincode` convenience wrappers and sim/external outputs (`sim_output`, `sim_cluster_output`, `send_bincode_external`), which genuinely serialize, keep their bounds;

No trait signatures changed, so this should not be a breaking change.

### Tests

- New embedded flow in `hydro_test` (`o2m_demux_embedded`): a payload type **without** serde derives flowing through `.demux(..., TCP.fail_stop().embedded())`, generated from `hydro_test_embedded`'s `build.rs` — the exact non-test context from the issue (this fails to compile without the fix) — plus a runtime test.
- New compile-fail test proving `.bincode()` demux of the same type is still rejected (stable + nightly stderr snapshots).
- `cargo clippy --workspace --all-targets` clean in the three CI configs (default, `--all-features`, `--no-default-features`).

Note: the nightly compile-fail snapshot was generated with nightly 2026-08-25; some unrelated nightly snapshots on main already drift against current nightly, so this one may need the same regen chore in CI.

