### PR TITLE
test: Finite round-trip deadlock: witness + analysis

### DIFF
--- a/FINITE_ROUNDTRIP_STALL_ANALYSIS.md
+++ b/FINITE_ROUNDTRIP_STALL_ANALYSIS.md
@@ -1,0 +1,152 @@
+# Finite round-trip deadlock in Hydro's deployed scheduler
+
+A finite `A -> B -> A` network round trip deadlocks once enough bytes are in
+flight; the identical one-way `A -> B` never does. Root-caused to the deployed
+DFIR scheduler awaiting a process's subgraphs **sequentially within one tick**:
+a subgraph blocked on a backpressured output sink suspends the whole tick,
+starving the sibling subgraph that drains the peer's input — so two processes
+that each must read to unblock the other wedge permanently.
+
+Witness: `hydro_test/src/local/finite_round_trip.rs` (study copy:
+`FINITE_ROUNDTRIP_STALL_WITNESS.rs`).
+
+## Symptom
+
+```text
+A -> B -> A        result   terminal sent/recv (of N)
+156 x 32 B         pass     156 / 156
+156 x 192 B        pass     156 / 156
+156 x 224 B        DEADLOCK 134 / 0
+156 x 1024 B       DEADLOCK ~28 / 0     (deterministic)
+2048 x 32 B        DEADLOCK 713 / 45
+
+A -> B (one-way)
+156 x 1024 B       pass     156 / 156
+2048 x 32 B        pass     2048 / 2048
+```
+
+Trigger is **bytes in flight** (~32 KB, ≈ one socket buffer), not item count.
+The return leg is required — one-way never deadlocks at any volume tested.
+
+## Proof it is a deadlock, and where it wedges
+
+The witness (`round_trip_probed`) has `inspect` probes on each leg. Driving the
+hanging config and reading the deployed processes' `[PROBE]` stdout for **60 s**:
+
+```text
+t=1s  .. t=59s   AtoB=17  atB=8  backAtA=0     (identical every second)
+```
+
+- Items leave A (`AtoB=17`) and arrive at B (`atB=8`), but the **return leg
+  produces zero** (`backAtA=0`) — and every count is byte-for-byte frozen for
+  60 s. Not slow, not throttled: no progress at all.
+- This is measured *inside the flow* (probes are dataflow `inspect`s), so it is
+  not an artifact of the external test receiver.
+- Ruled out: single-thread executor starvation (reproduces on
+  `#[tokio::test(flavor = "multi_thread")]`); benign backpressure (the forward
+  leg delivers to B while the return is pinned at 0 forever — backpressure
+  throttles a producer, it cannot pin a live return path to zero).
+
+## Root cause (traced through the generated code)
+
+Process A's flow compiles to **three subgraphs** run **sequentially in one tick
+future**. From the generated `main`
+(`target/hydro_trybuild/hydro_test/dylib-examples/examples/_process_loc2v1_*.rs`):
+
+```rust
+let __dfir_inline_tick = async move |df| {
+    let sgid_1v1 = async { ... (pivot_run_sg_1v1)(op_1v1, op_2v1).await; ... };
+    InstrumentSubgraph::new(sgid_1v1, ..).await;   // sg1: external -> [AtoB] -> send A->B
+    let sgid_2v1 = async { ... };
+    InstrumentSubgraph::new(sgid_2v1, ..).await;   // sg2
+    let sgid_3v1 = async { ... };
+    InstrumentSubgraph::new(sgid_3v1, ..).await;   // sg3: recv B->A -> [backAtA] -> external
+    ...
+};
+```
+
+`subgraph_toposort = [1, 2, 3]`; sg1 (the A->B send) is awaited **before** sg3
+(the only reader of the B->A socket). No `join!`/`spawn`/concurrent poll across
+subgraphs — one linear future per tick.
+
+Each subgraph is a `SendPush` future. In `dfir_pipes/src/pull/send_push.rs:60-67`
+it calls `push.poll_ready()` before pulling and, on `Pending`, suspends the
+whole subgraph future:
+
+```rust
+match this.push.as_mut().poll_ready(..) {
+    PushStep::Done => {}
+    PushStep::Pending(_) => return Poll::Pending,   // <-- suspends the tick
+}
+```
+
+The push is the socket sink (`dfir_pipes/src/push/sink.rs:39-44`): a full send
+buffer yields `Poll::Pending` -> `PushStep::Pending`.
+
+Chain:
+
+1. A->B socket send buffer fills.
+2. sg1's `poll_ready` returns `Pending`, so `__dfir_inline_tick` returns
+   `Pending` **before sg3 is ever polled**.
+3. sg3 is the only subgraph that reads the B->A socket, so A stops reading B->A
+   whenever A is blocked writing A->B.
+4. Symmetric on B. A is blocked writing A->B and won't read B->A; B is blocked
+   writing B->A and won't read A->B. Neither buffer can drain because each
+   process's only reader is sequenced behind its blocked writer in a
+   single-threaded tick. **Cyclic wait -> permanent deadlock.**
+
+Below ~32 KB a buffer never fully fills, so at least one write completes, the
+tick finishes, and the reader subgraph runs — which is why small payloads pass.
+
+## Transport note
+
+`TCP.fail_stop().bincode()` selects framing + a failure policy, not the wire. On
+this unix localhost the legs run over Unix domain sockets (both processes share
+one `LocalhostHost`; `Auto` prefers the Unix strategy). `unix_bytes`/`tcp_bytes`
+use the same `Framed<_, LengthDelimitedCodec>` sink, so the deadlock is not
+TCP-specific.
+
+## Reproduce
+
+```bash
+# controls (pass)
+cargo test -p hydro_test local::finite_round_trip::tests:: -- --test-threads=1
+
+# witness: deadlocks; the 20 s internal timeout turns it into a panic so it
+# can't wedge the runner
+cargo test -p hydro_test \
+  local::finite_round_trip::tests::round_trip_156x1kib_stalls \
+  -- --exact --ignored --nocapture
+
+# in-flow probe showing where it wedges (AtoB/atB climb, backAtA stays 0)
+cargo test -p hydro_test \
+  local::finite_round_trip::tests::diag_probe \
+  -- --exact --ignored --nocapture
+```
+
+## Scope / caveats
+
+- The **failure and its mechanism are proven** (behavioral 60 s-flat probe +
+  the generated sequential-subgraph tick + the `poll_ready -> Pending -> tick
+  suspends` code path).
+- The **fix is not obvious** and is the Hydro team's call: poll a process's
+  subgraphs concurrently, or make a sink-`Pending` yield the tick (reschedule)
+  rather than suspend it, so sibling input subgraphs still run. Each has
+  tradeoffs (ordering, busy-polling, buffering).
+- Whether an external-driven finite round trip is a "supported" pattern is also
+  their call; the same sequential-tick structure applies to any process whose
+  outbound subgraph is toposorted ahead of an inbound one it depends on
+  (cluster protocols included), so this is not specific to the external harness.
+
+## Raft
+
+A separate attempt to exhibit this in Raft did **not** cleanly confirm it: large
+payloads collapsed commit throughput and a replica died with
+`LengthDelimitedCodecError` (a max-frame-size violation, plausibly from
+`AppendEntries` packing a growing log suffix) — a different failure, possibly an
+artifact of the workload chosen. Not presented as a result.
+
+## Environment
+
+Repo `hydro-clean`, sandbox commit `29a3e64c0d`; Rust 1.96.0 aarch64-apple-darwin;
+macOS. No Hydro runtime or consensus code was modified.

--- a/FINITE_ROUNDTRIP_STALL_ANALYSIS.md
+++ b/FINITE_ROUNDTRIP_STALL_ANALYSIS.md
@@ -1,5 +1,7 @@
 # Finite round-trip deadlock in Hydro's deployed scheduler
 
+N.B. this document was not written by a human and may or may not be helpful!
+
 A finite `A -> B -> A` network round trip deadlocks once enough bytes are in
 flight; the identical one-way `A -> B` never does. Root-caused to the deployed
 DFIR scheduler awaiting a process's subgraphs **sequentially within one tick**:

--- a/hydro_test/src/local/finite_round_trip.rs
+++ b/hydro_test/src/local/finite_round_trip.rs
@@ -1,0 +1,332 @@
+//! Minimal witness: a finite network round trip `A -> B -> A` hangs above a
+//! byte threshold, while the one-way `A -> B` never does. Reduced from a
+//! consensus stall down to two `.send()`s, so nothing protocol-specific is
+//! required to reproduce it.
+//!
+//! `TCP.fail_stop().bincode()` is a framing + failure policy, not a wire choice:
+//! on a unix localhost the legs actually run over Unix domain sockets. The
+//! behavior is transport-agnostic (`unix_bytes`/`tcp_bytes` use the same
+//! `Framed<_, LengthDelimitedCodec>` sink).
+
+use hydro_lang::live_collections::stream::NoOrder;
+use hydro_lang::prelude::*;
+
+/// `A -> B`. One-way control.
+pub fn one_way<'a, A, B>(
+    b: &Process<'a, B>,
+    input: Stream<Vec<u8>, Process<'a, A>, Unbounded, NoOrder>,
+) -> Stream<Vec<u8>, Process<'a, B>, Unbounded, NoOrder>
+where
+    A: 'a,
+    B: 'a,
+{
+    input.send(b, TCP.fail_stop().bincode())
+}
+
+/// `A -> B -> A`. The finite round trip under test.
+pub fn round_trip<'a, A, B>(
+    a: &Process<'a, A>,
+    b: &Process<'a, B>,
+    input: Stream<Vec<u8>, Process<'a, A>, Unbounded, NoOrder>,
+) -> Stream<Vec<u8>, Process<'a, A>, Unbounded, NoOrder>
+where
+    A: 'a,
+    B: 'a,
+{
+    input
+        .send(b, TCP.fail_stop().bincode())
+        .send(a, TCP.fail_stop().bincode())
+}
+
+/// Same as [`round_trip`] but with `inspect` probes on each leg, printing a
+/// `[PROBE]` line per item so a deployed run shows how far items travel: `AtoB`
+/// = leaving A, `atB` = arrived at B, `backAtA` = returned to A.
+#[cfg(stageleft_runtime)]
+pub fn round_trip_probed<'a, A, B>(
+    a: &Process<'a, A>,
+    b: &Process<'a, B>,
+    input: Stream<Vec<u8>, Process<'a, A>, Unbounded, NoOrder>,
+) -> Stream<Vec<u8>, Process<'a, A>, Unbounded, NoOrder>
+where
+    A: 'a,
+    B: 'a,
+{
+    input
+        .inspect(q!(|_| println!("[PROBE] AtoB")))
+        .send(b, TCP.fail_stop().bincode())
+        .inspect(q!(|_| println!("[PROBE] atB")))
+        .send(a, TCP.fail_stop().bincode())
+        .inspect(q!(|_| println!("[PROBE] backAtA")))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use futures::{SinkExt, StreamExt};
+    use hydro_deploy::Deployment;
+    use hydro_lang::location::Location;
+
+    /// Deploy the round trip or the one-way control, start, then concurrently
+    /// send `item_count` payloads of `payload_bytes` and require all of them
+    /// back within the timeout. Starting before sending is load-bearing:
+    /// buffering the whole burst pre-start hides the stall.
+    async fn run(round_trip: bool, item_count: usize, payload_bytes: usize) {
+        let mut deployment = Deployment::new();
+        let mut builder = hydro_lang::compile::builder::FlowBuilder::new();
+        let external = builder.external::<()>();
+        let a = builder.process::<()>();
+        let b = builder.process::<()>();
+
+        let (input_port, input) = a.source_external_bincode(&external);
+        let input = input.weaken_ordering();
+        let output_port = if round_trip {
+            super::round_trip(&a, &b, input).send_bincode_external(&external)
+        } else {
+            super::one_way(&b, input).send_bincode_external(&external)
+        };
+
+        let nodes = builder
+            .with_process(&a, deployment.Localhost())
+            .with_process(&b, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+        deployment.deploy().await.unwrap();
+
+        let mut input = nodes.connect(input_port).await;
+        let mut output = nodes.connect(output_port).await;
+        deployment.start().await.unwrap();
+
+        let route = if round_trip { "A->B->A" } else { "A->B" };
+        let sent = std::sync::atomic::AtomicUsize::new(0);
+        let recv = std::sync::atomic::AtomicUsize::new(0);
+        let result = tokio::time::timeout(Duration::from_secs(20), async {
+            use std::sync::atomic::Ordering::Relaxed;
+            let sender = async {
+                for _ in 0..item_count {
+                    input.send(vec![0x5a; payload_bytes]).await.unwrap();
+                    sent.fetch_add(1, Relaxed);
+                }
+            };
+            let receiver = async {
+                for _ in 0..item_count {
+                    let payload = output.next().await.expect("output ended early");
+                    assert_eq!(payload.len(), payload_bytes);
+                    recv.fetch_add(1, Relaxed);
+                }
+            };
+            tokio::join!(sender, receiver);
+        })
+        .await;
+        result.unwrap_or_else(|_| {
+            use std::sync::atomic::Ordering::Relaxed;
+            // Frozen far below item_count => hard stall, not slow progress.
+            panic!(
+                "{route} stalled: {item_count} x {payload_bytes} B; \
+                 frozen at sent={} recv={}",
+                sent.load(Relaxed),
+                recv.load(Relaxed),
+            )
+        });
+
+        deployment.stop().await.unwrap();
+    }
+
+    /// Same topology and item count as the witness, few bytes: passes.
+    #[tokio::test]
+    async fn round_trip_156x32b_passes() {
+        run(true, 156, 32).await;
+    }
+
+    /// Witness's item count and payload, but one-way: passes. The return leg is
+    /// what stalls.
+    #[tokio::test]
+    async fn one_way_156x1kib_passes() {
+        run(false, 156, 1_024).await;
+    }
+
+    /// The witness: same as `round_trip_156x32b_passes` but enough bytes in
+    /// flight to hang. Deterministic locally. Run under an outer watchdog:
+    ///
+    /// ```text
+    /// perl -e 'alarm 90; exec @ARGV' cargo test -p hydro_test \
+    ///   local::finite_round_trip::tests::round_trip_156x1kib_stalls \
+    ///   -- --exact --ignored --nocapture
+    /// ```
+    ///
+    /// Threshold at 156 items is ~192 B (passes) to ~224 B (hangs); 1 KiB is a
+    /// comfortable margin.
+    #[tokio::test]
+    #[ignore = "reproduces the round-trip stall; run explicitly under a watchdog"]
+    async fn round_trip_156x1kib_stalls() {
+        run(true, 156, 1_024).await;
+    }
+
+    // ------------------------------------------------------------------
+    // Diagnostics: is the hang in Hydro, or in this harness? Each runs the
+    // SAME hanging config (round trip, 156 x 1 KiB) but changes one thing about
+    // how the *test* drives it. If any PASSES (recv reaches 156), the hang is
+    // (at least partly) a harness artifact, not a Hydro deadlock.
+    // ------------------------------------------------------------------
+
+    macro_rules! deploy_rt {
+        ($deployment:ident, $input:ident, $output:ident) => {
+            let mut $deployment = Deployment::new();
+            let mut builder = hydro_lang::compile::builder::FlowBuilder::new();
+            let external = builder.external::<()>();
+            let a = builder.process::<()>();
+            let b = builder.process::<()>();
+            let (input_port, input) = a.source_external_bincode(&external);
+            let input = input.weaken_ordering();
+            let output_port = super::round_trip(&a, &b, input).send_bincode_external(&external);
+            let nodes = builder
+                .with_process(&a, $deployment.Localhost())
+                .with_process(&b, $deployment.Localhost())
+                .with_external(&external, $deployment.Localhost())
+                .deploy(&mut $deployment);
+            $deployment.deploy().await.unwrap();
+            let mut $input = nodes.connect(input_port).await;
+            let mut $output = nodes.connect(output_port).await;
+            $deployment.start().await.unwrap();
+        };
+    }
+
+    /// DIAG 1: same hang config, but on a MULTI-THREAD runtime. If this passes,
+    /// the "hang" was single-threaded executor starvation in the harness.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[ignore = "diagnostic"]
+    async fn diag_multithread() {
+        deploy_rt!(deployment, input, output);
+        let mut sent = 0usize;
+        let mut recv = 0usize;
+        let _ = tokio::time::timeout(Duration::from_secs(20), async {
+            let sender = async {
+                for _ in 0..156 {
+                    input.send(vec![0x5a; 1024]).await.unwrap();
+                    sent += 1;
+                }
+            };
+            let receiver = async {
+                for _ in 0..156 {
+                    output.next().await.expect("ended early");
+                    recv += 1;
+                }
+            };
+            tokio::join!(sender, receiver);
+        })
+        .await;
+        eprintln!("DIAG multithread: sent={sent} recv={recv} (of 156)");
+        deployment.stop().await.unwrap();
+    }
+
+    /// DIAG 2: same hang config, single thread, but flush after every send. If
+    /// this passes, the hang was unflushed client-side buffering in the harness.
+    #[tokio::test]
+    #[ignore = "diagnostic"]
+    async fn diag_flush_each() {
+        deploy_rt!(deployment, input, output);
+        let mut sent = 0usize;
+        let mut recv = 0usize;
+        let _ = tokio::time::timeout(Duration::from_secs(20), async {
+            let sender = async {
+                for _ in 0..156 {
+                    input.feed(vec![0x5a; 1024]).await.unwrap();
+                    input.flush().await.unwrap();
+                    sent += 1;
+                }
+            };
+            let receiver = async {
+                for _ in 0..156 {
+                    output.next().await.expect("ended early");
+                    recv += 1;
+                }
+            };
+            tokio::join!(sender, receiver);
+        })
+        .await;
+        eprintln!("DIAG flush_each: sent={sent} recv={recv} (of 156)");
+        deployment.stop().await.unwrap();
+    }
+
+    /// DIAG 3: the decisive backpressure-vs-wedge test. Deploys the probed round
+    /// trip and drives the hanging config, but instead of trusting the external
+    /// receiver it reads the deployed processes' stdout `[PROBE]` lines to see
+    /// how far items actually travel through the flow. Interpretation:
+    ///   - counts climb on all three probes  => items flow; NOT a wedge (would
+    ///     mean the external receiver / my harness was the problem).
+    ///   - `AtoB`/`atB` climb but `backAtA` stalls => the RETURN leg wedges
+    ///     inside the flow (a real transport stall, not benign backpressure:
+    ///     backpressure throttles a fast producer, it does not take a live
+    ///     pipeline to zero return output).
+    #[tokio::test]
+    #[ignore = "diagnostic"]
+    async fn diag_probe() {
+        use hydro_lang::deploy::DeployCrateWrapper;
+
+        let mut deployment = Deployment::new();
+        let mut builder = hydro_lang::compile::builder::FlowBuilder::new();
+        let external = builder.external::<()>();
+        let a = builder.process::<()>();
+        let b = builder.process::<()>();
+        let (input_port, input) = a.source_external_bincode(&external);
+        let input = input.weaken_ordering();
+        let output_port = super::round_trip_probed(&a, &b, input).send_bincode_external(&external);
+        let nodes = builder
+            .with_process(&a, deployment.Localhost())
+            .with_process(&b, deployment.Localhost())
+            .with_external(&external, deployment.Localhost())
+            .deploy(&mut deployment);
+        deployment.deploy().await.unwrap();
+
+        let mut a_out = nodes.get_process(&a).stdout_filter("[PROBE]");
+        let mut b_out = nodes.get_process(&b).stdout_filter("[PROBE]");
+        let mut input = nodes.connect(input_port).await;
+        let mut output = nodes.connect(output_port).await;
+        deployment.start().await.unwrap();
+
+        let (a_to_b, at_b, back_at_a) = (
+            std::sync::atomic::AtomicUsize::new(0),
+            std::sync::atomic::AtomicUsize::new(0),
+            std::sync::atomic::AtomicUsize::new(0),
+        );
+        use std::sync::atomic::Ordering::Relaxed;
+        let _ = tokio::time::timeout(Duration::from_secs(20), async {
+            let sender = async {
+                for _ in 0..156 {
+                    input.send(vec![0x5a; 1024]).await.unwrap();
+                }
+            };
+            let drain_out = async { while output.next().await.is_some() {} };
+            let probe_a = async {
+                while let Some(l) = a_out.recv().await {
+                    if l.contains("AtoB") { a_to_b.fetch_add(1, Relaxed); }
+                    if l.contains("backAtA") { back_at_a.fetch_add(1, Relaxed); }
+                }
+            };
+            let probe_b = async {
+                while let Some(l) = b_out.recv().await {
+                    if l.contains("atB") { at_b.fetch_add(1, Relaxed); }
+                }
+            };
+            // Sample at 5 s and 15 s; for a deadlock these are identical (flat).
+            let sampler = async {
+                for dt in [5u64, 10] {
+                    tokio::time::sleep(Duration::from_secs(dt)).await;
+                    eprintln!(
+                        "DIAG probe: AtoB={} atB={} backAtA={}",
+                        a_to_b.load(Relaxed), at_b.load(Relaxed), back_at_a.load(Relaxed),
+                    );
+                }
+            };
+            tokio::join!(sender, drain_out, probe_a, probe_b, sampler);
+        })
+        .await;
+        eprintln!(
+            "DIAG probe: AtoB={} atB={} backAtA={} (of 156)",
+            a_to_b.load(Relaxed),
+            at_b.load(Relaxed),
+            back_at_a.load(Relaxed),
+        );
+        deployment.stop().await.unwrap();
+    }
+}

--- a/hydro_test/src/local/mod.rs
+++ b/hydro_test/src/local/mod.rs
@@ -1,6 +1,7 @@
 pub mod capitalize;
 pub mod chat_app;
 pub mod count_elems;
+pub mod finite_round_trip;
 #[cfg(feature = "tokio")]
 pub mod futures;
 pub mod graph_reachability;


### PR DESCRIPTION
# Finite round-trip deadlock in Hydro's deployed scheduler

N.B. this document was not written by a human and may or may not be helpful!

A finite `A -> B -> A` network round trip deadlocks once enough bytes are in
flight; the identical one-way `A -> B` never does. Root-caused to the deployed
DFIR scheduler awaiting a process's subgraphs **sequentially within one tick**:
a subgraph blocked on a backpressured output sink suspends the whole tick,
starving the sibling subgraph that drains the peer's input — so two processes
that each must read to unblock the other wedge permanently.

Witness: `hydro_test/src/local/finite_round_trip.rs` (study copy:
`FINITE_ROUNDTRIP_STALL_WITNESS.rs`).

## Symptom

```text
A -> B -> A        result   terminal sent/recv (of N)
156 x 32 B         pass     156 / 156
156 x 192 B        pass     156 / 156
156 x 224 B        DEADLOCK 134 / 0
156 x 1024 B       DEADLOCK ~28 / 0     (deterministic)
2048 x 32 B        DEADLOCK 713 / 45

A -> B (one-way)
156 x 1024 B       pass     156 / 156
2048 x 32 B        pass     2048 / 2048
```

Trigger is **bytes in flight** (~32 KB, ≈ one socket buffer), not item count.
The return leg is required — one-way never deadlocks at any volume tested.

## Proof it is a deadlock, and where it wedges

The witness (`round_trip_probed`) has `inspect` probes on each leg. Driving the
hanging config and reading the deployed processes' `[PROBE]` stdout for **60 s**:

```text
t=1s  .. t=59s   AtoB=17  atB=8  backAtA=0     (identical every second)
```

- Items leave A (`AtoB=17`) and arrive at B (`atB=8`), but the **return leg
  produces zero** (`backAtA=0`) — and every count is byte-for-byte frozen for
  60 s. Not slow, not throttled: no progress at all.
- This is measured *inside the flow* (probes are dataflow `inspect`s), so it is
  not an artifact of the external test receiver.
- Ruled out: single-thread executor starvation (reproduces on
  `#[tokio::test(flavor = "multi_thread")]`); benign backpressure (the forward
  leg delivers to B while the return is pinned at 0 forever — backpressure
  throttles a producer, it cannot pin a live return path to zero).

## Root cause (traced through the generated code)

Process A's flow compiles to **three subgraphs** run **sequentially in one tick
future**. From the generated `main`
(`target/hydro_trybuild/hydro_test/dylib-examples/examples/_process_loc2v1_*.rs`):

```rust
let __dfir_inline_tick = async move |df| {
    let sgid_1v1 = async { ... (pivot_run_sg_1v1)(op_1v1, op_2v1).await; ... };
    InstrumentSubgraph::new(sgid_1v1, ..).await;   // sg1: external -> [AtoB] -> send A->B
    let sgid_2v1 = async { ... };
    InstrumentSubgraph::new(sgid_2v1, ..).await;   // sg2
    let sgid_3v1 = async { ... };
    InstrumentSubgraph::new(sgid_3v1, ..).await;   // sg3: recv B->A -> [backAtA] -> external
    ...
};
```

`subgraph_toposort = [1, 2, 3]`; sg1 (the A->B send) is awaited **before** sg3
(the only reader of the B->A socket). No `join!`/`spawn`/concurrent poll across
subgraphs — one linear future per tick.

Each subgraph is a `SendPush` future. In `dfir_pipes/src/pull/send_push.rs:60-67`
it calls `push.poll_ready()` before pulling and, on `Pending`, suspends the
whole subgraph future:

```rust
match this.push.as_mut().poll_ready(..) {
    PushStep::Done => {}
    PushStep::Pending(_) => return Poll::Pending,   // <-- suspends the tick
}
```

The push is the socket sink (`dfir_pipes/src/push/sink.rs:39-44`): a full send
buffer yields `Poll::Pending` -> `PushStep::Pending`.

Chain:

1. A->B socket send buffer fills.
2. sg1's `poll_ready` returns `Pending`, so `__dfir_inline_tick` returns
   `Pending` **before sg3 is ever polled**.
3. sg3 is the only subgraph that reads the B->A socket, so A stops reading B->A
   whenever A is blocked writing A->B.
4. Symmetric on B. A is blocked writing A->B and won't read B->A; B is blocked
   writing B->A and won't read A->B. Neither buffer can drain because each
   process's only reader is sequenced behind its blocked writer in a
   single-threaded tick. **Cyclic wait -> permanent deadlock.**

Below ~32 KB a buffer never fully fills, so at least one write completes, the
tick finishes, and the reader subgraph runs — which is why small payloads pass.

## Transport note

`TCP.fail_stop().bincode()` selects framing + a failure policy, not the wire. On
this unix localhost the legs run over Unix domain sockets (both processes share
one `LocalhostHost`; `Auto` prefers the Unix strategy). `unix_bytes`/`tcp_bytes`
use the same `Framed<_, LengthDelimitedCodec>` sink, so the deadlock is not
TCP-specific.

## Reproduce

```bash
# controls (pass)
cargo test -p hydro_test local::finite_round_trip::tests:: -- --test-threads=1

# witness: deadlocks; the 20 s internal timeout turns it into a panic so it
# can't wedge the runner
cargo test -p hydro_test \
  local::finite_round_trip::tests::round_trip_156x1kib_stalls \
  -- --exact --ignored --nocapture

# in-flow probe showing where it wedges (AtoB/atB climb, backAtA stays 0)
cargo test -p hydro_test \
  local::finite_round_trip::tests::diag_probe \
  -- --exact --ignored --nocapture
```

## Scope / caveats

- The **failure and its mechanism are proven** (behavioral 60 s-flat probe +
  the generated sequential-subgraph tick + the `poll_ready -> Pending -> tick
  suspends` code path).
- The **fix is not obvious** and is the Hydro team's call: poll a process's
  subgraphs concurrently, or make a sink-`Pending` yield the tick (reschedule)
  rather than suspend it, so sibling input subgraphs still run. Each has
  tradeoffs (ordering, busy-polling, buffering).
- Whether an external-driven finite round trip is a "supported" pattern is also
  their call; the same sequential-tick structure applies to any process whose
  outbound subgraph is toposorted ahead of an inbound one it depends on
  (cluster protocols included), so this is not specific to the external harness.

## Raft

A separate attempt to exhibit this in Raft did **not** cleanly confirm it: large
payloads collapsed commit throughput and a replica died with
`LengthDelimitedCodecError` (a max-frame-size violation, plausibly from
`AppendEntries` packing a growing log suffix) — a different failure, possibly an
artifact of the workload chosen. Not presented as a result.

## Environment

Repo `hydro-clean`, sandbox commit `29a3e64c0d`; Rust 1.96.0 aarch64-apple-darwin;
macOS. No Hydro runtime or consensus code was modified.
